### PR TITLE
fix:detail tab's external urls render as hyperlink

### DIFF
--- a/src/components/ui/ItemDetailList.js
+++ b/src/components/ui/ItemDetailList.js
@@ -738,9 +738,10 @@ export class Detail extends React.PureComponent {
             } else if (item.charAt(0) === '/') {
                 if (popLink) return <a key={item} href={item} target="_blank" rel="noreferrer noopener">{ item }</a>;
                 else return <a key={item} href={item}>{ item }</a>;
-            } else if (item.slice(0,4) === 'http') {
+            } else if (['http', 'www.'].indexOf(item.slice(0, 4)) > -1) {
+                // TODO: more comprehensive regexp url validator needed, look at: https://stackoverflow.com/a/5717133
                 // Is a URL. Check if we should render it as a link/uri.
-                const schemaProperty = getSchemaProperty(keyPrefix, schemas, {}, atType);
+                const schemaProperty = getSchemaProperty(keyPrefix, schemas || {}, atType);
                 if (
                     schemaProperty &&
                     typeof schemaProperty.format === 'string' &&


### PR DESCRIPTION
**Problem**:  Page's Detail Tab is not rendering external urls as hyperlink. (@burakalver) Url's starting with http, https, www. are rendered as plaint text. (e.g. https://data.4dnucleome.org/quality-metrics-pairsqc/2cccaf25-6816-41cf-a76d-77935e8e9f9d/ and https://data.4dnucleome.org/vendors/sigma-aldrich/

**Solution**: 
1. http and https starting urls actually should work but `schema-transform.js/getSchemaProperty(field, schemas, startAt = 'ExperimentSet')` function is called as `getSchemaProperty(keyPrefix, schemas, {}, atType)` in `ItemDetailList`. This should be `getSchemaProperty(keyPrefix, schemas || {}, atType)`, it is just a typo error and fixed.
2. On the other hand, rendering as hyperlink or plain text of `www.` prefixed urls (lack of http or https) is a decision, user must be aware and should define the url schema while submitting.  In this commit, a minor fix added `www.` prefixed urls, but a comprehensive js RegExp url validator needed. (googled and find out this one, https://stackoverflow.com/a/5717133