### PR TITLE
Minor fix to show tooltip over QMS tables column headers

### DIFF
--- a/src/components/browse/components/StackedBlockTable.js
+++ b/src/components/browse/components/StackedBlockTable.js
@@ -457,7 +457,7 @@ function TableHeaders(props){
         const cls = "heading-block col-" + colHeader.columnClass + (colHeader.className ? ' ' + colHeader.className : '');
 
         return (
-            <div className={cls} key={key} style={{ 'width' : colWidth }} data-column-class={colHeader.columnClass}>
+            <div className={cls} key={key} style={{ 'width' : colWidth }} data-column-class={colHeader.columnClass} data-tip={visibleTitle}>
                 { visibleTitle }
             </div>
         );


### PR DESCRIPTION
**Problem:** Quality Metrics Summary table display ellipsis for long header columns (and also browser's built-in tooltip not working on mouse hover) - https://data.4dnucleome.org/experiment-set-replicates/4DNESDG4HNP9/

**Solution:** A minor fix: data-tip attribute addded `data-tip={visibleTitle}`

**Improvement:** Tooltip is shown even if the column header is fully visible, since the ellipsis is displayed by browser vis the css `text-overflow: ellipsis` rule. Prevent tooltip for fully visible column headers is a nice to have.