### PR TITLE
Single Item Selection & SubmissionView Changes

### DIFF
--- a/es/components/browse/SearchView.js
+++ b/es/components/browse/SearchView.js
@@ -50,7 +50,7 @@ var _SortController = require("./components/SortController");
 
 var _typedefs = require("./../util/typedefs");
 
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
 function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function (obj) { return typeof obj; }; } else { _typeof = function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
@@ -117,9 +117,9 @@ var SearchControllersContainer = function (_React$PureComponent) {
     value: function render() {
       var context = this.props.context;
       var defaultHiddenColumns = (0, _tableCommons.defaultHiddenColumnMapFromColumns)(context.columns);
-      return _react.default.createElement(_CustomColumnController.CustomColumnController, {
+      return _react["default"].createElement(_CustomColumnController.CustomColumnController, {
         defaultHiddenColumns: defaultHiddenColumns
-      }, _react.default.createElement(_SortController.SortController, _underscore.default.pick(this.props, 'href', 'context', 'navigate'), _react.default.createElement(ControlsAndResults, _extends({}, this.props, {
+      }, _react["default"].createElement(_SortController.SortController, _underscore["default"].pick(this.props, 'href', 'context', 'navigate'), _react["default"].createElement(ControlsAndResults, _extends({}, this.props, {
         isTermSelected: this.isTermSelected,
         onFilter: this.onFilter
       }))));
@@ -127,7 +127,7 @@ var SearchControllersContainer = function (_React$PureComponent) {
   }]);
 
   return SearchControllersContainer;
-}(_react.default.PureComponent);
+}(_react["default"].PureComponent);
 
 exports.SearchControllersContainer = SearchControllersContainer;
 
@@ -153,7 +153,7 @@ var ControlsAndResults = function (_React$PureComponent2) {
     _this2.state = {
       selectedItems: new Map()
     };
-    _this2.searchResultTableRef = _react.default.createRef();
+    _this2.searchResultTableRef = _react["default"].createRef();
     return _this2;
   }
 
@@ -167,7 +167,7 @@ var ControlsAndResults = function (_React$PureComponent2) {
         var resultID = _object.itemUtil.atId(result);
 
         if (nextItems.has(resultID)) {
-          nextItems.delete(resultID);
+          nextItems["delete"](resultID);
         } else {
           if (!isMultiSelect) {
             nextItems.clear();
@@ -206,8 +206,8 @@ var ControlsAndResults = function (_React$PureComponent2) {
         _iteratorError = err;
       } finally {
         try {
-          if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
+          if (!_iteratorNormalCompletion && _iterator["return"] != null) {
+            _iterator["return"]();
           }
         } finally {
           if (_didIteratorError) {
@@ -274,29 +274,29 @@ var ControlsAndResults = function (_React$PureComponent2) {
         return columnExtensionMap;
       }
 
-      columnExtensionMap = _underscore.default.clone(columnExtensionMap);
+      columnExtensionMap = _underscore["default"].clone(columnExtensionMap);
       var origDisplayTitleRenderFxn = columnExtensionMap.display_title && columnExtensionMap.display_title.render || _tableCommons.basicColumnExtensionMap.display_title.render;
 
       if (inSelectionMode) {
-        columnExtensionMap.display_title = _underscore.default.extend({}, columnExtensionMap.display_title, {
+        columnExtensionMap.display_title = _underscore["default"].extend({}, columnExtensionMap.display_title, {
           'minColumnWidth': 120,
           'render': function render(result, columnDefinition, props, width) {
             var selectedItems = _this3.state.selectedItems;
             var isChecked = selectedItems.has(_object.itemUtil.atId(result));
 
-            var checkBoxControl = _react.default.createElement("input", {
+            var checkBoxControl = _react["default"].createElement("input", {
               type: "checkbox",
               checked: isChecked,
               onChange: _this3.handleSelectItemClick.bind(_this3, result, currentAction === 'multiselect'),
               className: "mr-2"
             });
 
-            var currentTitleBlock = origDisplayTitleRenderFxn(result, columnDefinition, _underscore.default.extend({}, props, {
+            var currentTitleBlock = origDisplayTitleRenderFxn(result, columnDefinition, _underscore["default"].extend({}, props, {
               currentAction: currentAction
             }), width, true);
             var newChildren = currentTitleBlock.props.children.slice(0);
             newChildren.unshift(checkBoxControl);
-            return _react.default.cloneElement(currentTitleBlock, {
+            return _react["default"].cloneElement(currentTitleBlock, {
               'children': newChildren
             });
           }
@@ -345,13 +345,13 @@ var ControlsAndResults = function (_React$PureComponent2) {
           href = _this$props2.href,
           context = _this$props2.context;
 
-      var urlPartsQuery = _url.default.parse(href, true).query;
+      var urlPartsQuery = _url["default"].parse(href, true).query;
 
       var clearFiltersURL = typeof context.clear_filters === 'string' && context.clear_filters || null;
 
-      var clearFiltersURLQuery = clearFiltersURL && _url.default.parse(clearFiltersURL, true).query;
+      var clearFiltersURLQuery = clearFiltersURL && _url["default"].parse(clearFiltersURL, true).query;
 
-      return !!(clearFiltersURLQuery && !_underscore.default.isEqual(clearFiltersURLQuery, urlPartsQuery));
+      return !!(clearFiltersURLQuery && !_underscore["default"].isEqual(clearFiltersURLQuery, urlPartsQuery));
     }
   }, {
     key: "renderSearchDetailPane",
@@ -359,7 +359,7 @@ var ControlsAndResults = function (_React$PureComponent2) {
       var _this$props3 = this.props,
           windowWidth = _this$props3.windowWidth,
           schemas = _this$props3.schemas;
-      return _react.default.createElement(_SearchResultDetailPane.SearchResultDetailPane, {
+      return _react["default"].createElement(_SearchResultDetailPane.SearchResultDetailPane, {
         result: result,
         rowNumber: rowNumber,
         containerWidth: containerWidth,
@@ -390,36 +390,36 @@ var ControlsAndResults = function (_React$PureComponent2) {
 
       var selfExtendedColumnExtensionMap = this.columnExtensionMapWithSelectButton(columnExtensionMap, currentAction, specificType, abstractType);
       var columnDefinitions = (0, _tableCommons.columnsToColumnDefinitions)(context.columns || {}, selfExtendedColumnExtensionMap);
-      return _react.default.createElement("div", {
+      return _react["default"].createElement("div", {
         className: "row"
-      }, facets.length ? _react.default.createElement("div", {
+      }, facets.length ? _react["default"].createElement("div", {
         className: facetColumnClassName
-      }, _react.default.createElement("div", {
+      }, _react["default"].createElement("div", {
         className: "above-results-table-row"
-      }), _react.default.createElement(_FacetList.FacetList, _extends({
+      }), _react["default"].createElement(_FacetList.FacetList, _extends({
         className: "with-header-bg",
         facets: facets,
         filters: context.filters,
         onClearFilters: this.handleClearFilters,
         itemTypeForSchemas: specificType,
         showClearFiltersButton: this.isClearFiltersBtnVisible()
-      }, _underscore.default.pick(this.props, 'isTermSelected', 'schemas', 'session', 'onFilter', 'currentAction', 'windowWidth', 'windowHeight', 'termTransformFxn', 'separateSingleTermFacets')))) : null, _react.default.createElement("div", {
+      }, _underscore["default"].pick(this.props, 'isTermSelected', 'schemas', 'session', 'onFilter', 'currentAction', 'windowWidth', 'windowHeight', 'termTransformFxn', 'separateSingleTermFacets')))) : null, _react["default"].createElement("div", {
         className: tableColumnClassName
-      }, _react.default.createElement(_AboveSearchViewTableControls.AboveSearchViewTableControls, _extends({
+      }, _react["default"].createElement(_AboveSearchViewTableControls.AboveSearchViewTableControls, _extends({
         showTotalResults: context.total,
         parentForceUpdate: this.forceUpdateOnSelf
-      }, _underscore.default.pick(this.props, 'addHiddenColumn', 'removeHiddenColumn', 'isFullscreen', 'context', 'columns', 'currentAction', 'windowWidth', 'windowHeight', 'toggleFullScreen'), {
+      }, _underscore["default"].pick(this.props, 'addHiddenColumn', 'removeHiddenColumn', 'isFullscreen', 'context', 'columns', 'currentAction', 'windowWidth', 'windowHeight', 'toggleFullScreen'), {
         hiddenColumns: hiddenColumns,
         columnDefinitions: columnDefinitions
-      })), _react.default.createElement(_SearchResultTable.SearchResultTable, _extends({
+      })), _react["default"].createElement(_SearchResultTable.SearchResultTable, _extends({
         ref: this.searchResultTableRef,
         renderDetailPane: this.renderSearchDetailPane,
         totalExpected: context.total
-      }, _underscore.default.pick(this.props, 'href', 'sortBy', 'sortColumn', 'sortReverse', 'currentAction', 'windowWidth', 'registerWindowOnScrollHandler', 'schemas'), {
+      }, _underscore["default"].pick(this.props, 'href', 'sortBy', 'sortColumn', 'sortReverse', 'currentAction', 'windowWidth', 'registerWindowOnScrollHandler', 'schemas'), {
         hiddenColumns: hiddenColumns,
         results: results,
         columnDefinitions: columnDefinitions
-      })), (0, _misc.isSelectAction)(currentAction) ? _react.default.createElement(SelectStickyFooter, _extends({
+      })), (0, _misc.isSelectAction)(currentAction) ? _react["default"].createElement(SelectStickyFooter, _extends({
         context: context,
         schemas: schemas,
         selectedItems: selectedItems,
@@ -432,13 +432,13 @@ var ControlsAndResults = function (_React$PureComponent2) {
   }]);
 
   return ControlsAndResults;
-}(_react.default.PureComponent);
+}(_react["default"].PureComponent);
 
-_defineProperty(ControlsAndResults, "searchItemTypesFromHref", (0, _memoizeOne.default)(function (href, schemas) {
+_defineProperty(ControlsAndResults, "searchItemTypesFromHref", (0, _memoizeOne["default"])(function (href, schemas) {
   var specificType = 'Item';
   var abstractType = null;
 
-  var urlParts = _url.default.parse(href, true);
+  var urlParts = _url["default"].parse(href, true);
 
   if (typeof urlParts.query.type === 'string') {
     if (urlParts.query.type !== 'Item') {
@@ -465,7 +465,7 @@ var SearchView = function (_React$PureComponent3) {
   _createClass(SearchView, [{
     key: "componentDidMount",
     value: function componentDidMount() {
-      _reactTooltip.default.rebuild();
+      _reactTooltip["default"].rebuild();
     }
   }, {
     key: "render",
@@ -474,9 +474,9 @@ var SearchView = function (_React$PureComponent3) {
           propFacets = _this$props5.facets,
           propNavigate = _this$props5.navigate,
           context = _this$props5.context;
-      return _react.default.createElement("div", {
+      return _react["default"].createElement("div", {
         className: "search-page-container"
-      }, _react.default.createElement(_AboveSearchTablePanel.AboveSearchTablePanel, _underscore.default.pick(this.props, 'href', 'context', 'schemas')), _react.default.createElement(SearchControllersContainer, _extends({}, this.props, {
+      }, _react["default"].createElement(_AboveSearchTablePanel.AboveSearchTablePanel, _underscore["default"].pick(this.props, 'href', 'context', 'schemas')), _react["default"].createElement(SearchControllersContainer, _extends({}, this.props, {
         facets: propFacets || context.facets,
         navigate: propNavigate || _navigate.navigate
       })));
@@ -484,20 +484,20 @@ var SearchView = function (_React$PureComponent3) {
   }]);
 
   return SearchView;
-}(_react.default.PureComponent);
+}(_react["default"].PureComponent);
 
 exports.SearchView = SearchView;
 
 _defineProperty(SearchView, "propTypes", {
-  'context': _propTypes.default.object.isRequired,
-  'currentAction': _propTypes.default.string,
-  'href': _propTypes.default.string.isRequired,
-  'session': _propTypes.default.bool.isRequired,
-  'navigate': _propTypes.default.func,
-  'facets': _propTypes.default.array,
-  'isFullscreen': _propTypes.default.bool.isRequired,
-  'toggleFullScreen': _propTypes.default.func.isRequired,
-  'separateSingleTermFacets': _propTypes.default.bool.isRequired
+  'context': _propTypes["default"].object.isRequired,
+  'currentAction': _propTypes["default"].string,
+  'href': _propTypes["default"].string.isRequired,
+  'session': _propTypes["default"].bool.isRequired,
+  'navigate': _propTypes["default"].func,
+  'facets': _propTypes["default"].array,
+  'isFullscreen': _propTypes["default"].bool.isRequired,
+  'toggleFullScreen': _propTypes["default"].func.isRequired,
+  'separateSingleTermFacets': _propTypes["default"].bool.isRequired
 });
 
 _defineProperty(SearchView, "defaultProps", {
@@ -507,7 +507,7 @@ _defineProperty(SearchView, "defaultProps", {
   'separateSingleTermFacets': true
 });
 
-var SelectStickyFooter = _react.default.memo(function (props) {
+var SelectStickyFooter = _react["default"].memo(function (props) {
   var context = props.context,
       schemas = props.schemas,
       selectedItems = props.selectedItems,
@@ -516,32 +516,32 @@ var SelectStickyFooter = _react.default.memo(function (props) {
       currentAction = props.currentAction;
   var itemTypeFriendlyName = (0, _schemaTransforms.getSchemaTypeFromSearchContext)(context, schemas);
   currentAction === 'selection' && selectedItems.size === 1 ? selectedItems.entries().next().value[1].display_title : '0';
-  return _react.default.createElement(StickyFooter, null, _react.default.createElement("div", {
+  return _react["default"].createElement(StickyFooter, null, _react["default"].createElement("div", {
     className: "row"
-  }, _react.default.createElement("div", {
+  }, _react["default"].createElement("div", {
     className: "col-12 col-md-9 text-md-left col-sm-center"
-  }, currentAction === 'multiselect' ? _react.default.createElement("h3", {
+  }, currentAction === 'multiselect' ? _react["default"].createElement("h3", {
     className: "mt-03 mb-0"
-  }, selectedItems.size, _react.default.createElement("small", {
+  }, selectedItems.size, _react["default"].createElement("small", {
     className: "text-muted ml-08"
-  }, itemTypeFriendlyName + (selectedItems.size === 1 ? '' : 's'), " selected")) : _react.default.createElement("h3", {
+  }, itemTypeFriendlyName + (selectedItems.size === 1 ? '' : 's'), " selected")) : _react["default"].createElement("h3", {
     className: "mt-03 mb-0"
-  }, "\xA0")), _react.default.createElement("div", {
+  }, "\xA0")), _react["default"].createElement("div", {
     className: "col-12 col-md-3 text-md-right col-sm-center"
-  }, _react.default.createElement("button", {
+  }, _react["default"].createElement("button", {
     type: "button",
     className: "btn btn-success",
     onClick: onComplete,
     disabled: selectedItems.size === 0,
     "data-tip": "Select checked items and close window"
-  }, _react.default.createElement("i", {
+  }, _react["default"].createElement("i", {
     className: "icon icon-fw fas icon-check"
-  }), "\xA0 Apply"), _react.default.createElement("button", {
+  }), "\xA0 Apply"), _react["default"].createElement("button", {
     type: "button",
     className: "btn btn-outline-warning ml-1",
     onClick: onCancel,
     "data-tip": "Cancel selection and close window"
-  }, _react.default.createElement("i", {
+  }, _react["default"].createElement("i", {
     className: "icon icon-fw fas icon-times"
   }), "\xA0 Cancel"))));
 });
@@ -550,9 +550,9 @@ function StickyFooter(props) {
   var children = props.children,
       passProps = _objectWithoutProperties(props, ["children"]);
 
-  return _react.default.createElement("div", _extends({
+  return _react["default"].createElement("div", _extends({
     className: "sticky-page-footer"
-  }, passProps), _react.default.createElement("div", {
+  }, passProps), _react["default"].createElement("div", {
     className: "container"
   }, children));
 }

--- a/es/components/browse/SearchView.js
+++ b/es/components/browse/SearchView.js
@@ -515,7 +515,7 @@ var SelectStickyFooter = _react.default.memo(function (props) {
       onCancel = props.onCancel,
       currentAction = props.currentAction;
   var itemTypeFriendlyName = (0, _schemaTransforms.getSchemaTypeFromSearchContext)(context, schemas);
-  var selectedItemDisplayTitle = currentAction === 'selection' && selectedItems.size === 1 ? selectedItems.entries().next().value[1].display_title : '0';
+  currentAction === 'selection' && selectedItems.size === 1 ? selectedItems.entries().next().value[1].display_title : '0';
   return _react.default.createElement(StickyFooter, null, _react.default.createElement("div", {
     className: "row"
   }, _react.default.createElement("div", {
@@ -526,13 +526,7 @@ var SelectStickyFooter = _react.default.memo(function (props) {
     className: "text-muted ml-08"
   }, itemTypeFriendlyName + (selectedItems.size === 1 ? '' : 's'), " selected")) : _react.default.createElement("h3", {
     className: "mt-03 mb-0"
-  }, _react.default.createElement("span", {
-    style: {
-      'fontSize': '80%'
-    }
-  }, selectedItemDisplayTitle), _react.default.createElement("small", {
-    className: "text-muted ml-08"
-  }, selectedItems.size === 1 ? '' : itemTypeFriendlyName + 's', " selected"))), _react.default.createElement("div", {
+  }, "\xA0")), _react.default.createElement("div", {
     className: "col-12 col-md-3 text-md-right col-sm-center"
   }, _react.default.createElement("button", {
     type: "button",

--- a/es/components/browse/SearchView.js
+++ b/es/components/browse/SearchView.js
@@ -48,11 +48,9 @@ var _SearchResultDetailPane = require("./components/SearchResultDetailPane");
 
 var _SortController = require("./components/SortController");
 
-var _Checkbox = require("../forms/components/Checkbox");
-
 var _typedefs = require("./../util/typedefs");
 
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function (obj) { return typeof obj; }; } else { _typeof = function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
@@ -119,9 +117,9 @@ var SearchControllersContainer = function (_React$PureComponent) {
     value: function render() {
       var context = this.props.context;
       var defaultHiddenColumns = (0, _tableCommons.defaultHiddenColumnMapFromColumns)(context.columns);
-      return _react["default"].createElement(_CustomColumnController.CustomColumnController, {
+      return _react.default.createElement(_CustomColumnController.CustomColumnController, {
         defaultHiddenColumns: defaultHiddenColumns
-      }, _react["default"].createElement(_SortController.SortController, _underscore["default"].pick(this.props, 'href', 'context', 'navigate'), _react["default"].createElement(ControlsAndResults, _extends({}, this.props, {
+      }, _react.default.createElement(_SortController.SortController, _underscore.default.pick(this.props, 'href', 'context', 'navigate'), _react.default.createElement(ControlsAndResults, _extends({}, this.props, {
         isTermSelected: this.isTermSelected,
         onFilter: this.onFilter
       }))));
@@ -129,7 +127,7 @@ var SearchControllersContainer = function (_React$PureComponent) {
   }]);
 
   return SearchControllersContainer;
-}(_react["default"].PureComponent);
+}(_react.default.PureComponent);
 
 exports.SearchControllersContainer = SearchControllersContainer;
 
@@ -150,26 +148,18 @@ var ControlsAndResults = function (_React$PureComponent2) {
     _this2.handleClearFilters = _this2.handleClearFilters.bind(_assertThisInitialized(_this2));
     _this2.columnExtensionMapWithSelectButton = _this2.columnExtensionMapWithSelectButton.bind(_assertThisInitialized(_this2));
     _this2.renderSearchDetailPane = _this2.renderSearchDetailPane.bind(_assertThisInitialized(_this2));
-    _this2.handleMultiSelectItemCompleteClick = _this2.handleMultiSelectItemCompleteClick.bind(_assertThisInitialized(_this2));
+    _this2.handleSelectItemCompleteClick = _this2.handleSelectItemCompleteClick.bind(_assertThisInitialized(_this2));
     _this2.handleSelectCancelClick = _this2.handleSelectCancelClick.bind(_assertThisInitialized(_this2));
     _this2.state = {
       selectedItems: new Map()
     };
-    _this2.searchResultTableRef = _react["default"].createRef();
+    _this2.searchResultTableRef = _react.default.createRef();
     return _this2;
   }
 
   _createClass(ControlsAndResults, [{
-    key: "handleSingleSelectItemClick",
-    value: function handleSingleSelectItemClick(result) {
-      this.sendDataToParentWindow([{
-        'id': _object.itemUtil.atId(result),
-        'json': result
-      }]);
-    }
-  }, {
-    key: "handleMultiSelectItemClick",
-    value: function handleMultiSelectItemClick(result) {
+    key: "handleSelectItemClick",
+    value: function handleSelectItemClick(result, isMultiSelect) {
       this.setState(function (_ref) {
         var prevItems = _ref.selectedItems;
         var nextItems = new Map(prevItems);
@@ -177,8 +167,12 @@ var ControlsAndResults = function (_React$PureComponent2) {
         var resultID = _object.itemUtil.atId(result);
 
         if (nextItems.has(resultID)) {
-          nextItems["delete"](resultID);
+          nextItems.delete(resultID);
         } else {
+          if (!isMultiSelect) {
+            nextItems.clear();
+          }
+
           nextItems.set(resultID, result);
         }
 
@@ -188,8 +182,8 @@ var ControlsAndResults = function (_React$PureComponent2) {
       });
     }
   }, {
-    key: "handleMultiSelectItemCompleteClick",
-    value: function handleMultiSelectItemCompleteClick() {
+    key: "handleSelectItemCompleteClick",
+    value: function handleSelectItemCompleteClick() {
       var selectedItems = this.state.selectedItems;
       var itemsWrappedWithID = [];
       var _iteratorNormalCompletion = true;
@@ -212,8 +206,8 @@ var ControlsAndResults = function (_React$PureComponent2) {
         _iteratorError = err;
       } finally {
         try {
-          if (!_iteratorNormalCompletion && _iterator["return"] != null) {
-            _iterator["return"]();
+          if (!_iteratorNormalCompletion && _iterator.return != null) {
+            _iterator.return();
           }
         } finally {
           if (_didIteratorError) {
@@ -280,42 +274,29 @@ var ControlsAndResults = function (_React$PureComponent2) {
         return columnExtensionMap;
       }
 
-      columnExtensionMap = _underscore["default"].clone(columnExtensionMap);
+      columnExtensionMap = _underscore.default.clone(columnExtensionMap);
       var origDisplayTitleRenderFxn = columnExtensionMap.display_title && columnExtensionMap.display_title.render || _tableCommons.basicColumnExtensionMap.display_title.render;
 
       if (inSelectionMode) {
-        columnExtensionMap.display_title = _underscore["default"].extend({}, columnExtensionMap.display_title, {
+        columnExtensionMap.display_title = _underscore.default.extend({}, columnExtensionMap.display_title, {
           'minColumnWidth': 120,
           'render': function render(result, columnDefinition, props, width) {
-            var checkBoxControl;
+            var selectedItems = _this3.state.selectedItems;
+            var isChecked = selectedItems.has(_object.itemUtil.atId(result));
 
-            if (currentAction === 'multiselect') {
-              var selectedItems = _this3.state.selectedItems;
-              var isChecked = selectedItems.has(_object.itemUtil.atId(result));
-              checkBoxControl = _react["default"].createElement("input", {
-                type: "checkbox",
-                checked: isChecked,
-                onChange: _this3.handleMultiSelectItemClick.bind(_this3, result),
-                className: "mr-2"
-              });
-            } else {
-              checkBoxControl = _react["default"].createElement("div", {
-                className: "select-button-container"
-              }, _react["default"].createElement("button", {
-                type: "button",
-                className: "select-button",
-                onClick: _this3.handleSingleSelectItemClick.bind(_this3, result)
-              }, _react["default"].createElement("i", {
-                className: "icon icon-fw icon-check fas"
-              })));
-            }
+            var checkBoxControl = _react.default.createElement("input", {
+              type: "checkbox",
+              checked: isChecked,
+              onChange: _this3.handleSelectItemClick.bind(_this3, result, currentAction === 'multiselect'),
+              className: "mr-2"
+            });
 
-            var currentTitleBlock = origDisplayTitleRenderFxn(result, columnDefinition, _underscore["default"].extend({}, props, {
+            var currentTitleBlock = origDisplayTitleRenderFxn(result, columnDefinition, _underscore.default.extend({}, props, {
               currentAction: currentAction
             }), width, true);
             var newChildren = currentTitleBlock.props.children.slice(0);
             newChildren.unshift(checkBoxControl);
-            return _react["default"].cloneElement(currentTitleBlock, {
+            return _react.default.cloneElement(currentTitleBlock, {
               'children': newChildren
             });
           }
@@ -364,13 +345,13 @@ var ControlsAndResults = function (_React$PureComponent2) {
           href = _this$props2.href,
           context = _this$props2.context;
 
-      var urlPartsQuery = _url["default"].parse(href, true).query;
+      var urlPartsQuery = _url.default.parse(href, true).query;
 
       var clearFiltersURL = typeof context.clear_filters === 'string' && context.clear_filters || null;
 
-      var clearFiltersURLQuery = clearFiltersURL && _url["default"].parse(clearFiltersURL, true).query;
+      var clearFiltersURLQuery = clearFiltersURL && _url.default.parse(clearFiltersURL, true).query;
 
-      return !!(clearFiltersURLQuery && !_underscore["default"].isEqual(clearFiltersURLQuery, urlPartsQuery));
+      return !!(clearFiltersURLQuery && !_underscore.default.isEqual(clearFiltersURLQuery, urlPartsQuery));
     }
   }, {
     key: "renderSearchDetailPane",
@@ -378,7 +359,7 @@ var ControlsAndResults = function (_React$PureComponent2) {
       var _this$props3 = this.props,
           windowWidth = _this$props3.windowWidth,
           schemas = _this$props3.schemas;
-      return _react["default"].createElement(_SearchResultDetailPane.SearchResultDetailPane, {
+      return _react.default.createElement(_SearchResultDetailPane.SearchResultDetailPane, {
         result: result,
         rowNumber: rowNumber,
         containerWidth: containerWidth,
@@ -409,54 +390,55 @@ var ControlsAndResults = function (_React$PureComponent2) {
 
       var selfExtendedColumnExtensionMap = this.columnExtensionMapWithSelectButton(columnExtensionMap, currentAction, specificType, abstractType);
       var columnDefinitions = (0, _tableCommons.columnsToColumnDefinitions)(context.columns || {}, selfExtendedColumnExtensionMap);
-      return _react["default"].createElement("div", {
+      return _react.default.createElement("div", {
         className: "row"
-      }, facets.length ? _react["default"].createElement("div", {
+      }, facets.length ? _react.default.createElement("div", {
         className: facetColumnClassName
-      }, _react["default"].createElement("div", {
+      }, _react.default.createElement("div", {
         className: "above-results-table-row"
-      }), _react["default"].createElement(_FacetList.FacetList, _extends({
+      }), _react.default.createElement(_FacetList.FacetList, _extends({
         className: "with-header-bg",
         facets: facets,
         filters: context.filters,
         onClearFilters: this.handleClearFilters,
         itemTypeForSchemas: specificType,
         showClearFiltersButton: this.isClearFiltersBtnVisible()
-      }, _underscore["default"].pick(this.props, 'isTermSelected', 'schemas', 'session', 'onFilter', 'currentAction', 'windowWidth', 'windowHeight', 'termTransformFxn', 'separateSingleTermFacets')))) : null, _react["default"].createElement("div", {
+      }, _underscore.default.pick(this.props, 'isTermSelected', 'schemas', 'session', 'onFilter', 'currentAction', 'windowWidth', 'windowHeight', 'termTransformFxn', 'separateSingleTermFacets')))) : null, _react.default.createElement("div", {
         className: tableColumnClassName
-      }, _react["default"].createElement(_AboveSearchViewTableControls.AboveSearchViewTableControls, _extends({
+      }, _react.default.createElement(_AboveSearchViewTableControls.AboveSearchViewTableControls, _extends({
         showTotalResults: context.total,
         parentForceUpdate: this.forceUpdateOnSelf
-      }, _underscore["default"].pick(this.props, 'addHiddenColumn', 'removeHiddenColumn', 'isFullscreen', 'context', 'columns', 'currentAction', 'windowWidth', 'windowHeight', 'toggleFullScreen'), {
+      }, _underscore.default.pick(this.props, 'addHiddenColumn', 'removeHiddenColumn', 'isFullscreen', 'context', 'columns', 'currentAction', 'windowWidth', 'windowHeight', 'toggleFullScreen'), {
         hiddenColumns: hiddenColumns,
         columnDefinitions: columnDefinitions
-      })), _react["default"].createElement(_SearchResultTable.SearchResultTable, _extends({
+      })), _react.default.createElement(_SearchResultTable.SearchResultTable, _extends({
         ref: this.searchResultTableRef,
         renderDetailPane: this.renderSearchDetailPane,
         totalExpected: context.total
-      }, _underscore["default"].pick(this.props, 'href', 'sortBy', 'sortColumn', 'sortReverse', 'currentAction', 'windowWidth', 'registerWindowOnScrollHandler', 'schemas'), {
+      }, _underscore.default.pick(this.props, 'href', 'sortBy', 'sortColumn', 'sortReverse', 'currentAction', 'windowWidth', 'registerWindowOnScrollHandler', 'schemas'), {
         hiddenColumns: hiddenColumns,
         results: results,
         columnDefinitions: columnDefinitions
-      })), currentAction === 'multiselect' ? _react["default"].createElement(MultiSelectStickyFooter, _extends({
+      })), (0, _misc.isSelectAction)(currentAction) ? _react.default.createElement(SelectStickyFooter, _extends({
         context: context,
         schemas: schemas,
-        selectedItems: selectedItems
+        selectedItems: selectedItems,
+        currentAction: currentAction
       }, {
-        onComplete: this.handleMultiSelectItemCompleteClick,
+        onComplete: this.handleSelectItemCompleteClick,
         onCancel: this.handleSelectCancelClick
       })) : null));
     }
   }]);
 
   return ControlsAndResults;
-}(_react["default"].PureComponent);
+}(_react.default.PureComponent);
 
-_defineProperty(ControlsAndResults, "searchItemTypesFromHref", (0, _memoizeOne["default"])(function (href, schemas) {
+_defineProperty(ControlsAndResults, "searchItemTypesFromHref", (0, _memoizeOne.default)(function (href, schemas) {
   var specificType = 'Item';
   var abstractType = null;
 
-  var urlParts = _url["default"].parse(href, true);
+  var urlParts = _url.default.parse(href, true);
 
   if (typeof urlParts.query.type === 'string') {
     if (urlParts.query.type !== 'Item') {
@@ -483,7 +465,7 @@ var SearchView = function (_React$PureComponent3) {
   _createClass(SearchView, [{
     key: "componentDidMount",
     value: function componentDidMount() {
-      _reactTooltip["default"].rebuild();
+      _reactTooltip.default.rebuild();
     }
   }, {
     key: "render",
@@ -492,9 +474,9 @@ var SearchView = function (_React$PureComponent3) {
           propFacets = _this$props5.facets,
           propNavigate = _this$props5.navigate,
           context = _this$props5.context;
-      return _react["default"].createElement("div", {
+      return _react.default.createElement("div", {
         className: "search-page-container"
-      }, _react["default"].createElement(_AboveSearchTablePanel.AboveSearchTablePanel, _underscore["default"].pick(this.props, 'href', 'context', 'schemas')), _react["default"].createElement(SearchControllersContainer, _extends({}, this.props, {
+      }, _react.default.createElement(_AboveSearchTablePanel.AboveSearchTablePanel, _underscore.default.pick(this.props, 'href', 'context', 'schemas')), _react.default.createElement(SearchControllersContainer, _extends({}, this.props, {
         facets: propFacets || context.facets,
         navigate: propNavigate || _navigate.navigate
       })));
@@ -502,20 +484,20 @@ var SearchView = function (_React$PureComponent3) {
   }]);
 
   return SearchView;
-}(_react["default"].PureComponent);
+}(_react.default.PureComponent);
 
 exports.SearchView = SearchView;
 
 _defineProperty(SearchView, "propTypes", {
-  'context': _propTypes["default"].object.isRequired,
-  'currentAction': _propTypes["default"].string,
-  'href': _propTypes["default"].string.isRequired,
-  'session': _propTypes["default"].bool.isRequired,
-  'navigate': _propTypes["default"].func,
-  'facets': _propTypes["default"].array,
-  'isFullscreen': _propTypes["default"].bool.isRequired,
-  'toggleFullScreen': _propTypes["default"].func.isRequired,
-  'separateSingleTermFacets': _propTypes["default"].bool.isRequired
+  'context': _propTypes.default.object.isRequired,
+  'currentAction': _propTypes.default.string,
+  'href': _propTypes.default.string.isRequired,
+  'session': _propTypes.default.bool.isRequired,
+  'navigate': _propTypes.default.func,
+  'facets': _propTypes.default.array,
+  'isFullscreen': _propTypes.default.bool.isRequired,
+  'toggleFullScreen': _propTypes.default.func.isRequired,
+  'separateSingleTermFacets': _propTypes.default.bool.isRequired
 });
 
 _defineProperty(SearchView, "defaultProps", {
@@ -525,37 +507,47 @@ _defineProperty(SearchView, "defaultProps", {
   'separateSingleTermFacets': true
 });
 
-var MultiSelectStickyFooter = _react["default"].memo(function (props) {
+var SelectStickyFooter = _react.default.memo(function (props) {
   var context = props.context,
       schemas = props.schemas,
       selectedItems = props.selectedItems,
       onComplete = props.onComplete,
-      onCancel = props.onCancel;
+      onCancel = props.onCancel,
+      currentAction = props.currentAction;
   var itemTypeFriendlyName = (0, _schemaTransforms.getSchemaTypeFromSearchContext)(context, schemas);
-  return _react["default"].createElement(StickyFooter, null, _react["default"].createElement("div", {
+  var selectedItemDisplayTitle = currentAction === 'selection' && selectedItems.size === 1 ? selectedItems.entries().next().value[1].display_title : '0';
+  return _react.default.createElement(StickyFooter, null, _react.default.createElement("div", {
     className: "row"
-  }, _react["default"].createElement("div", {
-    className: "col-12 col-md-6 text-md-left col-sm-center"
-  }, _react["default"].createElement("h3", {
+  }, _react.default.createElement("div", {
+    className: "col-12 col-md-9 text-md-left col-sm-center"
+  }, currentAction === 'multiselect' ? _react.default.createElement("h3", {
     className: "mt-03 mb-0"
-  }, selectedItems.size, _react["default"].createElement("small", {
+  }, selectedItems.size, _react.default.createElement("small", {
     className: "text-muted ml-08"
-  }, itemTypeFriendlyName + (selectedItems.size === 1 ? '' : 's'), " selected"))), _react["default"].createElement("div", {
-    className: "col-12 col-md-6 text-md-right col-sm-center"
-  }, _react["default"].createElement("button", {
+  }, itemTypeFriendlyName + (selectedItems.size === 1 ? '' : 's'), " selected")) : _react.default.createElement("h3", {
+    className: "mt-03 mb-0"
+  }, _react.default.createElement("span", {
+    style: {
+      'fontSize': '80%'
+    }
+  }, selectedItemDisplayTitle), _react.default.createElement("small", {
+    className: "text-muted ml-08"
+  }, selectedItems.size === 1 ? '' : itemTypeFriendlyName + 's', " selected"))), _react.default.createElement("div", {
+    className: "col-12 col-md-3 text-md-right col-sm-center"
+  }, _react.default.createElement("button", {
     type: "button",
     className: "btn btn-success",
     onClick: onComplete,
     disabled: selectedItems.size === 0,
     "data-tip": "Select checked items and close window"
-  }, _react["default"].createElement("i", {
+  }, _react.default.createElement("i", {
     className: "icon icon-fw fas icon-check"
-  }), "\xA0 Apply"), _react["default"].createElement("button", {
+  }), "\xA0 Apply"), _react.default.createElement("button", {
     type: "button",
     className: "btn btn-outline-warning ml-1",
     onClick: onCancel,
     "data-tip": "Cancel selection and close window"
-  }, _react["default"].createElement("i", {
+  }, _react.default.createElement("i", {
     className: "icon icon-fw fas icon-times"
   }), "\xA0 Cancel"))));
 });
@@ -564,9 +556,9 @@ function StickyFooter(props) {
   var children = props.children,
       passProps = _objectWithoutProperties(props, ["children"]);
 
-  return _react["default"].createElement("div", _extends({
+  return _react.default.createElement("div", _extends({
     className: "sticky-page-footer"
-  }, passProps), _react["default"].createElement("div", {
+  }, passProps), _react.default.createElement("div", {
     className: "container"
   }, children));
 }

--- a/es/components/browse/components/SearchResultTable.js
+++ b/es/components/browse/components/SearchResultTable.js
@@ -45,7 +45,7 @@ var _Alerts = require("./../../ui/Alerts");
 
 var _tableCommons = require("./table-commons");
 
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _toConsumableArray(arr) { return _arrayWithoutHoles(arr) || _iterableToArray(arr) || _nonIterableSpread(); }
 
@@ -77,7 +77,7 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
 
 function _extends() { _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
 
-var ResultRowColumnBlock = _react["default"].memo(function (props) {
+var ResultRowColumnBlock = _react.default.memo(function (props) {
   var columnDefinition = props.columnDefinition,
       columnNumber = props.columnNumber,
       mounted = props.mounted,
@@ -92,27 +92,27 @@ var ResultRowColumnBlock = _react["default"].memo(function (props) {
     blockWidth = (0, _tableCommons.getColumnWidthFromDefinition)(columnDefinition, mounted, windowWidth);
   }
 
-  return _react["default"].createElement("div", {
+  return _react.default.createElement("div", {
     className: "search-result-column-block",
     style: {
       "width": blockWidth
     },
     "data-field": columnDefinition.field
-  }, _react["default"].createElement(_tableCommons.ResultRowColumnBlockValue, _extends({}, props, {
+  }, _react.default.createElement(_tableCommons.ResultRowColumnBlockValue, _extends({}, props, {
     width: blockWidth,
     schemas: schemas
   })));
 });
 
-var DefaultDetailPane = _react["default"].memo(function (_ref) {
+var DefaultDetailPane = _react.default.memo(function (_ref) {
   var result = _ref.result;
-  return _react["default"].createElement("div", null, result.description ? _react["default"].createElement("div", {
+  return _react.default.createElement("div", null, result.description ? _react.default.createElement("div", {
     className: "flexible-description-box result-table-result-heading"
-  }, result.description) : null, _react["default"].createElement("div", {
+  }, result.description) : null, _react.default.createElement("div", {
     className: "item-page-detail"
-  }, _react["default"].createElement("h4", {
+  }, _react.default.createElement("h4", {
     className: "text-300"
-  }, "Details"), _react["default"].createElement(_ItemDetailList.Detail, {
+  }, "Details"), _react.default.createElement(_ItemDetailList.Detail, {
     context: result,
     open: false
   })));
@@ -131,7 +131,7 @@ var ResultDetail = function (_React$PureComponent) {
     _this.state = {
       'closing': false
     };
-    _this.detailRef = _react["default"].createRef();
+    _this.detailRef = _react.default.createRef();
     _this.firstFoundHeight = null;
     return _this;
   }
@@ -182,34 +182,34 @@ var ResultDetail = function (_React$PureComponent) {
           renderDetailPane = _this$props2.renderDetailPane,
           toggleDetailOpen = _this$props2.toggleDetailOpen;
       var closing = this.state.closing;
-      return _react["default"].createElement("div", {
+      return _react.default.createElement("div", {
         className: "result-table-detail-container detail-" + (open || closing ? 'open' : 'closed')
-      }, open ? _react["default"].createElement("div", {
+      }, open ? _react.default.createElement("div", {
         className: "result-table-detail",
         ref: this.detailRef,
         style: {
           'width': tableContainerWidth,
           'transform': _utilities.style.translate3d(tableContainerScrollLeft)
         }
-      }, renderDetailPane(result, rowNumber, tableContainerWidth, this.setDetailHeightFromPane), _react["default"].createElement("div", {
+      }, renderDetailPane(result, rowNumber, tableContainerWidth, this.setDetailHeightFromPane), _react.default.createElement("div", {
         className: "close-button-container text-center",
         onClick: toggleDetailOpen,
         "data-tip": "Collapse Details"
-      }, _react["default"].createElement("i", {
+      }, _react.default.createElement("i", {
         className: "icon icon-angle-up fas"
-      }))) : _react["default"].createElement("div", null));
+      }))) : _react.default.createElement("div", null));
     }
   }]);
 
   return ResultDetail;
-}(_react["default"].PureComponent);
+}(_react.default.PureComponent);
 
 _defineProperty(ResultDetail, "propTypes", {
-  'result': _propTypes["default"].object.isRequired,
-  'open': _propTypes["default"].bool.isRequired,
-  'renderDetailPane': _propTypes["default"].func.isRequired,
-  'rowNumber': _propTypes["default"].number,
-  'toggleDetailOpen': _propTypes["default"].func.isRequired
+  'result': _propTypes.default.object.isRequired,
+  'open': _propTypes.default.bool.isRequired,
+  'renderDetailPane': _propTypes.default.func.isRequired,
+  'rowNumber': _propTypes.default.number,
+  'toggleDetailOpen': _propTypes.default.func.isRequired
 });
 
 var ResultRow = function (_React$PureComponent2) {
@@ -234,7 +234,7 @@ var ResultRow = function (_React$PureComponent2) {
     _classCallCheck(this, ResultRow);
 
     _this2 = _possibleConstructorReturn(this, _getPrototypeOf(ResultRow).call(this, props));
-    _this2.toggleDetailOpen = _underscore["default"].throttle(_this2.toggleDetailOpen.bind(_assertThisInitialized(_this2)), 250);
+    _this2.toggleDetailOpen = _underscore.default.throttle(_this2.toggleDetailOpen.bind(_assertThisInitialized(_this2)), 250);
     _this2.isOpen = _this2.isOpen.bind(_assertThisInitialized(_this2));
     _this2.setDetailHeight = _this2.setDetailHeight.bind(_assertThisInitialized(_this2));
     _this2.handleDragStart = _this2.handleDragStart.bind(_assertThisInitialized(_this2));
@@ -275,7 +275,7 @@ var ResultRow = function (_React$PureComponent2) {
           schemas = _this$props6.schemas;
       evt.dataTransfer.setData('text/4dn-item-json', JSON.stringify(result));
 
-      var hrefParts = _url["default"].parse(href);
+      var hrefParts = _url.default.parse(href);
 
       var atId = _object.itemUtil.atId(result);
 
@@ -308,8 +308,8 @@ var ResultRow = function (_React$PureComponent2) {
           columnDefinitions = _this$props7.columnDefinitions,
           selectedFiles = _this$props7.selectedFiles;
       var detailOpen = this.isOpen();
-      return _underscore["default"].map(columnDefinitions, function (columnDefinition, columnNumber) {
-        var passedProps = _underscore["default"].extend(_underscore["default"].omit(_this3.props, 'tableContainerWidth', 'tableContainerScrollLeft', 'renderDetailPane', 'id'), {
+      return _underscore.default.map(columnDefinitions, function (columnDefinition, columnNumber) {
+        var passedProps = _underscore.default.extend(_underscore.default.omit(_this3.props, 'tableContainerWidth', 'tableContainerScrollLeft', 'renderDetailPane', 'id'), {
           columnDefinition: columnDefinition,
           columnNumber: columnNumber,
           detailOpen: detailOpen,
@@ -318,7 +318,7 @@ var ResultRow = function (_React$PureComponent2) {
           'selectedFiles': columnNumber === 0 ? selectedFiles : null
         });
 
-        return _react["default"].createElement(ResultRowColumnBlock, passedProps);
+        return _react.default.createElement(ResultRowColumnBlock, passedProps);
       });
     }
   }, {
@@ -330,16 +330,16 @@ var ResultRow = function (_React$PureComponent2) {
       var detailOpen = this.isOpen();
       var isDraggable = (0, _misc.isSelectAction)(currentAction);
 
-      var detailProps = _underscore["default"].omit(this.props, 'openDetailPanes', 'mounted', 'headerColumnWidths', 'columnDefinitions', 'id', 'detailOpen', 'setDetailHeight');
+      var detailProps = _underscore.default.omit(this.props, 'openDetailPanes', 'mounted', 'headerColumnWidths', 'columnDefinitions', 'id', 'detailOpen', 'setDetailHeight');
 
-      return _react["default"].createElement("div", {
+      return _react.default.createElement("div", {
         className: "search-result-row detail-" + (detailOpen ? 'open' : 'closed') + (isDraggable ? ' is-draggable' : ''),
         "data-row-number": rowNumber
-      }, _react["default"].createElement("div", {
+      }, _react.default.createElement("div", {
         className: "columns clearfix result-table-row",
         draggable: isDraggable,
         onDragStart: isDraggable ? this.handleDragStart : null
-      }, this.renderColumns()), _react["default"].createElement(ResultDetail, _extends({}, detailProps, {
+      }, this.renderColumns()), _react.default.createElement(ResultDetail, _extends({}, detailProps, {
         open: !!detailOpen,
         toggleDetailOpen: this.toggleDetailOpen,
         setDetailHeight: this.setDetailHeight
@@ -348,34 +348,34 @@ var ResultRow = function (_React$PureComponent2) {
   }]);
 
   return ResultRow;
-}(_react["default"].PureComponent);
+}(_react.default.PureComponent);
 
 _defineProperty(ResultRow, "propTypes", {
-  'result': _propTypes["default"].shape({
-    '@type': _propTypes["default"].arrayOf(_propTypes["default"].string).isRequired,
-    '@id': _propTypes["default"].string,
-    'lab': _propTypes["default"].object,
-    'display_title': _propTypes["default"].string.isRequired,
-    'status': _propTypes["default"].string,
-    'date_created': _propTypes["default"].string.isRequired
+  'result': _propTypes.default.shape({
+    '@type': _propTypes.default.arrayOf(_propTypes.default.string).isRequired,
+    '@id': _propTypes.default.string,
+    'lab': _propTypes.default.object,
+    'display_title': _propTypes.default.string.isRequired,
+    'status': _propTypes.default.string,
+    'date_created': _propTypes.default.string.isRequired
   }).isRequired,
-  'rowNumber': _propTypes["default"].number.isRequired,
-  'mounted': _propTypes["default"].bool.isRequired,
-  'columnDefinitions': _propTypes["default"].arrayOf(_propTypes["default"].shape({
-    'title': _propTypes["default"].string.isRequired,
-    'field': _propTypes["default"].string.isRequired,
-    'render': _propTypes["default"].func,
-    'widthMap': _propTypes["default"].shape({
-      'lg': _propTypes["default"].number.isRequired,
-      'md': _propTypes["default"].number.isRequired,
-      'sm': _propTypes["default"].number.isRequired
+  'rowNumber': _propTypes.default.number.isRequired,
+  'mounted': _propTypes.default.bool.isRequired,
+  'columnDefinitions': _propTypes.default.arrayOf(_propTypes.default.shape({
+    'title': _propTypes.default.string.isRequired,
+    'field': _propTypes.default.string.isRequired,
+    'render': _propTypes.default.func,
+    'widthMap': _propTypes.default.shape({
+      'lg': _propTypes.default.number.isRequired,
+      'md': _propTypes.default.number.isRequired,
+      'sm': _propTypes.default.number.isRequired
     })
   })).isRequired,
-  'headerColumnWidths': _propTypes["default"].array,
-  'renderDetailPane': _propTypes["default"].func.isRequired,
-  'openDetailPanes': _propTypes["default"].object.isRequired,
-  'setDetailHeight': _propTypes["default"].func.isRequired,
-  'id': _propTypes["default"].string.isRequired
+  'headerColumnWidths': _propTypes.default.array,
+  'renderDetailPane': _propTypes.default.func.isRequired,
+  'openDetailPanes': _propTypes.default.object.isRequired,
+  'setDetailHeight': _propTypes.default.func.isRequired,
+  'id': _propTypes.default.string.isRequired
 });
 
 var LoadMoreAsYouScroll = function (_React$PureComponent3) {
@@ -396,7 +396,7 @@ var LoadMoreAsYouScroll = function (_React$PureComponent3) {
     _this4 = _possibleConstructorReturn(this, _getPrototypeOf(LoadMoreAsYouScroll).call(this, props));
     _this4.getInitialFrom = _this4.getInitialFrom.bind(_assertThisInitialized(_this4));
     _this4.rebuiltHref = _this4.rebuiltHref.bind(_assertThisInitialized(_this4));
-    _this4.handleLoad = _underscore["default"].throttle(_this4.handleLoad.bind(_assertThisInitialized(_this4)), 3000);
+    _this4.handleLoad = _underscore.default.throttle(_this4.handleLoad.bind(_assertThisInitialized(_this4)), 3000);
     var state = {
       'isLoading': false,
       'canLoad': true
@@ -426,7 +426,7 @@ var LoadMoreAsYouScroll = function (_React$PureComponent3) {
       var href = this.props.href;
 
       if (typeof href === 'string') {
-        var parts = _url["default"].parse(href, true);
+        var parts = _url.default.parse(href, true);
 
         if (parts.query.limit && !isNaN(parts.query.from)) return parseInt(parts.query.from);
       }
@@ -440,13 +440,13 @@ var LoadMoreAsYouScroll = function (_React$PureComponent3) {
           href = _this$props9.href,
           results = _this$props9.results;
 
-      var parts = _url["default"].parse(href, true);
+      var parts = _url.default.parse(href, true);
 
       var q = parts.query;
       var initialFrom = this.getInitialFrom();
       q.from = initialFrom + results.length;
-      parts.search = '?' + _querystring["default"].stringify(q);
-      return _url["default"].format(parts);
+      parts.search = '?' + _querystring.default.stringify(q);
+      return _url.default.format(parts);
     }
   }, {
     key: "handleLoad",
@@ -462,11 +462,11 @@ var LoadMoreAsYouScroll = function (_React$PureComponent3) {
               results = _this5$props.results,
               setResults = _this5$props.setResults;
 
-          var oldKeys = _underscore["default"].map(results, _object.itemUtil.atId);
+          var oldKeys = _underscore.default.map(results, _object.itemUtil.atId);
 
-          var newKeys = _underscore["default"].map(resp['@graph'], _object.itemUtil.atId);
+          var newKeys = _underscore.default.map(resp['@graph'], _object.itemUtil.atId);
 
-          var keyIntersection = _underscore["default"].intersection(oldKeys.sort(), newKeys.sort());
+          var keyIntersection = _underscore.default.intersection(oldKeys.sort(), newKeys.sort());
 
           if (keyIntersection.length > 0) {
             _patchedConsole.patchedConsoleInstance.error('FOUND ALREADY-PRESENT RESULT IN NEW RESULTS', keyIntersection, newKeys);
@@ -516,10 +516,10 @@ var LoadMoreAsYouScroll = function (_React$PureComponent3) {
           isLoading = _this$state.isLoading;
 
       if (!(propMounted || stateMounted)) {
-        return _react["default"].createElement("div", null, children);
+        return _react.default.createElement("div", null, children);
       }
 
-      var elementHeight = _underscore["default"].keys(openDetailPanes).length === 0 ? rowHeight : _react["default"].Children.map(children, function (c) {
+      var elementHeight = _underscore.default.keys(openDetailPanes).length === 0 ? rowHeight : _react.default.Children.map(children, function (c) {
         if (typeof openDetailPanes[c.props.id] === 'number') {
           return openDetailPanes[c.props.id] + openRowHeight + 2;
         }
@@ -527,35 +527,35 @@ var LoadMoreAsYouScroll = function (_React$PureComponent3) {
         return rowHeight;
       });
       var canLoad = LoadMoreAsYouScroll.canLoadMore(totalExpected, results);
-      return _react["default"].createElement(_reactInfinite["default"], {
+      return _react.default.createElement(_reactInfinite.default, {
         elementHeight: elementHeight,
         useWindowAsScrollContainer: true,
         onInfiniteLoad: this.handleLoad,
         isInfiniteLoading: isLoading,
         timeScrollStateLastsForAfterUserScrolls: 250,
-        loadingSpinnerDelegate: _react["default"].createElement("div", {
+        loadingSpinnerDelegate: _react.default.createElement("div", {
           className: "search-result-row loading text-center",
           style: {
             'maxWidth': tableContainerWidth,
             'transform': _utilities.style.translate3d(tableContainerScrollLeft)
           }
-        }, _react["default"].createElement("i", {
+        }, _react.default.createElement("i", {
           className: "icon icon-circle-notch icon-spin fas"
         }), "\xA0 Loading..."),
         infiniteLoadBeginEdgeOffset: canLoad ? 200 : undefined,
-        preloadAdditionalHeight: _reactInfinite["default"].containerHeightScaleFactor(1.5),
-        preloadBatchSize: _reactInfinite["default"].containerHeightScaleFactor(1.5)
+        preloadAdditionalHeight: _reactInfinite.default.containerHeightScaleFactor(1.5),
+        preloadBatchSize: _reactInfinite.default.containerHeightScaleFactor(1.5)
       }, children);
     }
   }]);
 
   return LoadMoreAsYouScroll;
-}(_react["default"].PureComponent);
+}(_react.default.PureComponent);
 
 _defineProperty(LoadMoreAsYouScroll, "propTypes", {
-  'href': _propTypes["default"].string.isRequired,
-  'limit': _propTypes["default"].number,
-  'rowHeight': _propTypes["default"].number.isRequired
+  'href': _propTypes.default.string.isRequired,
+  'limit': _propTypes.default.number,
+  'rowHeight': _propTypes.default.number.isRequired
 });
 
 _defineProperty(LoadMoreAsYouScroll, "defaultProps", {
@@ -701,12 +701,12 @@ var ShadowBorderLayer = function (_React$Component) {
         className += ' faded-out';
       }
 
-      return _react["default"].createElement("div", {
+      return _react.default.createElement("div", {
         className: className,
         onMouseDown: this.handleLeftScrollButtonMouseDown,
         onMouseUp: this.handleScrollButtonUp,
         onMouseOut: this.handleScrollButtonUp
-      }, _react["default"].createElement("i", {
+      }, _react.default.createElement("i", {
         className: "icon icon-caret-left fas"
       }));
     }
@@ -720,12 +720,12 @@ var ShadowBorderLayer = function (_React$Component) {
         className += ' faded-out';
       }
 
-      return _react["default"].createElement("div", {
+      return _react.default.createElement("div", {
         className: className,
         onMouseDown: this.handleRightScrollButtonMouseDown,
         onMouseUp: this.handleScrollButtonUp,
         onMouseOut: this.handleScrollButtonUp
-      }, _react["default"].createElement("i", {
+      }, _react.default.createElement("i", {
         className: "icon icon-caret-right fas"
       }));
     }
@@ -773,14 +773,14 @@ var ShadowBorderLayer = function (_React$Component) {
     value: function render() {
       if (this.props.fullRowWidth <= this.props.tableContainerWidth) return null;
       var edges = this.edgeHiddenContentWidths();
-      return _react["default"].createElement("div", {
+      return _react.default.createElement("div", {
         className: "shadow-border-layer hidden-xs" + this.shadowStateClass(edges) + this.tallDimensionClass() + (this.props.isWindowPastTableTop ? ' fixed-position-arrows' : '')
       }, this.edgeScrollButtonLeft(edges.left), this.edgeScrollButtonRight(edges.right));
     }
   }]);
 
   return ShadowBorderLayer;
-}(_react["default"].Component);
+}(_react.default.Component);
 
 _defineProperty(ShadowBorderLayer, "defaultProps", {
   'horizontalScrollRateOnEdgeButton': 10
@@ -794,7 +794,7 @@ var DimensioningContainer = function (_React$PureComponent4) {
     value: function resetHeaderColumnWidths(columnDefinitions) {
       var mounted = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : false;
       var windowWidth = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : null;
-      return _underscore["default"].map(columnDefinitions, function (colDef) {
+      return _underscore.default.map(columnDefinitions, function (colDef) {
         return (0, _tableCommons.getColumnWidthFromDefinition)(colDef, mounted, windowWidth);
       });
     }
@@ -812,7 +812,7 @@ var DimensioningContainer = function (_React$PureComponent4) {
 
       if (elementsFound && elementsFound.length > 0) {
         var headerElement = document.querySelector('div.search-headers-column-block[data-field="' + columnField + '"] .column-title');
-        maxColWidth = Math.max(_underscore["default"].reduce(elementsFound, function (m, elem) {
+        maxColWidth = Math.max(_underscore.default.reduce(elementsFound, function (m, elem) {
           return Math.max(m, elem.offsetWidth);
         }, 0), headerElement && headerElement.offsetWidth + 12 || 0);
       }
@@ -839,7 +839,7 @@ var DimensioningContainer = function (_React$PureComponent4) {
       if (detailPanes && detailPanes.length > 0) {
         var transformStyle = _utilities.style.translate3d(leftOffset);
 
-        _underscore["default"].forEach(detailPanes, function (d) {
+        _underscore.default.forEach(detailPanes, function (d) {
           d.style.transform = transformStyle;
         });
       }
@@ -878,13 +878,13 @@ var DimensioningContainer = function (_React$PureComponent4) {
     _classCallCheck(this, DimensioningContainer);
 
     _this8 = _possibleConstructorReturn(this, _getPrototypeOf(DimensioningContainer).call(this, props));
-    _this8.throttledUpdate = _underscore["default"].debounce(_this8.forceUpdate.bind(_assertThisInitialized(_this8)), 500);
-    _this8.toggleDetailPaneOpen = _underscore["default"].throttle(_this8.toggleDetailPaneOpen.bind(_assertThisInitialized(_this8)), 500);
+    _this8.throttledUpdate = _underscore.default.debounce(_this8.forceUpdate.bind(_assertThisInitialized(_this8)), 500);
+    _this8.toggleDetailPaneOpen = _underscore.default.throttle(_this8.toggleDetailPaneOpen.bind(_assertThisInitialized(_this8)), 500);
     _this8.setDetailHeight = _this8.setDetailHeight.bind(_assertThisInitialized(_this8));
     _this8.setContainerScrollLeft = _this8.setContainerScrollLeft.bind(_assertThisInitialized(_this8));
     _this8.onHorizontalScroll = _this8.onHorizontalScroll.bind(_assertThisInitialized(_this8));
-    _this8.onVerticalScroll = _underscore["default"].throttle(_this8.onVerticalScroll.bind(_assertThisInitialized(_this8)), 200);
-    _this8.setHeaderWidths = _underscore["default"].throttle(_this8.setHeaderWidths.bind(_assertThisInitialized(_this8)), 300);
+    _this8.onVerticalScroll = _underscore.default.throttle(_this8.onVerticalScroll.bind(_assertThisInitialized(_this8)), 200);
+    _this8.setHeaderWidths = _underscore.default.throttle(_this8.setHeaderWidths.bind(_assertThisInitialized(_this8)), 300);
     _this8.getTableDims = _this8.getTableDims.bind(_assertThisInitialized(_this8));
     _this8.resetWidths = _this8.resetWidths.bind(_assertThisInitialized(_this8));
     _this8.setResults = _this8.setResults.bind(_assertThisInitialized(_this8));
@@ -899,8 +899,8 @@ var DimensioningContainer = function (_React$PureComponent4) {
       'isWindowPastTableTop': false,
       'openDetailPanes': {}
     };
-    _this8.innerContainerRef = _react["default"].createRef();
-    _this8.loadMoreAsYouScrollRef = _react["default"].createRef();
+    _this8.innerContainerRef = _react.default.createRef();
+    _this8.loadMoreAsYouScrollRef = _react.default.createRef();
     return _this8;
   }
 
@@ -911,7 +911,7 @@ var DimensioningContainer = function (_React$PureComponent4) {
           columnDefinitions = _this$props12.columnDefinitions,
           windowWidth = _this$props12.windowWidth,
           registerWindowOnScrollHandler = _this$props12.registerWindowOnScrollHandler,
-          nextState = _underscore["default"].extend(this.getTableDims(), {
+          nextState = _underscore.default.extend(this.getTableDims(), {
         'mounted': true
       }),
           innerContainerElem = this.innerContainerRef.current;
@@ -947,7 +947,7 @@ var DimensioningContainer = function (_React$PureComponent4) {
     key: "componentDidUpdate",
     value: function componentDidUpdate(pastProps, pastState) {
       if (pastState.results !== this.state.results) {
-        _reactTooltip["default"].rebuild();
+        _reactTooltip.default.rebuild();
       }
 
       if (pastProps.columnDefinitions.length !== this.props.columnDefinitions.length) {
@@ -962,7 +962,7 @@ var DimensioningContainer = function (_React$PureComponent4) {
       var cb = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : null;
       this.setState(function (_ref2) {
         var openDetailPanes = _ref2.openDetailPanes;
-        openDetailPanes = _underscore["default"].clone(openDetailPanes);
+        openDetailPanes = _underscore.default.clone(openDetailPanes);
 
         if (openDetailPanes[rowKey]) {
           delete openDetailPanes[rowKey];
@@ -980,7 +980,7 @@ var DimensioningContainer = function (_React$PureComponent4) {
     value: function setDetailHeight(rowKey, height, cb) {
       this.setState(function (_ref3) {
         var openDetailPanes = _ref3.openDetailPanes;
-        openDetailPanes = _underscore["default"].clone(openDetailPanes);
+        openDetailPanes = _underscore.default.clone(openDetailPanes);
 
         if (typeof openDetailPanes[rowKey] === 'undefined') {
           return null;
@@ -1089,7 +1089,7 @@ var DimensioningContainer = function (_React$PureComponent4) {
               columnDefinitions = _this10$props.columnDefinitions,
               windowWidth = _this10$props.windowWidth;
 
-          _this10.setState(_underscore["default"].extend(_this10.getTableDims(), {
+          _this10.setState(_underscore.default.extend(_this10.getTableDims(), {
             'widths': DimensioningContainer.findAndDecreaseColumnWidths(columnDefinitions, 30, windowWidth)
           }));
         });
@@ -1107,7 +1107,7 @@ var DimensioningContainer = function (_React$PureComponent4) {
     key: "setResults",
     value: function setResults(results, cb) {
       this.setState({
-        'results': _underscore["default"].uniq(results, false, _object.itemUtil.atId)
+        'results': _underscore.default.uniq(results, false, _object.itemUtil.atId)
       }, cb);
     }
   }, {
@@ -1123,7 +1123,7 @@ var DimensioningContainer = function (_React$PureComponent4) {
           stickyHeaderTopOffset = _this$props13.stickyHeaderTopOffset,
           currentAction = _this$props13.currentAction,
           href = _this$props13.href;
-      var displayNavBar = !(href && typeof href === 'string' && href.indexOf('/search/') >= 0 && currentAction === 'multiselect');
+      var displayNavBar = !(href && typeof href === 'string' && href.indexOf('/search/') >= 0 && (0, _misc.isSelectAction)(currentAction));
       var rgs = (0, _layout.responsiveGridState)(windowWidth);
 
       switch (rgs) {
@@ -1150,7 +1150,7 @@ var DimensioningContainer = function (_React$PureComponent4) {
           tableContainerWidth = _this$state2.tableContainerWidth,
           tableLeftOffset = _this$state2.tableLeftOffset,
           widths = _this$state2.widths;
-      return _react["default"].createElement(_tableCommons.HeadersRow, _extends({}, _underscore["default"].pick(this.props, 'columnDefinitions', 'sortBy', 'sortColumn', 'sortReverse', 'defaultMinColumnWidth', 'rowHeight', 'renderDetailPane', 'windowWidth'), _underscore["default"].pick(this.state, 'mounted', 'results'), {
+      return _react.default.createElement(_tableCommons.HeadersRow, _extends({}, _underscore.default.pick(this.props, 'columnDefinitions', 'sortBy', 'sortColumn', 'sortReverse', 'defaultMinColumnWidth', 'rowHeight', 'renderDetailPane', 'windowWidth'), _underscore.default.pick(this.state, 'mounted', 'results'), {
         stickyHeaderTopOffset: this.stickyHeaderTopOffset(),
         headerColumnWidths: widths,
         setHeaderWidths: this.setHeaderWidths,
@@ -1176,7 +1176,7 @@ var DimensioningContainer = function (_React$PureComponent4) {
 
       var fullRowWidth = _tableCommons.HeadersRow.fullRowWidth(columnDefinitions, mounted, widths, windowWidth);
 
-      var commonPropsToPass = _underscore["default"].extend(_underscore["default"].pick(this.props, 'columnDefinitions', 'renderDetailPane', 'href', 'currentAction', 'selectedFiles', 'windowWidth', 'schemas'), {
+      var commonPropsToPass = _underscore.default.extend(_underscore.default.pick(this.props, 'columnDefinitions', 'renderDetailPane', 'href', 'currentAction', 'selectedFiles', 'windowWidth', 'schemas'), {
         openDetailPanes: openDetailPanes,
         tableContainerWidth: tableContainerWidth,
         tableContainerScrollLeft: tableContainerScrollLeft,
@@ -1187,10 +1187,10 @@ var DimensioningContainer = function (_React$PureComponent4) {
         'setDetailHeight': this.setDetailHeight
       });
 
-      return _underscore["default"].map(results, function (r, idx) {
+      return _underscore.default.map(results, function (r, idx) {
         var id = _object.itemUtil.atId(r);
 
-        return _react["default"].createElement(ResultRow, _extends({}, commonPropsToPass, {
+        return _react.default.createElement(ResultRow, _extends({}, commonPropsToPass, {
           result: r,
           rowNumber: idx,
           id: id,
@@ -1215,29 +1215,29 @@ var DimensioningContainer = function (_React$PureComponent4) {
 
       var canLoadMore = this.canLoadMore();
       var innerContainerElem = this.innerContainerRef.current;
-      return _react["default"].createElement("div", {
+      return _react.default.createElement("div", {
         className: "search-results-outer-container"
-      }, _react["default"].createElement(_reactSticky.StickyContainer, null, _react["default"].createElement("div", {
+      }, _react.default.createElement(_reactSticky.StickyContainer, null, _react.default.createElement("div", {
         className: "search-results-container" + (canLoadMore === false ? ' fully-loaded' : '')
-      }, _react["default"].createElement("div", {
+      }, _react.default.createElement("div", {
         className: "inner-container",
         ref: this.innerContainerRef
-      }, _react["default"].createElement("div", {
+      }, _react.default.createElement("div", {
         className: "scrollable-container",
         style: {
           minWidth: fullRowWidth + 6
         }
-      }, _react["default"].createElement(_reactSticky.Sticky, {
+      }, _react.default.createElement(_reactSticky.Sticky, {
         windowWidth: windowWidth,
         topOffset: this.stickyHeaderTopOffset()
-      }, this.renderHeadersRow), _react["default"].createElement(LoadMoreAsYouScroll, _extends({}, _underscore["default"].pick(this.props, 'href', 'limit', 'rowHeight', 'totalExpected', 'onDuplicateResultsFoundCallback', 'windowWidth', 'schemas'), _underscore["default"].pick(this.state, 'results', 'mounted', 'openDetailPanes'), {
+      }, this.renderHeadersRow), _react.default.createElement(LoadMoreAsYouScroll, _extends({}, _underscore.default.pick(this.props, 'href', 'limit', 'rowHeight', 'totalExpected', 'onDuplicateResultsFoundCallback', 'windowWidth', 'schemas'), _underscore.default.pick(this.state, 'results', 'mounted', 'openDetailPanes'), {
         tableContainerWidth: tableContainerWidth,
         tableContainerScrollLeft: tableContainerScrollLeft,
         innerContainerElem: innerContainerElem
       }, {
         setResults: this.setResults,
         ref: this.loadMoreAsYouScrollRef
-      }), this.renderResults()))), _react["default"].createElement(ShadowBorderLayer, _extends({
+      }), this.renderResults()))), _react.default.createElement(ShadowBorderLayer, _extends({
         tableContainerScrollLeft: tableContainerScrollLeft,
         tableContainerWidth: tableContainerWidth,
         fullRowWidth: fullRowWidth,
@@ -1245,12 +1245,12 @@ var DimensioningContainer = function (_React$PureComponent4) {
         innerContainerElem: innerContainerElem
       }, {
         setContainerScrollLeft: this.setContainerScrollLeft
-      })))), canLoadMore === false ? _react["default"].createElement("div", {
+      })))), canLoadMore === false ? _react.default.createElement("div", {
         key: "can-load-more",
         className: "fin search-result-row"
-      }, _react["default"].createElement("div", {
+      }, _react.default.createElement("div", {
         className: "inner"
-      }, "- ", _react["default"].createElement("span", null, "fin"), " -")) : _react["default"].createElement("div", {
+      }, "- ", _react.default.createElement("span", null, "fin"), " -")) : _react.default.createElement("div", {
         key: "can-load-more",
         className: "search-result-row empty-block"
       }));
@@ -1258,7 +1258,7 @@ var DimensioningContainer = function (_React$PureComponent4) {
   }]);
 
   return DimensioningContainer;
-}(_react["default"].PureComponent);
+}(_react.default.PureComponent);
 
 var SearchResultTable = function (_React$PureComponent5) {
   _inherits(SearchResultTable, _React$PureComponent5);
@@ -1277,7 +1277,7 @@ var SearchResultTable = function (_React$PureComponent5) {
 
     _this11 = _possibleConstructorReturn(this, _getPrototypeOf(SearchResultTable).call(this, props));
     _this11.getDimensionContainer = _this11.getDimensionContainer.bind(_assertThisInitialized(_this11));
-    _this11.dimensionContainerRef = _react["default"].createRef();
+    _this11.dimensionContainerRef = _react.default.createRef();
     return _this11;
   }
 
@@ -1298,7 +1298,7 @@ var SearchResultTable = function (_React$PureComponent5) {
           'title': 'Title'
         }
       }, columnExtensionMap);
-      return _react["default"].createElement(DimensioningContainer, _extends({}, _underscore["default"].omit(this.props, 'hiddenColumns', 'columnDefinitionOverrideMap', 'defaultWidthMap'), {
+      return _react.default.createElement(DimensioningContainer, _extends({}, _underscore.default.omit(this.props, 'hiddenColumns', 'columnDefinitionOverrideMap', 'defaultWidthMap'), {
         columnDefinitions: SearchResultTable.filterOutHiddenCols(colDefs, hiddenColumns),
         ref: this.dimensionContainerRef
       }));
@@ -1306,13 +1306,13 @@ var SearchResultTable = function (_React$PureComponent5) {
   }]);
 
   return SearchResultTable;
-}(_react["default"].PureComponent);
+}(_react.default.PureComponent);
 
 exports.SearchResultTable = SearchResultTable;
 
-_defineProperty(SearchResultTable, "filterOutHiddenCols", (0, _memoizeOne["default"])(function (columnDefinitions, hiddenColumns) {
+_defineProperty(SearchResultTable, "filterOutHiddenCols", (0, _memoizeOne.default)(function (columnDefinitions, hiddenColumns) {
   if (hiddenColumns) {
-    return _underscore["default"].filter(columnDefinitions, function (colDef) {
+    return _underscore.default.filter(columnDefinitions, function (colDef) {
       if (hiddenColumns[colDef.field] === true) return false;
       return true;
     });
@@ -1322,38 +1322,38 @@ _defineProperty(SearchResultTable, "filterOutHiddenCols", (0, _memoizeOne["defau
 }));
 
 _defineProperty(SearchResultTable, "propTypes", {
-  'results': _propTypes["default"].arrayOf(ResultRow.propTypes.result).isRequired,
-  'href': _propTypes["default"].string.isRequired,
-  'limit': _propTypes["default"].number,
-  'columnDefinitions': _propTypes["default"].arrayOf(_propTypes["default"].object),
-  'defaultWidthMap': _propTypes["default"].shape({
-    'lg': _propTypes["default"].number.isRequired,
-    'md': _propTypes["default"].number.isRequired,
-    'sm': _propTypes["default"].number.isRequired
+  'results': _propTypes.default.arrayOf(ResultRow.propTypes.result).isRequired,
+  'href': _propTypes.default.string.isRequired,
+  'limit': _propTypes.default.number,
+  'columnDefinitions': _propTypes.default.arrayOf(_propTypes.default.object),
+  'defaultWidthMap': _propTypes.default.shape({
+    'lg': _propTypes.default.number.isRequired,
+    'md': _propTypes.default.number.isRequired,
+    'sm': _propTypes.default.number.isRequired
   }).isRequired,
-  'hiddenColumns': _propTypes["default"].objectOf(_propTypes["default"].bool),
-  'renderDetailPane': _propTypes["default"].func,
-  'totalExpected': _propTypes["default"].number.isRequired,
-  'windowWidth': _propTypes["default"].number.isRequired,
-  'registerWindowOnScrollHandler': _propTypes["default"].func.isRequired,
-  'columnExtensionMap': _propTypes["default"].objectOf(_propTypes["default"].shape({
-    "title": _propTypes["default"].string.isRequired,
-    "widthMap": _propTypes["default"].shape({
-      'lg': _propTypes["default"].number,
-      'md': _propTypes["default"].number,
-      'sm': _propTypes["default"].number
+  'hiddenColumns': _propTypes.default.objectOf(_propTypes.default.bool),
+  'renderDetailPane': _propTypes.default.func,
+  'totalExpected': _propTypes.default.number.isRequired,
+  'windowWidth': _propTypes.default.number.isRequired,
+  'registerWindowOnScrollHandler': _propTypes.default.func.isRequired,
+  'columnExtensionMap': _propTypes.default.objectOf(_propTypes.default.shape({
+    "title": _propTypes.default.string.isRequired,
+    "widthMap": _propTypes.default.shape({
+      'lg': _propTypes.default.number,
+      'md': _propTypes.default.number,
+      'sm': _propTypes.default.number
     }),
-    "minColumnWidth": _propTypes["default"].number,
-    "order": _propTypes["default"].number,
-    "render": _propTypes["default"].func,
-    "noSort": _propTypes["default"].bool
+    "minColumnWidth": _propTypes.default.number,
+    "order": _propTypes.default.number,
+    "render": _propTypes.default.func,
+    "noSort": _propTypes.default.bool
   }))
 });
 
 _defineProperty(SearchResultTable, "defaultProps", {
   'columnExtensionMap': {},
   'renderDetailPane': function renderDetailPane(result, rowNumber, width) {
-    return _react["default"].createElement(DefaultDetailPane, {
+    return _react.default.createElement(DefaultDetailPane, {
       result: result,
       rowNumber: rowNumber,
       width: width

--- a/es/components/browse/components/SearchResultTable.js
+++ b/es/components/browse/components/SearchResultTable.js
@@ -45,7 +45,7 @@ var _Alerts = require("./../../ui/Alerts");
 
 var _tableCommons = require("./table-commons");
 
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
 function _toConsumableArray(arr) { return _arrayWithoutHoles(arr) || _iterableToArray(arr) || _nonIterableSpread(); }
 
@@ -77,7 +77,7 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
 
 function _extends() { _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
 
-var ResultRowColumnBlock = _react.default.memo(function (props) {
+var ResultRowColumnBlock = _react["default"].memo(function (props) {
   var columnDefinition = props.columnDefinition,
       columnNumber = props.columnNumber,
       mounted = props.mounted,
@@ -92,27 +92,27 @@ var ResultRowColumnBlock = _react.default.memo(function (props) {
     blockWidth = (0, _tableCommons.getColumnWidthFromDefinition)(columnDefinition, mounted, windowWidth);
   }
 
-  return _react.default.createElement("div", {
+  return _react["default"].createElement("div", {
     className: "search-result-column-block",
     style: {
       "width": blockWidth
     },
     "data-field": columnDefinition.field
-  }, _react.default.createElement(_tableCommons.ResultRowColumnBlockValue, _extends({}, props, {
+  }, _react["default"].createElement(_tableCommons.ResultRowColumnBlockValue, _extends({}, props, {
     width: blockWidth,
     schemas: schemas
   })));
 });
 
-var DefaultDetailPane = _react.default.memo(function (_ref) {
+var DefaultDetailPane = _react["default"].memo(function (_ref) {
   var result = _ref.result;
-  return _react.default.createElement("div", null, result.description ? _react.default.createElement("div", {
+  return _react["default"].createElement("div", null, result.description ? _react["default"].createElement("div", {
     className: "flexible-description-box result-table-result-heading"
-  }, result.description) : null, _react.default.createElement("div", {
+  }, result.description) : null, _react["default"].createElement("div", {
     className: "item-page-detail"
-  }, _react.default.createElement("h4", {
+  }, _react["default"].createElement("h4", {
     className: "text-300"
-  }, "Details"), _react.default.createElement(_ItemDetailList.Detail, {
+  }, "Details"), _react["default"].createElement(_ItemDetailList.Detail, {
     context: result,
     open: false
   })));
@@ -131,7 +131,7 @@ var ResultDetail = function (_React$PureComponent) {
     _this.state = {
       'closing': false
     };
-    _this.detailRef = _react.default.createRef();
+    _this.detailRef = _react["default"].createRef();
     _this.firstFoundHeight = null;
     return _this;
   }
@@ -182,34 +182,34 @@ var ResultDetail = function (_React$PureComponent) {
           renderDetailPane = _this$props2.renderDetailPane,
           toggleDetailOpen = _this$props2.toggleDetailOpen;
       var closing = this.state.closing;
-      return _react.default.createElement("div", {
+      return _react["default"].createElement("div", {
         className: "result-table-detail-container detail-" + (open || closing ? 'open' : 'closed')
-      }, open ? _react.default.createElement("div", {
+      }, open ? _react["default"].createElement("div", {
         className: "result-table-detail",
         ref: this.detailRef,
         style: {
           'width': tableContainerWidth,
           'transform': _utilities.style.translate3d(tableContainerScrollLeft)
         }
-      }, renderDetailPane(result, rowNumber, tableContainerWidth, this.setDetailHeightFromPane), _react.default.createElement("div", {
+      }, renderDetailPane(result, rowNumber, tableContainerWidth, this.setDetailHeightFromPane), _react["default"].createElement("div", {
         className: "close-button-container text-center",
         onClick: toggleDetailOpen,
         "data-tip": "Collapse Details"
-      }, _react.default.createElement("i", {
+      }, _react["default"].createElement("i", {
         className: "icon icon-angle-up fas"
-      }))) : _react.default.createElement("div", null));
+      }))) : _react["default"].createElement("div", null));
     }
   }]);
 
   return ResultDetail;
-}(_react.default.PureComponent);
+}(_react["default"].PureComponent);
 
 _defineProperty(ResultDetail, "propTypes", {
-  'result': _propTypes.default.object.isRequired,
-  'open': _propTypes.default.bool.isRequired,
-  'renderDetailPane': _propTypes.default.func.isRequired,
-  'rowNumber': _propTypes.default.number,
-  'toggleDetailOpen': _propTypes.default.func.isRequired
+  'result': _propTypes["default"].object.isRequired,
+  'open': _propTypes["default"].bool.isRequired,
+  'renderDetailPane': _propTypes["default"].func.isRequired,
+  'rowNumber': _propTypes["default"].number,
+  'toggleDetailOpen': _propTypes["default"].func.isRequired
 });
 
 var ResultRow = function (_React$PureComponent2) {
@@ -234,7 +234,7 @@ var ResultRow = function (_React$PureComponent2) {
     _classCallCheck(this, ResultRow);
 
     _this2 = _possibleConstructorReturn(this, _getPrototypeOf(ResultRow).call(this, props));
-    _this2.toggleDetailOpen = _underscore.default.throttle(_this2.toggleDetailOpen.bind(_assertThisInitialized(_this2)), 250);
+    _this2.toggleDetailOpen = _underscore["default"].throttle(_this2.toggleDetailOpen.bind(_assertThisInitialized(_this2)), 250);
     _this2.isOpen = _this2.isOpen.bind(_assertThisInitialized(_this2));
     _this2.setDetailHeight = _this2.setDetailHeight.bind(_assertThisInitialized(_this2));
     _this2.handleDragStart = _this2.handleDragStart.bind(_assertThisInitialized(_this2));
@@ -275,7 +275,7 @@ var ResultRow = function (_React$PureComponent2) {
           schemas = _this$props6.schemas;
       evt.dataTransfer.setData('text/4dn-item-json', JSON.stringify(result));
 
-      var hrefParts = _url.default.parse(href);
+      var hrefParts = _url["default"].parse(href);
 
       var atId = _object.itemUtil.atId(result);
 
@@ -308,8 +308,8 @@ var ResultRow = function (_React$PureComponent2) {
           columnDefinitions = _this$props7.columnDefinitions,
           selectedFiles = _this$props7.selectedFiles;
       var detailOpen = this.isOpen();
-      return _underscore.default.map(columnDefinitions, function (columnDefinition, columnNumber) {
-        var passedProps = _underscore.default.extend(_underscore.default.omit(_this3.props, 'tableContainerWidth', 'tableContainerScrollLeft', 'renderDetailPane', 'id'), {
+      return _underscore["default"].map(columnDefinitions, function (columnDefinition, columnNumber) {
+        var passedProps = _underscore["default"].extend(_underscore["default"].omit(_this3.props, 'tableContainerWidth', 'tableContainerScrollLeft', 'renderDetailPane', 'id'), {
           columnDefinition: columnDefinition,
           columnNumber: columnNumber,
           detailOpen: detailOpen,
@@ -318,7 +318,7 @@ var ResultRow = function (_React$PureComponent2) {
           'selectedFiles': columnNumber === 0 ? selectedFiles : null
         });
 
-        return _react.default.createElement(ResultRowColumnBlock, passedProps);
+        return _react["default"].createElement(ResultRowColumnBlock, passedProps);
       });
     }
   }, {
@@ -330,16 +330,16 @@ var ResultRow = function (_React$PureComponent2) {
       var detailOpen = this.isOpen();
       var isDraggable = (0, _misc.isSelectAction)(currentAction);
 
-      var detailProps = _underscore.default.omit(this.props, 'openDetailPanes', 'mounted', 'headerColumnWidths', 'columnDefinitions', 'id', 'detailOpen', 'setDetailHeight');
+      var detailProps = _underscore["default"].omit(this.props, 'openDetailPanes', 'mounted', 'headerColumnWidths', 'columnDefinitions', 'id', 'detailOpen', 'setDetailHeight');
 
-      return _react.default.createElement("div", {
+      return _react["default"].createElement("div", {
         className: "search-result-row detail-" + (detailOpen ? 'open' : 'closed') + (isDraggable ? ' is-draggable' : ''),
         "data-row-number": rowNumber
-      }, _react.default.createElement("div", {
+      }, _react["default"].createElement("div", {
         className: "columns clearfix result-table-row",
         draggable: isDraggable,
         onDragStart: isDraggable ? this.handleDragStart : null
-      }, this.renderColumns()), _react.default.createElement(ResultDetail, _extends({}, detailProps, {
+      }, this.renderColumns()), _react["default"].createElement(ResultDetail, _extends({}, detailProps, {
         open: !!detailOpen,
         toggleDetailOpen: this.toggleDetailOpen,
         setDetailHeight: this.setDetailHeight
@@ -348,34 +348,34 @@ var ResultRow = function (_React$PureComponent2) {
   }]);
 
   return ResultRow;
-}(_react.default.PureComponent);
+}(_react["default"].PureComponent);
 
 _defineProperty(ResultRow, "propTypes", {
-  'result': _propTypes.default.shape({
-    '@type': _propTypes.default.arrayOf(_propTypes.default.string).isRequired,
-    '@id': _propTypes.default.string,
-    'lab': _propTypes.default.object,
-    'display_title': _propTypes.default.string.isRequired,
-    'status': _propTypes.default.string,
-    'date_created': _propTypes.default.string.isRequired
+  'result': _propTypes["default"].shape({
+    '@type': _propTypes["default"].arrayOf(_propTypes["default"].string).isRequired,
+    '@id': _propTypes["default"].string,
+    'lab': _propTypes["default"].object,
+    'display_title': _propTypes["default"].string.isRequired,
+    'status': _propTypes["default"].string,
+    'date_created': _propTypes["default"].string.isRequired
   }).isRequired,
-  'rowNumber': _propTypes.default.number.isRequired,
-  'mounted': _propTypes.default.bool.isRequired,
-  'columnDefinitions': _propTypes.default.arrayOf(_propTypes.default.shape({
-    'title': _propTypes.default.string.isRequired,
-    'field': _propTypes.default.string.isRequired,
-    'render': _propTypes.default.func,
-    'widthMap': _propTypes.default.shape({
-      'lg': _propTypes.default.number.isRequired,
-      'md': _propTypes.default.number.isRequired,
-      'sm': _propTypes.default.number.isRequired
+  'rowNumber': _propTypes["default"].number.isRequired,
+  'mounted': _propTypes["default"].bool.isRequired,
+  'columnDefinitions': _propTypes["default"].arrayOf(_propTypes["default"].shape({
+    'title': _propTypes["default"].string.isRequired,
+    'field': _propTypes["default"].string.isRequired,
+    'render': _propTypes["default"].func,
+    'widthMap': _propTypes["default"].shape({
+      'lg': _propTypes["default"].number.isRequired,
+      'md': _propTypes["default"].number.isRequired,
+      'sm': _propTypes["default"].number.isRequired
     })
   })).isRequired,
-  'headerColumnWidths': _propTypes.default.array,
-  'renderDetailPane': _propTypes.default.func.isRequired,
-  'openDetailPanes': _propTypes.default.object.isRequired,
-  'setDetailHeight': _propTypes.default.func.isRequired,
-  'id': _propTypes.default.string.isRequired
+  'headerColumnWidths': _propTypes["default"].array,
+  'renderDetailPane': _propTypes["default"].func.isRequired,
+  'openDetailPanes': _propTypes["default"].object.isRequired,
+  'setDetailHeight': _propTypes["default"].func.isRequired,
+  'id': _propTypes["default"].string.isRequired
 });
 
 var LoadMoreAsYouScroll = function (_React$PureComponent3) {
@@ -396,7 +396,7 @@ var LoadMoreAsYouScroll = function (_React$PureComponent3) {
     _this4 = _possibleConstructorReturn(this, _getPrototypeOf(LoadMoreAsYouScroll).call(this, props));
     _this4.getInitialFrom = _this4.getInitialFrom.bind(_assertThisInitialized(_this4));
     _this4.rebuiltHref = _this4.rebuiltHref.bind(_assertThisInitialized(_this4));
-    _this4.handleLoad = _underscore.default.throttle(_this4.handleLoad.bind(_assertThisInitialized(_this4)), 3000);
+    _this4.handleLoad = _underscore["default"].throttle(_this4.handleLoad.bind(_assertThisInitialized(_this4)), 3000);
     var state = {
       'isLoading': false,
       'canLoad': true
@@ -426,7 +426,7 @@ var LoadMoreAsYouScroll = function (_React$PureComponent3) {
       var href = this.props.href;
 
       if (typeof href === 'string') {
-        var parts = _url.default.parse(href, true);
+        var parts = _url["default"].parse(href, true);
 
         if (parts.query.limit && !isNaN(parts.query.from)) return parseInt(parts.query.from);
       }
@@ -440,13 +440,13 @@ var LoadMoreAsYouScroll = function (_React$PureComponent3) {
           href = _this$props9.href,
           results = _this$props9.results;
 
-      var parts = _url.default.parse(href, true);
+      var parts = _url["default"].parse(href, true);
 
       var q = parts.query;
       var initialFrom = this.getInitialFrom();
       q.from = initialFrom + results.length;
-      parts.search = '?' + _querystring.default.stringify(q);
-      return _url.default.format(parts);
+      parts.search = '?' + _querystring["default"].stringify(q);
+      return _url["default"].format(parts);
     }
   }, {
     key: "handleLoad",
@@ -462,11 +462,11 @@ var LoadMoreAsYouScroll = function (_React$PureComponent3) {
               results = _this5$props.results,
               setResults = _this5$props.setResults;
 
-          var oldKeys = _underscore.default.map(results, _object.itemUtil.atId);
+          var oldKeys = _underscore["default"].map(results, _object.itemUtil.atId);
 
-          var newKeys = _underscore.default.map(resp['@graph'], _object.itemUtil.atId);
+          var newKeys = _underscore["default"].map(resp['@graph'], _object.itemUtil.atId);
 
-          var keyIntersection = _underscore.default.intersection(oldKeys.sort(), newKeys.sort());
+          var keyIntersection = _underscore["default"].intersection(oldKeys.sort(), newKeys.sort());
 
           if (keyIntersection.length > 0) {
             _patchedConsole.patchedConsoleInstance.error('FOUND ALREADY-PRESENT RESULT IN NEW RESULTS', keyIntersection, newKeys);
@@ -516,10 +516,10 @@ var LoadMoreAsYouScroll = function (_React$PureComponent3) {
           isLoading = _this$state.isLoading;
 
       if (!(propMounted || stateMounted)) {
-        return _react.default.createElement("div", null, children);
+        return _react["default"].createElement("div", null, children);
       }
 
-      var elementHeight = _underscore.default.keys(openDetailPanes).length === 0 ? rowHeight : _react.default.Children.map(children, function (c) {
+      var elementHeight = _underscore["default"].keys(openDetailPanes).length === 0 ? rowHeight : _react["default"].Children.map(children, function (c) {
         if (typeof openDetailPanes[c.props.id] === 'number') {
           return openDetailPanes[c.props.id] + openRowHeight + 2;
         }
@@ -527,35 +527,35 @@ var LoadMoreAsYouScroll = function (_React$PureComponent3) {
         return rowHeight;
       });
       var canLoad = LoadMoreAsYouScroll.canLoadMore(totalExpected, results);
-      return _react.default.createElement(_reactInfinite.default, {
+      return _react["default"].createElement(_reactInfinite["default"], {
         elementHeight: elementHeight,
         useWindowAsScrollContainer: true,
         onInfiniteLoad: this.handleLoad,
         isInfiniteLoading: isLoading,
         timeScrollStateLastsForAfterUserScrolls: 250,
-        loadingSpinnerDelegate: _react.default.createElement("div", {
+        loadingSpinnerDelegate: _react["default"].createElement("div", {
           className: "search-result-row loading text-center",
           style: {
             'maxWidth': tableContainerWidth,
             'transform': _utilities.style.translate3d(tableContainerScrollLeft)
           }
-        }, _react.default.createElement("i", {
+        }, _react["default"].createElement("i", {
           className: "icon icon-circle-notch icon-spin fas"
         }), "\xA0 Loading..."),
         infiniteLoadBeginEdgeOffset: canLoad ? 200 : undefined,
-        preloadAdditionalHeight: _reactInfinite.default.containerHeightScaleFactor(1.5),
-        preloadBatchSize: _reactInfinite.default.containerHeightScaleFactor(1.5)
+        preloadAdditionalHeight: _reactInfinite["default"].containerHeightScaleFactor(1.5),
+        preloadBatchSize: _reactInfinite["default"].containerHeightScaleFactor(1.5)
       }, children);
     }
   }]);
 
   return LoadMoreAsYouScroll;
-}(_react.default.PureComponent);
+}(_react["default"].PureComponent);
 
 _defineProperty(LoadMoreAsYouScroll, "propTypes", {
-  'href': _propTypes.default.string.isRequired,
-  'limit': _propTypes.default.number,
-  'rowHeight': _propTypes.default.number.isRequired
+  'href': _propTypes["default"].string.isRequired,
+  'limit': _propTypes["default"].number,
+  'rowHeight': _propTypes["default"].number.isRequired
 });
 
 _defineProperty(LoadMoreAsYouScroll, "defaultProps", {
@@ -701,12 +701,12 @@ var ShadowBorderLayer = function (_React$Component) {
         className += ' faded-out';
       }
 
-      return _react.default.createElement("div", {
+      return _react["default"].createElement("div", {
         className: className,
         onMouseDown: this.handleLeftScrollButtonMouseDown,
         onMouseUp: this.handleScrollButtonUp,
         onMouseOut: this.handleScrollButtonUp
-      }, _react.default.createElement("i", {
+      }, _react["default"].createElement("i", {
         className: "icon icon-caret-left fas"
       }));
     }
@@ -720,12 +720,12 @@ var ShadowBorderLayer = function (_React$Component) {
         className += ' faded-out';
       }
 
-      return _react.default.createElement("div", {
+      return _react["default"].createElement("div", {
         className: className,
         onMouseDown: this.handleRightScrollButtonMouseDown,
         onMouseUp: this.handleScrollButtonUp,
         onMouseOut: this.handleScrollButtonUp
-      }, _react.default.createElement("i", {
+      }, _react["default"].createElement("i", {
         className: "icon icon-caret-right fas"
       }));
     }
@@ -773,14 +773,14 @@ var ShadowBorderLayer = function (_React$Component) {
     value: function render() {
       if (this.props.fullRowWidth <= this.props.tableContainerWidth) return null;
       var edges = this.edgeHiddenContentWidths();
-      return _react.default.createElement("div", {
+      return _react["default"].createElement("div", {
         className: "shadow-border-layer hidden-xs" + this.shadowStateClass(edges) + this.tallDimensionClass() + (this.props.isWindowPastTableTop ? ' fixed-position-arrows' : '')
       }, this.edgeScrollButtonLeft(edges.left), this.edgeScrollButtonRight(edges.right));
     }
   }]);
 
   return ShadowBorderLayer;
-}(_react.default.Component);
+}(_react["default"].Component);
 
 _defineProperty(ShadowBorderLayer, "defaultProps", {
   'horizontalScrollRateOnEdgeButton': 10
@@ -794,7 +794,7 @@ var DimensioningContainer = function (_React$PureComponent4) {
     value: function resetHeaderColumnWidths(columnDefinitions) {
       var mounted = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : false;
       var windowWidth = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : null;
-      return _underscore.default.map(columnDefinitions, function (colDef) {
+      return _underscore["default"].map(columnDefinitions, function (colDef) {
         return (0, _tableCommons.getColumnWidthFromDefinition)(colDef, mounted, windowWidth);
       });
     }
@@ -812,7 +812,7 @@ var DimensioningContainer = function (_React$PureComponent4) {
 
       if (elementsFound && elementsFound.length > 0) {
         var headerElement = document.querySelector('div.search-headers-column-block[data-field="' + columnField + '"] .column-title');
-        maxColWidth = Math.max(_underscore.default.reduce(elementsFound, function (m, elem) {
+        maxColWidth = Math.max(_underscore["default"].reduce(elementsFound, function (m, elem) {
           return Math.max(m, elem.offsetWidth);
         }, 0), headerElement && headerElement.offsetWidth + 12 || 0);
       }
@@ -839,7 +839,7 @@ var DimensioningContainer = function (_React$PureComponent4) {
       if (detailPanes && detailPanes.length > 0) {
         var transformStyle = _utilities.style.translate3d(leftOffset);
 
-        _underscore.default.forEach(detailPanes, function (d) {
+        _underscore["default"].forEach(detailPanes, function (d) {
           d.style.transform = transformStyle;
         });
       }
@@ -878,13 +878,13 @@ var DimensioningContainer = function (_React$PureComponent4) {
     _classCallCheck(this, DimensioningContainer);
 
     _this8 = _possibleConstructorReturn(this, _getPrototypeOf(DimensioningContainer).call(this, props));
-    _this8.throttledUpdate = _underscore.default.debounce(_this8.forceUpdate.bind(_assertThisInitialized(_this8)), 500);
-    _this8.toggleDetailPaneOpen = _underscore.default.throttle(_this8.toggleDetailPaneOpen.bind(_assertThisInitialized(_this8)), 500);
+    _this8.throttledUpdate = _underscore["default"].debounce(_this8.forceUpdate.bind(_assertThisInitialized(_this8)), 500);
+    _this8.toggleDetailPaneOpen = _underscore["default"].throttle(_this8.toggleDetailPaneOpen.bind(_assertThisInitialized(_this8)), 500);
     _this8.setDetailHeight = _this8.setDetailHeight.bind(_assertThisInitialized(_this8));
     _this8.setContainerScrollLeft = _this8.setContainerScrollLeft.bind(_assertThisInitialized(_this8));
     _this8.onHorizontalScroll = _this8.onHorizontalScroll.bind(_assertThisInitialized(_this8));
-    _this8.onVerticalScroll = _underscore.default.throttle(_this8.onVerticalScroll.bind(_assertThisInitialized(_this8)), 200);
-    _this8.setHeaderWidths = _underscore.default.throttle(_this8.setHeaderWidths.bind(_assertThisInitialized(_this8)), 300);
+    _this8.onVerticalScroll = _underscore["default"].throttle(_this8.onVerticalScroll.bind(_assertThisInitialized(_this8)), 200);
+    _this8.setHeaderWidths = _underscore["default"].throttle(_this8.setHeaderWidths.bind(_assertThisInitialized(_this8)), 300);
     _this8.getTableDims = _this8.getTableDims.bind(_assertThisInitialized(_this8));
     _this8.resetWidths = _this8.resetWidths.bind(_assertThisInitialized(_this8));
     _this8.setResults = _this8.setResults.bind(_assertThisInitialized(_this8));
@@ -899,8 +899,8 @@ var DimensioningContainer = function (_React$PureComponent4) {
       'isWindowPastTableTop': false,
       'openDetailPanes': {}
     };
-    _this8.innerContainerRef = _react.default.createRef();
-    _this8.loadMoreAsYouScrollRef = _react.default.createRef();
+    _this8.innerContainerRef = _react["default"].createRef();
+    _this8.loadMoreAsYouScrollRef = _react["default"].createRef();
     return _this8;
   }
 
@@ -911,7 +911,7 @@ var DimensioningContainer = function (_React$PureComponent4) {
           columnDefinitions = _this$props12.columnDefinitions,
           windowWidth = _this$props12.windowWidth,
           registerWindowOnScrollHandler = _this$props12.registerWindowOnScrollHandler,
-          nextState = _underscore.default.extend(this.getTableDims(), {
+          nextState = _underscore["default"].extend(this.getTableDims(), {
         'mounted': true
       }),
           innerContainerElem = this.innerContainerRef.current;
@@ -947,7 +947,7 @@ var DimensioningContainer = function (_React$PureComponent4) {
     key: "componentDidUpdate",
     value: function componentDidUpdate(pastProps, pastState) {
       if (pastState.results !== this.state.results) {
-        _reactTooltip.default.rebuild();
+        _reactTooltip["default"].rebuild();
       }
 
       if (pastProps.columnDefinitions.length !== this.props.columnDefinitions.length) {
@@ -962,7 +962,7 @@ var DimensioningContainer = function (_React$PureComponent4) {
       var cb = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : null;
       this.setState(function (_ref2) {
         var openDetailPanes = _ref2.openDetailPanes;
-        openDetailPanes = _underscore.default.clone(openDetailPanes);
+        openDetailPanes = _underscore["default"].clone(openDetailPanes);
 
         if (openDetailPanes[rowKey]) {
           delete openDetailPanes[rowKey];
@@ -980,7 +980,7 @@ var DimensioningContainer = function (_React$PureComponent4) {
     value: function setDetailHeight(rowKey, height, cb) {
       this.setState(function (_ref3) {
         var openDetailPanes = _ref3.openDetailPanes;
-        openDetailPanes = _underscore.default.clone(openDetailPanes);
+        openDetailPanes = _underscore["default"].clone(openDetailPanes);
 
         if (typeof openDetailPanes[rowKey] === 'undefined') {
           return null;
@@ -1089,7 +1089,7 @@ var DimensioningContainer = function (_React$PureComponent4) {
               columnDefinitions = _this10$props.columnDefinitions,
               windowWidth = _this10$props.windowWidth;
 
-          _this10.setState(_underscore.default.extend(_this10.getTableDims(), {
+          _this10.setState(_underscore["default"].extend(_this10.getTableDims(), {
             'widths': DimensioningContainer.findAndDecreaseColumnWidths(columnDefinitions, 30, windowWidth)
           }));
         });
@@ -1107,7 +1107,7 @@ var DimensioningContainer = function (_React$PureComponent4) {
     key: "setResults",
     value: function setResults(results, cb) {
       this.setState({
-        'results': _underscore.default.uniq(results, false, _object.itemUtil.atId)
+        'results': _underscore["default"].uniq(results, false, _object.itemUtil.atId)
       }, cb);
     }
   }, {
@@ -1150,7 +1150,7 @@ var DimensioningContainer = function (_React$PureComponent4) {
           tableContainerWidth = _this$state2.tableContainerWidth,
           tableLeftOffset = _this$state2.tableLeftOffset,
           widths = _this$state2.widths;
-      return _react.default.createElement(_tableCommons.HeadersRow, _extends({}, _underscore.default.pick(this.props, 'columnDefinitions', 'sortBy', 'sortColumn', 'sortReverse', 'defaultMinColumnWidth', 'rowHeight', 'renderDetailPane', 'windowWidth'), _underscore.default.pick(this.state, 'mounted', 'results'), {
+      return _react["default"].createElement(_tableCommons.HeadersRow, _extends({}, _underscore["default"].pick(this.props, 'columnDefinitions', 'sortBy', 'sortColumn', 'sortReverse', 'defaultMinColumnWidth', 'rowHeight', 'renderDetailPane', 'windowWidth'), _underscore["default"].pick(this.state, 'mounted', 'results'), {
         stickyHeaderTopOffset: this.stickyHeaderTopOffset(),
         headerColumnWidths: widths,
         setHeaderWidths: this.setHeaderWidths,
@@ -1176,7 +1176,7 @@ var DimensioningContainer = function (_React$PureComponent4) {
 
       var fullRowWidth = _tableCommons.HeadersRow.fullRowWidth(columnDefinitions, mounted, widths, windowWidth);
 
-      var commonPropsToPass = _underscore.default.extend(_underscore.default.pick(this.props, 'columnDefinitions', 'renderDetailPane', 'href', 'currentAction', 'selectedFiles', 'windowWidth', 'schemas'), {
+      var commonPropsToPass = _underscore["default"].extend(_underscore["default"].pick(this.props, 'columnDefinitions', 'renderDetailPane', 'href', 'currentAction', 'selectedFiles', 'windowWidth', 'schemas'), {
         openDetailPanes: openDetailPanes,
         tableContainerWidth: tableContainerWidth,
         tableContainerScrollLeft: tableContainerScrollLeft,
@@ -1187,10 +1187,10 @@ var DimensioningContainer = function (_React$PureComponent4) {
         'setDetailHeight': this.setDetailHeight
       });
 
-      return _underscore.default.map(results, function (r, idx) {
+      return _underscore["default"].map(results, function (r, idx) {
         var id = _object.itemUtil.atId(r);
 
-        return _react.default.createElement(ResultRow, _extends({}, commonPropsToPass, {
+        return _react["default"].createElement(ResultRow, _extends({}, commonPropsToPass, {
           result: r,
           rowNumber: idx,
           id: id,
@@ -1215,29 +1215,29 @@ var DimensioningContainer = function (_React$PureComponent4) {
 
       var canLoadMore = this.canLoadMore();
       var innerContainerElem = this.innerContainerRef.current;
-      return _react.default.createElement("div", {
+      return _react["default"].createElement("div", {
         className: "search-results-outer-container"
-      }, _react.default.createElement(_reactSticky.StickyContainer, null, _react.default.createElement("div", {
+      }, _react["default"].createElement(_reactSticky.StickyContainer, null, _react["default"].createElement("div", {
         className: "search-results-container" + (canLoadMore === false ? ' fully-loaded' : '')
-      }, _react.default.createElement("div", {
+      }, _react["default"].createElement("div", {
         className: "inner-container",
         ref: this.innerContainerRef
-      }, _react.default.createElement("div", {
+      }, _react["default"].createElement("div", {
         className: "scrollable-container",
         style: {
           minWidth: fullRowWidth + 6
         }
-      }, _react.default.createElement(_reactSticky.Sticky, {
+      }, _react["default"].createElement(_reactSticky.Sticky, {
         windowWidth: windowWidth,
         topOffset: this.stickyHeaderTopOffset()
-      }, this.renderHeadersRow), _react.default.createElement(LoadMoreAsYouScroll, _extends({}, _underscore.default.pick(this.props, 'href', 'limit', 'rowHeight', 'totalExpected', 'onDuplicateResultsFoundCallback', 'windowWidth', 'schemas'), _underscore.default.pick(this.state, 'results', 'mounted', 'openDetailPanes'), {
+      }, this.renderHeadersRow), _react["default"].createElement(LoadMoreAsYouScroll, _extends({}, _underscore["default"].pick(this.props, 'href', 'limit', 'rowHeight', 'totalExpected', 'onDuplicateResultsFoundCallback', 'windowWidth', 'schemas'), _underscore["default"].pick(this.state, 'results', 'mounted', 'openDetailPanes'), {
         tableContainerWidth: tableContainerWidth,
         tableContainerScrollLeft: tableContainerScrollLeft,
         innerContainerElem: innerContainerElem
       }, {
         setResults: this.setResults,
         ref: this.loadMoreAsYouScrollRef
-      }), this.renderResults()))), _react.default.createElement(ShadowBorderLayer, _extends({
+      }), this.renderResults()))), _react["default"].createElement(ShadowBorderLayer, _extends({
         tableContainerScrollLeft: tableContainerScrollLeft,
         tableContainerWidth: tableContainerWidth,
         fullRowWidth: fullRowWidth,
@@ -1245,12 +1245,12 @@ var DimensioningContainer = function (_React$PureComponent4) {
         innerContainerElem: innerContainerElem
       }, {
         setContainerScrollLeft: this.setContainerScrollLeft
-      })))), canLoadMore === false ? _react.default.createElement("div", {
+      })))), canLoadMore === false ? _react["default"].createElement("div", {
         key: "can-load-more",
         className: "fin search-result-row"
-      }, _react.default.createElement("div", {
+      }, _react["default"].createElement("div", {
         className: "inner"
-      }, "- ", _react.default.createElement("span", null, "fin"), " -")) : _react.default.createElement("div", {
+      }, "- ", _react["default"].createElement("span", null, "fin"), " -")) : _react["default"].createElement("div", {
         key: "can-load-more",
         className: "search-result-row empty-block"
       }));
@@ -1258,7 +1258,7 @@ var DimensioningContainer = function (_React$PureComponent4) {
   }]);
 
   return DimensioningContainer;
-}(_react.default.PureComponent);
+}(_react["default"].PureComponent);
 
 var SearchResultTable = function (_React$PureComponent5) {
   _inherits(SearchResultTable, _React$PureComponent5);
@@ -1277,7 +1277,7 @@ var SearchResultTable = function (_React$PureComponent5) {
 
     _this11 = _possibleConstructorReturn(this, _getPrototypeOf(SearchResultTable).call(this, props));
     _this11.getDimensionContainer = _this11.getDimensionContainer.bind(_assertThisInitialized(_this11));
-    _this11.dimensionContainerRef = _react.default.createRef();
+    _this11.dimensionContainerRef = _react["default"].createRef();
     return _this11;
   }
 
@@ -1298,7 +1298,7 @@ var SearchResultTable = function (_React$PureComponent5) {
           'title': 'Title'
         }
       }, columnExtensionMap);
-      return _react.default.createElement(DimensioningContainer, _extends({}, _underscore.default.omit(this.props, 'hiddenColumns', 'columnDefinitionOverrideMap', 'defaultWidthMap'), {
+      return _react["default"].createElement(DimensioningContainer, _extends({}, _underscore["default"].omit(this.props, 'hiddenColumns', 'columnDefinitionOverrideMap', 'defaultWidthMap'), {
         columnDefinitions: SearchResultTable.filterOutHiddenCols(colDefs, hiddenColumns),
         ref: this.dimensionContainerRef
       }));
@@ -1306,13 +1306,13 @@ var SearchResultTable = function (_React$PureComponent5) {
   }]);
 
   return SearchResultTable;
-}(_react.default.PureComponent);
+}(_react["default"].PureComponent);
 
 exports.SearchResultTable = SearchResultTable;
 
-_defineProperty(SearchResultTable, "filterOutHiddenCols", (0, _memoizeOne.default)(function (columnDefinitions, hiddenColumns) {
+_defineProperty(SearchResultTable, "filterOutHiddenCols", (0, _memoizeOne["default"])(function (columnDefinitions, hiddenColumns) {
   if (hiddenColumns) {
-    return _underscore.default.filter(columnDefinitions, function (colDef) {
+    return _underscore["default"].filter(columnDefinitions, function (colDef) {
       if (hiddenColumns[colDef.field] === true) return false;
       return true;
     });
@@ -1322,38 +1322,38 @@ _defineProperty(SearchResultTable, "filterOutHiddenCols", (0, _memoizeOne.defaul
 }));
 
 _defineProperty(SearchResultTable, "propTypes", {
-  'results': _propTypes.default.arrayOf(ResultRow.propTypes.result).isRequired,
-  'href': _propTypes.default.string.isRequired,
-  'limit': _propTypes.default.number,
-  'columnDefinitions': _propTypes.default.arrayOf(_propTypes.default.object),
-  'defaultWidthMap': _propTypes.default.shape({
-    'lg': _propTypes.default.number.isRequired,
-    'md': _propTypes.default.number.isRequired,
-    'sm': _propTypes.default.number.isRequired
+  'results': _propTypes["default"].arrayOf(ResultRow.propTypes.result).isRequired,
+  'href': _propTypes["default"].string.isRequired,
+  'limit': _propTypes["default"].number,
+  'columnDefinitions': _propTypes["default"].arrayOf(_propTypes["default"].object),
+  'defaultWidthMap': _propTypes["default"].shape({
+    'lg': _propTypes["default"].number.isRequired,
+    'md': _propTypes["default"].number.isRequired,
+    'sm': _propTypes["default"].number.isRequired
   }).isRequired,
-  'hiddenColumns': _propTypes.default.objectOf(_propTypes.default.bool),
-  'renderDetailPane': _propTypes.default.func,
-  'totalExpected': _propTypes.default.number.isRequired,
-  'windowWidth': _propTypes.default.number.isRequired,
-  'registerWindowOnScrollHandler': _propTypes.default.func.isRequired,
-  'columnExtensionMap': _propTypes.default.objectOf(_propTypes.default.shape({
-    "title": _propTypes.default.string.isRequired,
-    "widthMap": _propTypes.default.shape({
-      'lg': _propTypes.default.number,
-      'md': _propTypes.default.number,
-      'sm': _propTypes.default.number
+  'hiddenColumns': _propTypes["default"].objectOf(_propTypes["default"].bool),
+  'renderDetailPane': _propTypes["default"].func,
+  'totalExpected': _propTypes["default"].number.isRequired,
+  'windowWidth': _propTypes["default"].number.isRequired,
+  'registerWindowOnScrollHandler': _propTypes["default"].func.isRequired,
+  'columnExtensionMap': _propTypes["default"].objectOf(_propTypes["default"].shape({
+    "title": _propTypes["default"].string.isRequired,
+    "widthMap": _propTypes["default"].shape({
+      'lg': _propTypes["default"].number,
+      'md': _propTypes["default"].number,
+      'sm': _propTypes["default"].number
     }),
-    "minColumnWidth": _propTypes.default.number,
-    "order": _propTypes.default.number,
-    "render": _propTypes.default.func,
-    "noSort": _propTypes.default.bool
+    "minColumnWidth": _propTypes["default"].number,
+    "order": _propTypes["default"].number,
+    "render": _propTypes["default"].func,
+    "noSort": _propTypes["default"].bool
   }))
 });
 
 _defineProperty(SearchResultTable, "defaultProps", {
   'columnExtensionMap': {},
   'renderDetailPane': function renderDetailPane(result, rowNumber, width) {
-    return _react.default.createElement(DefaultDetailPane, {
+    return _react["default"].createElement(DefaultDetailPane, {
       result: result,
       rowNumber: rowNumber,
       width: width

--- a/es/components/forms/SubmissionView.js
+++ b/es/components/forms/SubmissionView.js
@@ -4,7 +4,7 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.buildContext = buildContext;
-exports["default"] = void 0;
+exports.default = void 0;
 
 var _react = _interopRequireDefault(require("react"));
 
@@ -34,7 +34,15 @@ var _SubmissionTree = require("./components/SubmissionTree");
 
 var _submissionFields = require("./components/submission-fields");
 
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _toConsumableArray(arr) { return _arrayWithoutHoles(arr) || _iterableToArray(arr) || _nonIterableSpread(); }
+
+function _nonIterableSpread() { throw new TypeError("Invalid attempt to spread non-iterable instance"); }
+
+function _iterableToArray(iter) { if (Symbol.iterator in Object(iter) || Object.prototype.toString.call(iter) === "[object Arguments]") return Array.from(iter); }
+
+function _arrayWithoutHoles(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = new Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } }
 
 function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function (obj) { return typeof obj; }; } else { _typeof = function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
@@ -44,9 +52,7 @@ function _objectWithoutProperties(source, excluded) { if (source == null) return
 
 function _objectWithoutPropertiesLoose(source, excluded) { if (source == null) return {}; var target = {}; var sourceKeys = Object.keys(source); var key, i; for (i = 0; i < sourceKeys.length; i++) { key = sourceKeys[i]; if (excluded.indexOf(key) >= 0) continue; target[key] = source[key]; } return target; }
 
-function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
-
-function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(source, true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(source).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); } return target; }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
@@ -86,7 +92,7 @@ var SubmissionView = function (_React$PureComponent) {
       if (keyHierarchy === null) return 0;
       var validationReturn = 1;
 
-      _underscore["default"].keys(keyHierarchy).forEach(function (key) {
+      _underscore.default.keys(keyHierarchy).forEach(function (key) {
         if (!isNaN(key)) {
           if (!keyComplete[key] && keyContext[key]) {
             validationReturn = 0;
@@ -123,7 +129,7 @@ var SubmissionView = function (_React$PureComponent) {
 
     _this = _possibleConstructorReturn(this, _getPrototypeOf(SubmissionView).call(this, props));
 
-    _underscore["default"].bindAll(_assertThisInitialized(_this), 'modifyKeyContext', 'initializePrincipal', 'initCreateObj', 'initCreateAlias', 'submitAmbiguousType', 'buildAmbiguousEnumEntry', 'handleTypeSelection', 'handleAliasChange', 'handleAliasLabChange', 'submitAlias', 'modifyAlias', 'createObj', 'removeObj', 'initExistingObj', 'addExistingObj', 'setSubmissionState', 'updateUpload', 'testPostNewContext', 'realPostNewContext', 'removeNullsFromContext', 'checkRoundTwo', 'buildDeleteFields', 'modifyMD5Progess', 'submitObject', 'finishRoundTwo', 'cancelCreateNewObject', 'cancelCreatePrimaryObject');
+    _underscore.default.bindAll(_assertThisInitialized(_this), 'modifyKeyContext', 'initializePrincipal', 'initCreateObj', 'initCreateAlias', 'submitAmbiguousType', 'buildAmbiguousEnumEntry', 'handleTypeSelection', 'handleAliasChange', 'handleAliasLabChange', 'submitAlias', 'modifyAlias', 'createObj', 'removeObj', 'initExistingObj', 'addExistingObj', 'setSubmissionState', 'updateUpload', 'testPostNewContext', 'realPostNewContext', 'removeNullsFromContext', 'checkRoundTwo', 'buildDeleteFields', 'modifyMD5Progess', 'submitObject', 'finishRoundTwo', 'cancelCreateNewObject', 'cancelCreatePrimaryObject');
 
     _this.state = {
       'keyContext': null,
@@ -169,7 +175,7 @@ var SubmissionView = function (_React$PureComponent) {
     value: function componentDidMount() {
       var schemas = this.props.schemas;
 
-      if (schemas && _underscore["default"].keys(schemas).length > 0) {
+      if (schemas && _underscore.default.keys(schemas).length > 0) {
         this.initializePrincipal();
       }
     }
@@ -213,7 +219,7 @@ var SubmissionView = function (_React$PureComponent) {
           'keyContext': contextCopy,
           'keyValid': validCopy
         };
-      }, _reactTooltip["default"].rebuild);
+      }, _reactTooltip.default.rebuild);
     }
   }, {
     key: "initializePrincipal",
@@ -231,7 +237,7 @@ var SubmissionView = function (_React$PureComponent) {
       var keyContext = {};
       var contextID = _util.object.itemUtil.atId(context) || null;
 
-      var parsedHref = _url["default"].parse(href, true);
+      var parsedHref = _url.default.parse(href, true);
 
       var principalTypes = context['@type'];
 
@@ -239,7 +245,7 @@ var SubmissionView = function (_React$PureComponent) {
         var typeFromHref = parsedHref.query && parsedHref.query.type || 'Item';
 
         if (Array.isArray(typeFromHref)) {
-          var _$without = _underscore["default"].without(typeFromHref, 'Item');
+          var _$without = _underscore.default.without(typeFromHref, 'Item');
 
           var _$without2 = _slicedToArray(_$without, 1);
 
@@ -273,7 +279,7 @@ var SubmissionView = function (_React$PureComponent) {
       var userHref = null;
 
       if (userInfo && Array.isArray(userInfo.user_actions)) {
-        userHref = _underscore["default"].findWhere(userInfo.user_actions, {
+        userHref = _underscore.default.findWhere(userInfo.user_actions, {
           'id': 'profile'
         }).href;
       } else {
@@ -324,7 +330,7 @@ var SubmissionView = function (_React$PureComponent) {
               currKey: 0,
               callbackHref: callbackHref
             }, function () {
-              _underscore["default"].forEach(initObjs, function (initObj) {
+              _underscore.default.forEach(initObjs, function (initObj) {
                 initObj.display = keyDisplay[initObj.path] || initObj.display;
 
                 _this2.initExistingObj(initObj);
@@ -381,7 +387,7 @@ var SubmissionView = function (_React$PureComponent) {
       }
 
       if (schema && schema.properties.aliases) {
-        this.setState(_underscore["default"].extend({
+        this.setState(_underscore.default.extend({
           'creatingAlias': autoSuggestedAlias,
           'creatingIdx': newIdx,
           'creatingType': type,
@@ -417,7 +423,7 @@ var SubmissionView = function (_React$PureComponent) {
   }, {
     key: "buildAmbiguousEnumEntry",
     value: function buildAmbiguousEnumEntry(val) {
-      return _react["default"].createElement(_DropdownButton.DropdownItem, {
+      return _react.default.createElement(_DropdownButton.DropdownItem, {
         key: val,
         title: val || '',
         eventKey: val,
@@ -525,7 +531,7 @@ var SubmissionView = function (_React$PureComponent) {
         var aliases = keyContext[currKey].aliases || null;
         var name = Array.isArray(aliases) && aliases.length > 1 && aliases[aliases.length - 2] || keyContext[currKey].name || keyContext[currKey].title || null;
 
-        var nextKeyDisplay = _underscore["default"].clone(keyDisplay);
+        var nextKeyDisplay = _underscore.default.clone(keyDisplay);
 
         if (name) {
           nextKeyDisplay[currKey] = name;
@@ -565,19 +571,19 @@ var SubmissionView = function (_React$PureComponent) {
             keyLinks = currState.keyLinks,
             prevKeyDisplay = currState.keyDisplay;
 
-        var contextCopy = _underscore["default"].clone(keyContext);
+        var contextCopy = _underscore.default.clone(keyContext);
 
-        var validCopy = _underscore["default"].clone(keyValid);
+        var validCopy = _underscore.default.clone(keyValid);
 
-        var typesCopy = _underscore["default"].clone(keyTypes);
+        var typesCopy = _underscore.default.clone(keyTypes);
 
         var parentKeyIdx = currKey;
 
-        var bookmarksCopy = _underscore["default"].clone(keyLinkBookmarks);
+        var bookmarksCopy = _underscore.default.clone(keyLinkBookmarks);
 
         var linksCopy = _util.object.deepClone(keyLinks);
 
-        var keyDisplay = _underscore["default"].clone(prevKeyDisplay);
+        var keyDisplay = _underscore.default.clone(prevKeyDisplay);
 
         var bookmarksList = [];
         var keyIdx;
@@ -585,7 +591,7 @@ var SubmissionView = function (_React$PureComponent) {
 
         if (newIdx === 0) {
           keyIdx = 0;
-          newHierarchy = _underscore["default"].clone(keyHierarchy);
+          newHierarchy = _underscore.default.clone(keyHierarchy);
         } else {
           keyIdx = keyIter + 1;
 
@@ -595,7 +601,7 @@ var SubmissionView = function (_React$PureComponent) {
             return;
           }
 
-          newHierarchy = modifyHierarchy(_underscore["default"].clone(keyHierarchy), keyIdx, parentKeyIdx);
+          newHierarchy = modifyHierarchy(_underscore.default.clone(keyHierarchy), keyIdx, parentKeyIdx);
           validCopy[keyIdx] = 1;
           validCopy[parentKeyIdx] = 0;
         }
@@ -604,7 +610,7 @@ var SubmissionView = function (_React$PureComponent) {
         var contextWithAlias = contextCopy && contextCopy[keyIdx] ? contextCopy[keyIdx] : {};
 
         if (Array.isArray(contextWithAlias.aliases)) {
-          contextWithAlias.aliases = _underscore["default"].uniq(_underscore["default"].filter(contextWithAlias.aliases.slice(0)).concat([alias]));
+          contextWithAlias.aliases = _underscore.default.uniq(_underscore.default.filter(contextWithAlias.aliases.slice(0)).concat([alias]));
         } else {
           contextWithAlias.aliases = [alias];
         }
@@ -613,7 +619,7 @@ var SubmissionView = function (_React$PureComponent) {
         bookmarksCopy[keyIdx] = bookmarksList;
         linksCopy[keyIdx] = newLink;
         keyDisplay[keyIdx] = alias;
-        return _underscore["default"].extend({
+        return _underscore.default.extend({
           'keyContext': contextCopy,
           'keyValid': validCopy,
           'keyTypes': typesCopy,
@@ -649,19 +655,19 @@ var SubmissionView = function (_React$PureComponent) {
 
         var keyCompleteCopy = _util.object.deepClone(keyComplete);
 
-        var bookmarksCopy = _underscore["default"].clone(keyLinkBookmarks);
+        var bookmarksCopy = _underscore.default.clone(keyLinkBookmarks);
 
-        var linksCopy = _underscore["default"].clone(keyLinks);
+        var linksCopy = _underscore.default.clone(keyLinks);
 
         var roundTwoCopy = roundTwoKeys.slice();
 
-        var hierarchy = _underscore["default"].clone(keyHierarchy);
+        var hierarchy = _underscore.default.clone(keyHierarchy);
 
         var dummyHierarchy = _util.object.deepClone(hierarchy);
 
         var hierKey = key;
 
-        _underscore["default"].keys(keyCompleteCopy).forEach(function (compKey) {
+        _underscore.default.keys(keyCompleteCopy).forEach(function (compKey) {
           if (keyCompleteCopy[compKey] === key) {
             hierKey = compKey;
           }
@@ -677,10 +683,10 @@ var SubmissionView = function (_React$PureComponent) {
         toDelete.push(key);
         var newHierarchy = trimHierarchy(hierarchy, hierKey);
 
-        _underscore["default"].forEach(toDelete, function (keyToDelete) {
+        _underscore.default.forEach(toDelete, function (keyToDelete) {
           if (isNaN(keyToDelete)) return;
 
-          if (_underscore["default"].contains(roundTwoCopy, keyToDelete)) {
+          if (_underscore.default.contains(roundTwoCopy, keyToDelete)) {
             var rmIdx = roundTwoCopy.indexOf(keyToDelete);
 
             if (rmIdx > -1) {
@@ -729,13 +735,13 @@ var SubmissionView = function (_React$PureComponent) {
             prevKeyLinks = _ref5.keyLinks;
         var parentKeyIdx = init ? 0 : currKey;
 
-        var keyDisplay = _underscore["default"].clone(prevKeyDisplay);
+        var keyDisplay = _underscore.default.clone(prevKeyDisplay);
 
-        var keyTypes = _underscore["default"].clone(prevKeyTypes);
+        var keyTypes = _underscore.default.clone(prevKeyTypes);
 
-        var keyLinks = _underscore["default"].clone(prevKeyLinks);
+        var keyLinks = _underscore.default.clone(prevKeyLinks);
 
-        var keyHierarchy = modifyHierarchy(_underscore["default"].clone(prevKeyHierarchy), path, parentKeyIdx);
+        var keyHierarchy = modifyHierarchy(_underscore.default.clone(prevKeyHierarchy), path, parentKeyIdx);
         keyDisplay[path] = display;
         keyTypes[path] = type;
         keyLinks[path] = field;
@@ -786,7 +792,7 @@ var SubmissionView = function (_React$PureComponent) {
               var validState = SubmissionView.findValidationState(value, keyHierarchy, keyContext, keyComplete);
 
               if (validState === 1) {
-                var nextKeyValid = _underscore["default"].clone(keyValid);
+                var nextKeyValid = _underscore.default.clone(keyValid);
 
                 nextKeyValid[value] = 1;
                 stateToSet['keyValid'] = nextKeyValid;
@@ -859,7 +865,7 @@ var SubmissionView = function (_React$PureComponent) {
               _this4.setState(stateToSet);
             }
           });
-        })["catch"](function () {
+        }).catch(function () {
           stateToSet.uploadStatus = 'MD5 calculation error';
           stateToSet.file = null;
           stateToSet.md5Progress = null;
@@ -889,7 +895,7 @@ var SubmissionView = function (_React$PureComponent) {
   }, {
     key: "checkRoundTwo",
     value: function checkRoundTwo(schema) {
-      var fields = schema.properties ? _underscore["default"].keys(schema.properties) : [];
+      var fields = schema.properties ? _underscore.default.keys(schema.properties) : [];
 
       for (var i = 0; i < fields.length; i++) {
         if (schema.properties[fields[i]]) {
@@ -920,7 +926,7 @@ var SubmissionView = function (_React$PureComponent) {
 
       var userGroups = _util.JWT.getUserGroups();
 
-      _underscore["default"].keys(origCopy).forEach(function (field) {
+      _underscore.default.keys(origCopy).forEach(function (field) {
         if (!(0, _submissionFields.isValueNull)(patchContext[field])) {
           return;
         }
@@ -936,12 +942,12 @@ var SubmissionView = function (_React$PureComponent) {
             return;
           }
 
-          if (fieldSchema.exclude_from && (_underscore["default"].contains(fieldSchema.exclude_from, 'FFedit-create') || fieldSchema.exclude_from == 'FFedit-create')) {
+          if (fieldSchema.exclude_from && (_underscore.default.contains(fieldSchema.exclude_from, 'FFedit-create') || fieldSchema.exclude_from == 'FFedit-create')) {
             return;
           }
 
           if (fieldSchema.permission && fieldSchema.permission == "import_items") {
-            if (_underscore["default"].contains(userGroups, 'admin')) deleteFields.push(field);
+            if (_underscore.default.contains(userGroups, 'admin')) deleteFields.push(field);
             return;
           }
 
@@ -994,7 +1000,7 @@ var SubmissionView = function (_React$PureComponent) {
       var currType = keyTypes[inKey];
       var currSchema = schemas[currType];
       stateToSet.processingFetch = false;
-      stateToSet.keyValid = _underscore["default"].clone(keyValid);
+      stateToSet.keyValid = _underscore.default.clone(keyValid);
       var finalizedContext = this.removeNullsFromContext(inKey);
       var i;
 
@@ -1031,7 +1037,7 @@ var SubmissionView = function (_React$PureComponent) {
             finalizedContext.lab = _util.object.itemUtil.atId(context.lab);
           }
 
-          if (currentSubmittingUser.groups && _underscore["default"].contains(currentSubmittingUser.groups, 'admin')) {
+          if (currentSubmittingUser.groups && _underscore.default.contains(currentSubmittingUser.groups, 'admin')) {
             if (context.submitted_by) {
               finalizedContext.submitted_by = _util.object.itemUtil.atId(context.submitted_by);
             } else {
@@ -1156,15 +1162,15 @@ var SubmissionView = function (_React$PureComponent) {
               var parentKey = parseInt(findParentFromHierarchy(keyHierarchy, inKey));
               stateToSet.currKey = parentKey !== null && !isNaN(parentKey) ? parentKey : 0;
 
-              var typesCopy = _underscore["default"].clone(keyTypes);
+              var typesCopy = _underscore.default.clone(keyTypes);
 
-              var keyCompleteCopy = _underscore["default"].clone(keyComplete);
+              var keyCompleteCopy = _underscore.default.clone(keyComplete);
 
-              var linksCopy = _underscore["default"].clone(keyLinks);
+              var linksCopy = _underscore.default.clone(keyLinks);
 
-              var displayCopy = _underscore["default"].clone(keyDisplay);
+              var displayCopy = _underscore.default.clone(keyDisplay);
 
-              var contextCopy = _underscore["default"].clone(keyContext);
+              var contextCopy = _underscore.default.clone(keyContext);
 
               var roundTwoCopy = roundTwoKeys.slice();
               keyCompleteCopy[inKey] = submitted_at_id;
@@ -1181,7 +1187,7 @@ var SubmissionView = function (_React$PureComponent) {
 
               var needsRoundTwo = _this6.checkRoundTwo(currSchema);
 
-              if (needsRoundTwo && !_underscore["default"].contains(roundTwoCopy, inKey)) {
+              if (needsRoundTwo && !_underscore.default.contains(roundTwoCopy, inKey)) {
                 roundTwoCopy.push(parseInt(inKey));
                 stateToSet.roundTwoKeys = roundTwoCopy;
               }
@@ -1210,7 +1216,7 @@ var SubmissionView = function (_React$PureComponent) {
               }
             }
 
-            _reactTooltip["default"].rebuild();
+            _reactTooltip.default.rebuild();
           }
         });
       };
@@ -1235,12 +1241,12 @@ var SubmissionView = function (_React$PureComponent) {
             _ref6$roundTwoKeys = _ref6.roundTwoKeys,
             roundTwoKeys = _ref6$roundTwoKeys === void 0 ? [] : _ref6$roundTwoKeys;
 
-        var validationCopy = _underscore["default"].clone(keyValid);
+        var validationCopy = _underscore.default.clone(keyValid);
 
         var roundTwoCopy = roundTwoKeys.slice();
         validationCopy[currKey] = 4;
 
-        if (_underscore["default"].contains(roundTwoCopy, currKey)) {
+        if (_underscore.default.contains(roundTwoCopy, currKey)) {
           var rmIdx = roundTwoCopy.indexOf(currKey);
 
           if (rmIdx > -1) {
@@ -1281,11 +1287,11 @@ var SubmissionView = function (_React$PureComponent) {
             creatingLinkForField = _ref7.creatingLinkForField;
         if (!creatingIdx) return null;
 
-        var nextKeyContext = _underscore["default"].clone(keyContext);
+        var nextKeyContext = _underscore.default.clone(keyContext);
 
         var currentContextPointer = nextKeyContext[currKey];
 
-        _underscore["default"].pairs(currentContextPointer).forEach(function (_ref8) {
+        _underscore.default.pairs(currentContextPointer).forEach(function (_ref8) {
           var _ref9 = _slicedToArray(_ref8, 2),
               field = _ref9[0],
               idx = _ref9[1];
@@ -1335,15 +1341,15 @@ var SubmissionView = function (_React$PureComponent) {
         if (callbackHref) {
           nextURI = callbackHref;
         } else {
-          var parts = _url["default"].parse(href, true);
+          var parts = _url.default.parse(href, true);
 
-          var modifiedQuery = _underscore["default"].omit(parts.query, 'currentAction');
+          var modifiedQuery = _underscore.default.omit(parts.query, 'currentAction');
 
-          var modifiedSearch = _queryString["default"].stringify(modifiedQuery);
+          var modifiedSearch = _queryString.default.stringify(modifiedQuery);
 
           parts.query = modifiedQuery;
           parts.search = (modifiedSearch.length > 0 ? '?' : '') + modifiedSearch;
-          nextURI = _url["default"].format(parts);
+          nextURI = _url.default.format(parts);
           navOpts.skipRequest = true;
         }
 
@@ -1390,46 +1396,46 @@ var SubmissionView = function (_React$PureComponent) {
           propsToPass = _objectWithoutProperties(_this$props5, ["context", "navigate"]);
 
       keyDisplay[currKey] || currType;
-      return _react["default"].createElement("div", {
+      return _react.default.createElement("div", {
         className: "submission-view-page-container container",
         id: "content"
-      }, _react["default"].createElement(TypeSelectModal, _extends({
+      }, _react.default.createElement(TypeSelectModal, _extends({
         show: showAmbiguousModal
-      }, _underscore["default"].pick(this.state, 'ambiguousIdx', 'ambiguousType', 'ambiguousSelected', 'currKey', 'creatingIdx'), _underscore["default"].pick(this, 'buildAmbiguousEnumEntry', 'submitAmbiguousType', 'cancelCreateNewObject', 'cancelCreatePrimaryObject'), {
+      }, _underscore.default.pick(this.state, 'ambiguousIdx', 'ambiguousType', 'ambiguousSelected', 'currKey', 'creatingIdx'), _underscore.default.pick(this, 'buildAmbiguousEnumEntry', 'submitAmbiguousType', 'cancelCreateNewObject', 'cancelCreatePrimaryObject'), {
         schemas: schemas
-      })), _react["default"].createElement(AliasSelectModal, _extends({
+      })), _react.default.createElement(AliasSelectModal, _extends({
         show: !showAmbiguousModal && creatingIdx !== null && creatingType !== null
-      }, _underscore["default"].pick(this.state, 'creatingAlias', 'creatingType', 'creatingAliasMessage', 'currKey', 'creatingIdx', 'currentSubmittingUser'), {
+      }, _underscore.default.pick(this.state, 'creatingAlias', 'creatingType', 'creatingAliasMessage', 'currKey', 'creatingIdx', 'currentSubmittingUser'), {
         handleAliasChange: this.handleAliasChange,
         submitAlias: this.submitAlias,
         cancelCreateNewObject: this.cancelCreateNewObject,
         cancelCreatePrimaryObject: this.cancelCreatePrimaryObject
-      })), _react["default"].createElement(WarningBanner, {
+      })), _react.default.createElement(WarningBanner, {
         cancelCreatePrimaryObject: this.cancelCreatePrimaryObject
-      }, _react["default"].createElement("button", {
+      }, _react.default.createElement("button", {
         type: "button",
         className: "btn btn-danger",
         onClick: this.cancelCreatePrimaryObject
-      }, "Cancel / Exit"), _react["default"].createElement(ValidationButton, _extends({}, _underscore["default"].pick(this.state, 'currKey', 'keyValid', 'md5Progress', 'upload', 'roundTwo', 'processingFetch'), {
+      }, "Cancel / Exit"), _react.default.createElement(ValidationButton, _extends({}, _underscore.default.pick(this.state, 'currKey', 'keyValid', 'md5Progress', 'upload', 'roundTwo', 'processingFetch'), {
         testPostNewContext: this.testPostNewContext,
         finishRoundTwo: this.finishRoundTwo
-      })), _react["default"].createElement(SubmitButton, _extends({}, _underscore["default"].pick(this.state, 'keyValid', 'currKey', 'roundTwo', 'upload', 'processingFetch', 'md5Progress'), {
+      })), _react.default.createElement(SubmitButton, _extends({}, _underscore.default.pick(this.state, 'keyValid', 'currKey', 'roundTwo', 'upload', 'processingFetch', 'md5Progress'), {
         realPostNewContext: this.realPostNewContext
-      }))), _react["default"].createElement(DetailTitleBanner, _extends({
+      }))), _react.default.createElement(DetailTitleBanner, _extends({
         hierarchy: keyHierarchy,
         setSubmissionState: this.setSubmissionState,
         schemas: schemas
-      }, _underscore["default"].pick(this.state, 'keyContext', 'keyTypes', 'keyDisplay', 'currKey', 'fullScreen'))), _react["default"].createElement("div", {
+      }, _underscore.default.pick(this.state, 'keyContext', 'keyTypes', 'keyDisplay', 'currKey', 'fullScreen'))), _react.default.createElement("div", {
         className: "clearfix row"
-      }, _react["default"].createElement("div", {
+      }, _react.default.createElement("div", {
         className: navCol
-      }, _react["default"].createElement(_SubmissionTree.SubmissionTree, _extends({
+      }, _react.default.createElement(_SubmissionTree.SubmissionTree, _extends({
         setSubmissionState: this.setSubmissionState,
         hierarchy: keyHierarchy,
         schemas: schemas
-      }, _underscore["default"].pick(this.state, 'keyValid', 'keyTypes', 'keyDisplay', 'keyComplete', 'currKey', 'keyLinkBookmarks', 'keyLinks', 'keyHierarchy')))), _react["default"].createElement("div", {
+      }, _underscore.default.pick(this.state, 'keyValid', 'keyTypes', 'keyDisplay', 'keyComplete', 'currKey', 'keyLinkBookmarks', 'keyLinks', 'keyHierarchy')))), _react.default.createElement("div", {
         className: bodyCol
-      }, _react["default"].createElement(IndividualObjectView, _extends({}, propsToPass, {
+      }, _react.default.createElement(IndividualObjectView, _extends({}, propsToPass, {
         schemas: schemas,
         currType: currType,
         currContext: currContext,
@@ -1441,16 +1447,16 @@ var SubmissionView = function (_React$PureComponent) {
         modifyAlias: this.modifyAlias,
         updateUpload: this.updateUpload,
         hierarchy: keyHierarchy
-      }, _underscore["default"].pick(this.state, 'keyDisplay', 'keyComplete', 'keyIter', 'currKey', 'keyContext', 'upload', 'uploadStatus', 'md5Progress', 'roundTwo', 'currentSubmittingUser'))))));
+      }, _underscore.default.pick(this.state, 'keyDisplay', 'keyComplete', 'keyIter', 'currKey', 'keyContext', 'upload', 'uploadStatus', 'md5Progress', 'roundTwo', 'currentSubmittingUser'))))));
     }
   }]);
 
   return SubmissionView;
-}(_react["default"].PureComponent);
+}(_react.default.PureComponent);
 
-exports["default"] = SubmissionView;
+exports.default = SubmissionView;
 
-var ValidationButton = _react["default"].memo(function (props) {
+var ValidationButton = _react.default.memo(function (props) {
   var currKey = props.currKey,
       keyValid = props.keyValid,
       md5Progress = props.md5Progress,
@@ -1463,35 +1469,35 @@ var ValidationButton = _react["default"].memo(function (props) {
 
   if (roundTwo) {
     if (upload === null && md5Progress === null) {
-      return _react["default"].createElement("button", {
+      return _react.default.createElement("button", {
         type: "button",
         className: "btn btn-warning",
         onClick: finishRoundTwo
       }, "Skip");
     } else {
-      return _react["default"].createElement("button", {
+      return _react.default.createElement("button", {
         type: "button",
         className: "btn btn-warning",
         disabled: true
       }, "Skip");
     }
   } else if (validity === 3 || validity === 4) {
-    return _react["default"].createElement("button", {
+    return _react.default.createElement("button", {
       type: "button",
       className: "btn btn-info",
       disabled: true
     }, "Validated");
   } else if (validity === 2) {
     if (processingFetch) {
-      return _react["default"].createElement("button", {
+      return _react.default.createElement("button", {
         type: "button",
         className: "btn btn-danger",
         disabled: true
-      }, _react["default"].createElement("i", {
+      }, _react.default.createElement("i", {
         className: "icon icon-spin icon-circle-notch fas"
       }));
     } else {
-      return _react["default"].createElement("button", {
+      return _react.default.createElement("button", {
         type: "button",
         className: "btn btn-danger",
         onClick: testPostNewContext
@@ -1499,22 +1505,22 @@ var ValidationButton = _react["default"].memo(function (props) {
     }
   } else if (validity === 1) {
     if (processingFetch) {
-      return _react["default"].createElement("button", {
+      return _react.default.createElement("button", {
         type: "button",
         className: "btn btn-info",
         disabled: true
-      }, _react["default"].createElement("i", {
+      }, _react.default.createElement("i", {
         className: "icon icon-spin icon-circle-notch fas"
       }));
     } else {
-      return _react["default"].createElement("button", {
+      return _react.default.createElement("button", {
         type: "button",
         className: "btn btn-info",
         onClick: testPostNewContext
       }, "Validate");
     }
   } else {
-    return _react["default"].createElement("button", {
+    return _react.default.createElement("button", {
       type: "button",
       className: "btn btn-info",
       disabled: true
@@ -1522,7 +1528,7 @@ var ValidationButton = _react["default"].memo(function (props) {
   }
 });
 
-var SubmitButton = _react["default"].memo(function (props) {
+var SubmitButton = _react.default.memo(function (props) {
   var keyValid = props.keyValid,
       currKey = props.currKey,
       roundTwo = props.roundTwo,
@@ -1534,15 +1540,15 @@ var SubmitButton = _react["default"].memo(function (props) {
 
   if (roundTwo) {
     if (upload !== null || processingFetch || md5Progress !== null) {
-      return _react["default"].createElement("button", {
+      return _react.default.createElement("button", {
         type: "button",
         disabled: true,
         className: "btn btn-success"
-      }, _react["default"].createElement("i", {
+      }, _react.default.createElement("i", {
         className: "icon icon-spin icon-circle-notch fas"
       }));
     } else {
-      return _react["default"].createElement("button", {
+      return _react.default.createElement("button", {
         type: "button",
         className: "btn btn-success",
         onClick: realPostNewContext
@@ -1550,28 +1556,28 @@ var SubmitButton = _react["default"].memo(function (props) {
     }
   } else if (validity == 3) {
     if (processingFetch) {
-      return _react["default"].createElement("button", {
+      return _react.default.createElement("button", {
         type: "button",
         disabled: true,
         className: "btn btn-success"
-      }, _react["default"].createElement("i", {
+      }, _react.default.createElement("i", {
         className: "icon icon-spin icon-circle-notch fas"
       }));
     } else {
-      return _react["default"].createElement("button", {
+      return _react.default.createElement("button", {
         type: "button",
         className: "btn btn-success",
         onClick: realPostNewContext
       }, "Submit");
     }
   } else if (validity == 4) {
-    return _react["default"].createElement("button", {
+    return _react.default.createElement("button", {
       type: "button",
       className: "btn btn-success",
       disabled: true
     }, "Submitted");
   } else {
-    return _react["default"].createElement("button", {
+    return _react.default.createElement("button", {
       type: "button",
       className: "btn btn-success",
       disabled: true
@@ -1579,17 +1585,17 @@ var SubmitButton = _react["default"].memo(function (props) {
   }
 });
 
-var WarningBanner = _react["default"].memo(function (props) {
+var WarningBanner = _react.default.memo(function (props) {
   var children = props.children;
-  return _react["default"].createElement("div", {
+  return _react.default.createElement("div", {
     className: "mb-2 mt-1 text-400 warning-banner"
-  }, _react["default"].createElement("div", {
+  }, _react.default.createElement("div", {
     className: "row"
-  }, _react["default"].createElement("div", {
+  }, _react.default.createElement("div", {
     className: "col"
-  }, "Please note: your work will be lost if you navigate away from, refresh or close this page while submitting. The submission process is under active development and features may change."), _react["default"].createElement("div", {
+  }, "Please note: your work will be lost if you navigate away from, refresh or close this page while submitting. The submission process is under active development and features may change."), _react.default.createElement("div", {
     className: "col-md-auto"
-  }, _react["default"].createElement("div", {
+  }, _react.default.createElement("div", {
     className: "action-buttons-container text-right"
   }, children))));
 });
@@ -1604,7 +1610,7 @@ var DetailTitleBanner = function (_React$PureComponent2) {
         if (typeof obj[currKey] !== 'undefined') {
           return [currKey];
         } else {
-          var nestedFound = _underscore["default"].find(_underscore["default"].map(_underscore["default"].pairs(obj), function (p) {
+          var nestedFound = _underscore.default.find(_underscore.default.map(_underscore.default.pairs(obj), function (p) {
             return [p[0], findNestedKey(p[1])];
           }), function (p) {
             return typeof p[1] !== 'undefined' && p[1] !== null;
@@ -1625,7 +1631,7 @@ var DetailTitleBanner = function (_React$PureComponent2) {
       var foundPropertyName = null;
       var arrayIdx = null;
 
-      _underscore["default"].pairs(context).forEach(function (p) {
+      _underscore.default.pairs(context).forEach(function (p) {
         if (foundPropertyName) return;
 
         if (p[1] === nextKey) {
@@ -1658,7 +1664,7 @@ var DetailTitleBanner = function (_React$PureComponent2) {
 
     _this8 = _possibleConstructorReturn(this, _getPrototypeOf(DetailTitleBanner).call(this, props));
     _this8.generateCrumbTitle = _this8.generateCrumbTitle.bind(_assertThisInitialized(_this8));
-    _this8.toggleOpen = _underscore["default"].throttle(_this8.toggleOpen.bind(_assertThisInitialized(_this8)), 500);
+    _this8.toggleOpen = _underscore.default.throttle(_this8.toggleOpen.bind(_assertThisInitialized(_this8)), 500);
     _this8.generateHierarchicalTitles = _this8.generateHierarchicalTitles.bind(_assertThisInitialized(_this8));
     _this8.state = {
       'open': true
@@ -1701,7 +1707,7 @@ var DetailTitleBanner = function (_React$PureComponent2) {
         hierarchyKeyList = [numKey];
       }
 
-      var icon = i === 0 ? null : _react["default"].createElement("i", {
+      var icon = i === 0 ? null : _react.default.createElement("i", {
         className: "icon icon-fw"
       }, "\u21B5");
       var isLast = i + 1 === hierarchyKeyList.length;
@@ -1724,21 +1730,21 @@ var DetailTitleBanner = function (_React$PureComponent2) {
         }
       }
 
-      return _react["default"].createElement(_Collapse.Collapse, {
-        "in": true,
+      return _react.default.createElement(_Collapse.Collapse, {
+        in: true,
         appear: hierarchyKeyList.length !== 1,
         key: i
-      }, _react["default"].createElement("div", {
+      }, _react.default.createElement("div", {
         className: "title-crumb depth-level-" + i + (isLast ? ' last-title' : ' mid-title')
-      }, _react["default"].createElement("div", {
+      }, _react.default.createElement("div", {
         className: "submission-working-title"
-      }, _react["default"].createElement("span", {
+      }, _react.default.createElement("span", {
         onClick: this.handleClick.bind(this, numKey)
-      }, icon, parentPropertyName ? _react["default"].createElement("span", {
+      }, icon, parentPropertyName ? _react.default.createElement("span", {
         className: "next-property-name"
-      }, parentPropertyName, ": ") : null, _react["default"].createElement("span", {
+      }, parentPropertyName, ": ") : null, _react.default.createElement("span", {
         className: "working-subtitle"
-      }, _util.schemaTransforms.getTitleForType(keyTypes[numKey], schemas)), " ", _react["default"].createElement("span", null, keyDisplay[numKey])))));
+      }, _util.schemaTransforms.getTitleForType(keyTypes[numKey], schemas)), " ", _react.default.createElement("span", null, keyDisplay[numKey])))));
     }
   }, {
     key: "generateHierarchicalTitles",
@@ -1746,7 +1752,7 @@ var DetailTitleBanner = function (_React$PureComponent2) {
       var _this$props7 = this.props,
           hierarchy = _this$props7.hierarchy,
           currKey = _this$props7.currKey;
-      return _underscore["default"].map(DetailTitleBanner.getListOfKeysInPath(hierarchy, currKey), this.generateCrumbTitle);
+      return _underscore.default.map(DetailTitleBanner.getListOfKeysInPath(hierarchy, currKey), this.generateCrumbTitle);
     }
   }, {
     key: "render",
@@ -1756,21 +1762,21 @@ var DetailTitleBanner = function (_React$PureComponent2) {
           currKey = _this$props8.currKey;
       var open = this.state.open;
       if (fullScreen) return null;
-      return _react["default"].createElement("h3", {
+      return _react.default.createElement("h3", {
         className: "crumbs-title mb-2"
-      }, _react["default"].createElement("div", {
+      }, _react.default.createElement("div", {
         className: "subtitle-heading form-section-heading mb-08"
-      }, _react["default"].createElement("span", {
+      }, _react.default.createElement("span", {
         className: "inline-block clickable",
         onClick: this.toggleOpen
-      }, "Currently Editing ", currKey > 0 ? _react["default"].createElement("i", {
+      }, "Currently Editing ", currKey > 0 ? _react.default.createElement("i", {
         className: "icon icon-fw fas icon-caret-" + (open ? 'down' : 'right')
       }) : null)), open ? this.generateHierarchicalTitles() : this.generateCrumbTitle(currKey));
     }
   }]);
 
   return DetailTitleBanner;
-}(_react["default"].PureComponent);
+}(_react.default.PureComponent);
 
 var TypeSelectModal = function (_React$Component) {
   _inherits(TypeSelectModal, _React$Component);
@@ -1830,24 +1836,24 @@ var TypeSelectModal = function (_React$Component) {
         ambiguousDescrip = schemas[ambiguousSelected].description;
       }
 
-      return _react["default"].createElement(_reactBootstrap.Modal, {
+      return _react.default.createElement(_reactBootstrap.Modal, {
         show: true,
         onHide: this.onHide,
         className: "submission-view-modal"
-      }, _react["default"].createElement(_reactBootstrap.Modal.Header, null, _react["default"].createElement(_reactBootstrap.Modal.Title, null, 'Multiple object types found for your new ' + ambiguousType)), _react["default"].createElement(_reactBootstrap.Modal.Body, null, _react["default"].createElement("div", {
+      }, _react.default.createElement(_reactBootstrap.Modal.Header, null, _react.default.createElement(_reactBootstrap.Modal.Title, null, 'Multiple object types found for your new ' + ambiguousType)), _react.default.createElement(_reactBootstrap.Modal.Body, null, _react.default.createElement("div", {
         onKeyDown: this.onContainerKeyDown.bind(this, submitAmbiguousType)
-      }, _react["default"].createElement("p", null, "Please select a specific object type from the menu below."), _react["default"].createElement("div", {
+      }, _react.default.createElement("p", null, "Please select a specific object type from the menu below."), _react.default.createElement("div", {
         className: "input-wrapper mb-15"
-      }, _react["default"].createElement(_DropdownButton.DropdownButton, {
+      }, _react.default.createElement(_DropdownButton.DropdownButton, {
         id: "dropdown-type-select",
         title: ambiguousSelected || "No value"
-      }, ambiguousType !== null ? _underscore["default"].map(_underscore["default"].keys(itemTypeHierarchy[ambiguousType]), function (val) {
+      }, ambiguousType !== null ? _underscore.default.map(_underscore.default.keys(itemTypeHierarchy[ambiguousType]), function (val) {
         return buildAmbiguousEnumEntry(val);
-      }) : null)), ambiguousDescrip ? _react["default"].createElement("div", {
+      }) : null)), ambiguousDescrip ? _react.default.createElement("div", {
         className: "mb-15 mt-15"
-      }, _react["default"].createElement("h5", {
+      }, _react.default.createElement("h5", {
         className: "text-500 mb-02"
-      }, "Description"), ambiguousDescrip) : null, _react["default"].createElement("button", {
+      }, "Description"), ambiguousDescrip) : null, _react.default.createElement("button", {
         type: "button",
         className: "btn btn-primary",
         disabled: ambiguousSelected === null,
@@ -1857,7 +1863,7 @@ var TypeSelectModal = function (_React$Component) {
   }]);
 
   return TypeSelectModal;
-}(_react["default"].Component);
+}(_react.default.Component);
 
 var AliasSelectModal = function (_TypeSelectModal) {
   _inherits(AliasSelectModal, _TypeSelectModal);
@@ -1881,33 +1887,33 @@ var AliasSelectModal = function (_TypeSelectModal) {
           currentSubmittingUser = _this$props11.currentSubmittingUser;
       if (!show) return null;
       var disabledBtn = creatingAlias.indexOf(':') < 0 || creatingAlias.indexOf(':') + 1 === creatingAlias.length;
-      return _react["default"].createElement(_reactBootstrap.Modal, {
+      return _react.default.createElement(_reactBootstrap.Modal, {
         show: true,
         onHide: this.onHide,
         className: "submission-view-modal"
-      }, _react["default"].createElement(_reactBootstrap.Modal.Header, null, _react["default"].createElement(_reactBootstrap.Modal.Title, null, "Give your new ", creatingType, " an alias")), _react["default"].createElement(_reactBootstrap.Modal.Body, null, _react["default"].createElement("div", {
+      }, _react.default.createElement(_reactBootstrap.Modal.Header, null, _react.default.createElement(_reactBootstrap.Modal.Title, null, "Give your new ", creatingType, " an alias")), _react.default.createElement(_reactBootstrap.Modal.Body, null, _react.default.createElement("div", {
         onKeyDown: this.onContainerKeyDown.bind(this, submitAlias)
-      }, _react["default"].createElement("p", {
+      }, _react.default.createElement("p", {
         className: "mt-0 mb-1"
-      }, "Aliases are lab specific identifiers to reference an object. The format is ", _react["default"].createElement("code", null, '<lab-name>:<identifier>'), " - a lab name and an identifier separated by a colon, e.g. ", _react["default"].createElement("code", null, "dcic-lab:42"), "."), _react["default"].createElement("p", {
+      }, "Aliases are lab specific identifiers to reference an object. The format is ", _react.default.createElement("code", null, '<lab-name>:<identifier>'), " - a lab name and an identifier separated by a colon, e.g. ", _react.default.createElement("code", null, "dcic-lab:42"), "."), _react.default.createElement("p", {
         className: "mt-0 mb-1"
-      }, "Please create your own alias to help you to refer to this Item later."), _react["default"].createElement("div", {
+      }, "Please create your own alias to help you to refer to this Item later."), _react.default.createElement("div", {
         className: "input-wrapper mt-2 mb-2"
-      }, _react["default"].createElement(_submissionFields.AliasInputField, {
+      }, _react.default.createElement(_submissionFields.AliasInputField, {
         value: creatingAlias,
         errorMessage: creatingAliasMessage,
         onAliasChange: handleAliasChange,
         currentSubmittingUser: currentSubmittingUser,
         withinModal: true
-      })), creatingAliasMessage ? _react["default"].createElement("div", {
+      })), creatingAliasMessage ? _react.default.createElement("div", {
         style: {
           'marginBottom': '15px',
           'color': '#7e4544',
           'fontSize': '1.2em'
         }
-      }, creatingAliasMessage) : null, _react["default"].createElement("div", {
+      }, creatingAliasMessage) : null, _react.default.createElement("div", {
         className: "text-right"
-      }, _react["default"].createElement("button", {
+      }, _react.default.createElement("button", {
         type: "button",
         className: "btn btn-primary",
         disabled: disabledBtn,
@@ -1929,7 +1935,7 @@ var IndividualObjectView = function (_React$Component2) {
 
     _this10 = _possibleConstructorReturn(this, _getPrototypeOf(IndividualObjectView).call(this, props));
 
-    _underscore["default"].bindAll(_assertThisInitialized(_this10), 'modifyNewContext', 'fetchAndValidateItem', 'checkObjectRemoval', 'selectObj', 'selectComplete', 'selectCancel', 'initiateField');
+    _underscore.default.bindAll(_assertThisInitialized(_this10), 'modifyNewContext', 'fetchAndValidateItem', 'checkObjectRemoval', 'selectObj', 'selectComplete', 'selectCancel', 'initiateField');
 
     _this10.state = {
       'selectType': null,
@@ -2086,21 +2092,49 @@ var IndividualObjectView = function (_React$Component2) {
     }
   }, {
     key: "selectComplete",
-    value: function selectComplete(value) {
+    value: function selectComplete(atIds) {
       var currContext = this.props.currContext;
       var _this$state7 = this.state,
           selectField = _this$state7.selectField,
           selectArrayIdx = _this$state7.selectArrayIdx,
           selectType = _this$state7.selectType;
       if (!selectField) throw new Error('No field being selected for');
-      var current = selectField && currContext[selectField];
+      var isMultiSelect = selectArrayIdx && Array.isArray(selectArrayIdx);
+      var cloneSelectArrayIdx = isMultiSelect ? _toConsumableArray(selectArrayIdx) : null;
+      var _iteratorNormalCompletion = true;
+      var _didIteratorError = false;
+      var _iteratorError = undefined;
 
-      var isRepeat = Array.isArray(current) && _underscore["default"].contains(current, value);
+      try {
+        for (var _iterator = atIds[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+          var atId = _step.value;
+          var current = selectField && currContext[selectField];
 
-      if (!isRepeat) {
-        this.fetchAndValidateItem(value, selectField, selectType, selectArrayIdx, null);
-      } else {
-        this.modifyNewContext(selectField, null, 'existing linked object', null, selectArrayIdx);
+          var isRepeat = Array.isArray(current) && _underscore.default.contains(current, atId);
+
+          if (!isRepeat) {
+            this.fetchAndValidateItem(atId, selectField, selectType, isMultiSelect ? _toConsumableArray(cloneSelectArrayIdx) : null, null);
+
+            if (isMultiSelect) {
+              cloneSelectArrayIdx[cloneSelectArrayIdx.length - 1]++;
+            }
+          } else {
+            this.modifyNewContext(selectField, null, 'existing linked object', null, cloneSelectArrayIdx);
+          }
+        }
+      } catch (err) {
+        _didIteratorError = true;
+        _iteratorError = err;
+      } finally {
+        try {
+          if (!_iteratorNormalCompletion && _iterator.return != null) {
+            _iterator.return();
+          }
+        } finally {
+          if (_didIteratorError) {
+            throw _iteratorError;
+          }
+        }
       }
 
       this.setState({
@@ -2145,7 +2179,7 @@ var IndividualObjectView = function (_React$Component2) {
       if (roundTwo && !secondRoundField) {
         return null;
       } else if (!roundTwo && secondRoundField) {
-        return _react["default"].createElement("div", {
+        return _react.default.createElement("div", {
           key: fieldTitle,
           className: "row field-row",
           required: false,
@@ -2153,15 +2187,15 @@ var IndividualObjectView = function (_React$Component2) {
           style: {
             'overflow': 'visible'
           }
-        }, _react["default"].createElement("div", {
+        }, _react.default.createElement("div", {
           className: "col-12 col-md-4"
-        }, _react["default"].createElement("h5", {
+        }, _react.default.createElement("h5", {
           className: "facet-title submission-field-title"
-        }, fieldTitle)), _react["default"].createElement("div", {
+        }, fieldTitle)), _react.default.createElement("div", {
           className: "col-12 col-md-8"
-        }, _react["default"].createElement("div", {
+        }, _react.default.createElement("div", {
           className: "field-container"
-        }, _react["default"].createElement("div", {
+        }, _react.default.createElement("div", {
           className: "notice-message"
         }, "This field is available after finishing initial submission."))));
       }
@@ -2179,7 +2213,7 @@ var IndividualObjectView = function (_React$Component2) {
           linked = (0, _SubmissionTree.fieldSchemaLinkToType)(fieldSchema);
 
       if (fieldType === 'enum') {
-        enumValues = fieldSchema["enum"] || fieldSchema.suggested_enum;
+        enumValues = fieldSchema.enum || fieldSchema.suggested_enum;
       }
 
       if (linked !== null) {
@@ -2203,7 +2237,7 @@ var IndividualObjectView = function (_React$Component2) {
         }
       }
 
-      return _react["default"].createElement(_submissionFields.BuildField, _extends({
+      return _react.default.createElement(_submissionFields.BuildField, _extends({
         field: field,
         fieldType: fieldType,
         fieldTip: fieldTip,
@@ -2211,7 +2245,7 @@ var IndividualObjectView = function (_React$Component2) {
         isLinked: isLinked,
         currType: currType,
         currContext: currContext
-      }, _underscore["default"].pick(this.props, 'md5Progress', 'edit', 'create', 'keyDisplay', 'keyComplete', 'setSubmissionState', 'upload', 'uploadStatus', 'updateUpload', 'currentSubmittingUser', 'roundTwo'), {
+      }, _underscore.default.pick(this.props, 'md5Progress', 'edit', 'create', 'keyDisplay', 'keyComplete', 'setSubmissionState', 'upload', 'uploadStatus', 'updateUpload', 'currentSubmittingUser', 'roundTwo'), {
         value: fieldValue,
         key: field,
         schema: fieldSchema,
@@ -2221,7 +2255,7 @@ var IndividualObjectView = function (_React$Component2) {
         linkType: linked,
         disabled: false,
         arrayIdx: null,
-        required: _underscore["default"].contains(currSchema.required, field),
+        required: _underscore.default.contains(currSchema.required, field),
         modifyNewContext: this.modifyNewContext,
         selectObj: this.selectObj,
         selectComplete: this.selectComplete,
@@ -2240,14 +2274,14 @@ var IndividualObjectView = function (_React$Component2) {
           currKey = _this$props13.currKey,
           schemas = _this$props13.schemas,
           roundTwo = _this$props13.roundTwo;
-      var fields = currContext ? _underscore["default"].keys(currContext) : [];
-      var fieldJSXComponents = sortPropFields(_underscore["default"].filter(_underscore["default"].map(fields, this.initiateField), function (f) {
+      var fields = currContext ? _underscore.default.keys(currContext) : [];
+      var fieldJSXComponents = sortPropFields(_underscore.default.filter(_underscore.default.map(fields, this.initiateField), function (f) {
         return !!f;
       }));
       var roundTwoDetailContext = roundTwo && keyComplete[currKey] && keyContext[keyComplete[currKey]];
-      return _react["default"].createElement("div", null, _react["default"].createElement(FormFieldsContainer, {
+      return _react.default.createElement("div", null, _react.default.createElement(FormFieldsContainer, {
         currKey: currKey
-      }, fieldJSXComponents), roundTwo ? _react["default"].createElement(RoundTwoDetailPanel, {
+      }, fieldJSXComponents), roundTwo ? _react.default.createElement(RoundTwoDetailPanel, {
         schemas: schemas,
         context: roundTwoDetailContext,
         open: true
@@ -2256,17 +2290,17 @@ var IndividualObjectView = function (_React$Component2) {
   }]);
 
   return IndividualObjectView;
-}(_react["default"].Component);
+}(_react.default.Component);
 
-var FormFieldsContainer = _react["default"].memo(function (props) {
+var FormFieldsContainer = _react.default.memo(function (props) {
   var children = props.children,
       title = props.title;
-  if (_react["default"].Children.count(children) === 0) return null;
-  return _react["default"].createElement("div", {
+  if (_react.default.Children.count(children) === 0) return null;
+  return _react.default.createElement("div", {
     className: "form-fields-container"
-  }, _react["default"].createElement("h4", {
+  }, _react.default.createElement("h4", {
     className: "clearfix page-subtitle form-section-heading submission-field-header"
-  }, title), _react["default"].createElement("div", {
+  }, title), _react.default.createElement("div", {
     className: "form-section-body"
   }, children));
 });
@@ -2310,21 +2344,21 @@ var RoundTwoDetailPanel = function (_React$PureComponent3) {
           context = _this$props14.context,
           schemas = _this$props14.schemas;
       var open = this.state.open;
-      return _react["default"].createElement("div", {
+      return _react.default.createElement("div", {
         className: "current-item-properties round-two-panel"
-      }, _react["default"].createElement("h4", {
+      }, _react.default.createElement("h4", {
         className: "clearfix page-subtitle submission-field-header"
-      }, _react["default"].createElement("button", {
+      }, _react.default.createElement("button", {
         type: "button",
         className: "btn btn-xs icon-container pull-left",
         onClick: this.handleToggle
-      }, _react["default"].createElement("i", {
+      }, _react.default.createElement("i", {
         className: "icon fas " + (open ? "icon-minus" : "icon-plus")
-      })), _react["default"].createElement("span", null, "Object Attributes")), _react["default"].createElement(_Collapse.Collapse, {
-        "in": open
-      }, _react["default"].createElement("div", {
+      })), _react.default.createElement("span", null, "Object Attributes")), _react.default.createElement(_Collapse.Collapse, {
+        in: open
+      }, _react.default.createElement("div", {
         className: "item-page-detail"
-      }, _react["default"].createElement(_ItemDetailList.Detail, {
+      }, _react.default.createElement(_ItemDetailList.Detail, {
         excludedKeys: _ItemDetailList.Detail.defaultProps.excludedKeys.concat('upload_credentials'),
         context: context,
         schemas: schemas,
@@ -2335,7 +2369,7 @@ var RoundTwoDetailPanel = function (_React$PureComponent3) {
   }]);
 
   return RoundTwoDetailPanel;
-}(_react["default"].PureComponent);
+}(_react.default.PureComponent);
 
 function buildContext(context, itemSchema) {
   var objList = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : null;
@@ -2346,16 +2380,16 @@ function buildContext(context, itemSchema) {
 
   var userGroups = _util.JWT.getUserGroups();
 
-  var fields = itemSchema.properties ? _underscore["default"].keys(itemSchema.properties) : [];
+  var fields = itemSchema.properties ? _underscore.default.keys(itemSchema.properties) : [];
 
-  _underscore["default"].forEach(fields, function (field) {
+  _underscore.default.forEach(fields, function (field) {
     var fieldSchema = _util.object.getNestedProperty(itemSchema, ['properties', field], true);
 
     if (!fieldSchema) {
       return;
     }
 
-    if (fieldSchema.exclude_from && (Array.isArray(fieldSchema.exclude_from) && _underscore["default"].contains(fieldSchema.exclude_from, 'FFedit-create') || fieldSchema.exclude_from === 'FFedit-create')) {
+    if (fieldSchema.exclude_from && (Array.isArray(fieldSchema.exclude_from) && _underscore.default.contains(fieldSchema.exclude_from, 'FFedit-create') || fieldSchema.exclude_from === 'FFedit-create')) {
       return;
     }
 
@@ -2364,7 +2398,7 @@ function buildContext(context, itemSchema) {
     }
 
     if (fieldSchema.permission && fieldSchema.permission == "import_items") {
-      if (!_underscore["default"].contains(userGroups, 'admin')) {
+      if (!_underscore.default.contains(userGroups, 'admin')) {
         return;
       }
     }
@@ -2391,7 +2425,7 @@ function buildContext(context, itemSchema) {
 
       if (linkedProperty !== null && typeof linkedProperty !== 'undefined' && !roundTwoExclude) {
         var fieldToStore = field;
-        linkedProperty = _underscore["default"].reject(linkedProperty, function (p) {
+        linkedProperty = _underscore.default.reject(linkedProperty, function (p) {
           return p === 'items' || p === 'properties';
         });
 
@@ -2399,7 +2433,7 @@ function buildContext(context, itemSchema) {
           fieldToStore += '.' + linkedProperty.join('.');
         }
 
-        if (!_underscore["default"].contains(objList, fieldToStore)) {
+        if (!_underscore.default.contains(objList, fieldToStore)) {
           objList.push(fieldToStore);
         }
 
@@ -2424,13 +2458,13 @@ function delvePreExistingObjects(initObjs, json, fieldSchema, listTerm) {
     }
   } else if (json instanceof Object && json) {
     if (fieldSchema.properties) {
-      _underscore["default"].keys(json).forEach(function (key) {
+      _underscore.default.keys(json).forEach(function (key) {
         if (fieldSchema.properties[key]) {
           delvePreExistingObjects(initObjs, json[key], fieldSchema.properties[key], listTerm);
         }
       });
     }
-  } else if (_underscore["default"].contains(_underscore["default"].keys(fieldSchema), 'linkTo')) {
+  } else if (_underscore.default.contains(_underscore.default.keys(fieldSchema), 'linkTo')) {
     initObjs.push({
       'path': json,
       'display': json,
@@ -2467,7 +2501,7 @@ function sortPropFields(fields) {
     return 0;
   }
 
-  _underscore["default"].forEach(fields, function (field) {
+  _underscore.default.forEach(fields, function (field) {
     if (!field) return;
 
     if (field.props.required) {
@@ -2493,7 +2527,7 @@ function gatherLinkToTitlesFromContextEmbedded(context) {
     idsToTitles[context['@id']] = context.display_title;
   }
 
-  _underscore["default"].values(context).forEach(function (value) {
+  _underscore.default.values(context).forEach(function (value) {
     if (Array.isArray(value)) {
       value.forEach(function (arrItem) {
         if (!Array.isArray(arrItem) && arrItem && _typeof(arrItem) === 'object') {
@@ -2509,7 +2543,7 @@ function gatherLinkToTitlesFromContextEmbedded(context) {
 }
 
 var modifyHierarchy = function myself(hierarchy, keyIdx, parentKeyIdx) {
-  _underscore["default"].keys(hierarchy).forEach(function (key) {
+  _underscore.default.keys(hierarchy).forEach(function (key) {
     if (key == parentKeyIdx) {
       hierarchy[parentKeyIdx][keyIdx] = {};
     } else {
@@ -2524,7 +2558,7 @@ var trimHierarchy = function myself(hierarchy, keyIdx) {
   if (hierarchy[keyIdx]) {
     delete hierarchy[keyIdx];
   } else {
-    _underscore["default"].keys(hierarchy).forEach(function (key) {
+    _underscore.default.keys(hierarchy).forEach(function (key) {
       hierarchy[key] = myself(hierarchy[key], keyIdx);
     });
   }
@@ -2536,7 +2570,7 @@ var searchHierarchy = function myself(hierarchy, keyIdx) {
   if (!hierarchy) return null;
   var found_hierarchy = null;
 
-  _underscore["default"].keys(hierarchy).forEach(function (key) {
+  _underscore.default.keys(hierarchy).forEach(function (key) {
     if (key == keyIdx) {
       found_hierarchy = hierarchy[key];
     } else {
@@ -2555,7 +2589,7 @@ var findParentFromHierarchy = function myself(hierarchy, keyIdx) {
   if (isNaN(keyIdx) || !hierarchy) return null;
   var found_parent = null;
 
-  _underscore["default"].keys(hierarchy).forEach(function (key) {
+  _underscore.default.keys(hierarchy).forEach(function (key) {
     if (keyIdx in hierarchy[key]) {
       found_parent = key;
     } else {
@@ -2570,7 +2604,7 @@ var findParentFromHierarchy = function myself(hierarchy, keyIdx) {
 var replaceInHierarchy = function myself(hierarchy, current, toReplace) {
   if (typeof current === 'number') current = current + '';
 
-  _underscore["default"].keys(hierarchy).forEach(function (key) {
+  _underscore.default.keys(hierarchy).forEach(function (key) {
     if (key === current) {
       var downstream = hierarchy[key];
       hierarchy[toReplace] = downstream;
@@ -2586,24 +2620,24 @@ var replaceInHierarchy = function myself(hierarchy, current, toReplace) {
 var flattenHierarchy = function myself(hierarchy) {
   var found_keys = [];
 
-  _underscore["default"].keys(hierarchy).forEach(function (key) {
+  _underscore.default.keys(hierarchy).forEach(function (key) {
     if (!isNaN(key)) key = parseInt(key);
     var sub_keys = myself(hierarchy[key]);
-    found_keys = _underscore["default"].union(found_keys, sub_keys, [key]);
+    found_keys = _underscore.default.union(found_keys, sub_keys, [key]);
   });
 
   return found_keys;
 };
 
 function removeNulls(context) {
-  _underscore["default"].keys(context).forEach(function (key) {
+  _underscore.default.keys(context).forEach(function (key) {
     if ((0, _submissionFields.isValueNull)(context[key])) {
       delete context[key];
     } else if (Array.isArray(context[key])) {
-      context[key] = _underscore["default"].filter(context[key], function (v) {
+      context[key] = _underscore.default.filter(context[key], function (v) {
         return !(0, _submissionFields.isValueNull)(v);
       });
-      context[key] = _underscore["default"].map(context[key], function (v) {
+      context[key] = _underscore.default.map(context[key], function (v) {
         return v && _typeof(v) === 'object' ? removeNulls(v) : v;
       });
     } else if (context[key] instanceof Object) {

--- a/es/components/forms/SubmissionView.js
+++ b/es/components/forms/SubmissionView.js
@@ -4,7 +4,7 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.buildContext = buildContext;
-exports.default = void 0;
+exports["default"] = void 0;
 
 var _react = _interopRequireDefault(require("react"));
 
@@ -34,7 +34,7 @@ var _SubmissionTree = require("./components/SubmissionTree");
 
 var _submissionFields = require("./components/submission-fields");
 
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
 function _toConsumableArray(arr) { return _arrayWithoutHoles(arr) || _iterableToArray(arr) || _nonIterableSpread(); }
 
@@ -52,7 +52,9 @@ function _objectWithoutProperties(source, excluded) { if (source == null) return
 
 function _objectWithoutPropertiesLoose(source, excluded) { if (source == null) return {}; var target = {}; var sourceKeys = Object.keys(source); var key, i; for (i = 0; i < sourceKeys.length; i++) { key = sourceKeys[i]; if (excluded.indexOf(key) >= 0) continue; target[key] = source[key]; } return target; }
 
-function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); } return target; }
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
+
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(source, true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(source).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
@@ -92,7 +94,7 @@ var SubmissionView = function (_React$PureComponent) {
       if (keyHierarchy === null) return 0;
       var validationReturn = 1;
 
-      _underscore.default.keys(keyHierarchy).forEach(function (key) {
+      _underscore["default"].keys(keyHierarchy).forEach(function (key) {
         if (!isNaN(key)) {
           if (!keyComplete[key] && keyContext[key]) {
             validationReturn = 0;
@@ -129,7 +131,7 @@ var SubmissionView = function (_React$PureComponent) {
 
     _this = _possibleConstructorReturn(this, _getPrototypeOf(SubmissionView).call(this, props));
 
-    _underscore.default.bindAll(_assertThisInitialized(_this), 'modifyKeyContext', 'initializePrincipal', 'initCreateObj', 'initCreateAlias', 'submitAmbiguousType', 'buildAmbiguousEnumEntry', 'handleTypeSelection', 'handleAliasChange', 'handleAliasLabChange', 'submitAlias', 'modifyAlias', 'createObj', 'removeObj', 'initExistingObj', 'addExistingObj', 'setSubmissionState', 'updateUpload', 'testPostNewContext', 'realPostNewContext', 'removeNullsFromContext', 'checkRoundTwo', 'buildDeleteFields', 'modifyMD5Progess', 'submitObject', 'finishRoundTwo', 'cancelCreateNewObject', 'cancelCreatePrimaryObject');
+    _underscore["default"].bindAll(_assertThisInitialized(_this), 'modifyKeyContext', 'initializePrincipal', 'initCreateObj', 'initCreateAlias', 'submitAmbiguousType', 'buildAmbiguousEnumEntry', 'handleTypeSelection', 'handleAliasChange', 'handleAliasLabChange', 'submitAlias', 'modifyAlias', 'createObj', 'removeObj', 'initExistingObj', 'addExistingObj', 'setSubmissionState', 'updateUpload', 'testPostNewContext', 'realPostNewContext', 'removeNullsFromContext', 'checkRoundTwo', 'buildDeleteFields', 'modifyMD5Progess', 'submitObject', 'finishRoundTwo', 'cancelCreateNewObject', 'cancelCreatePrimaryObject');
 
     _this.state = {
       'keyContext': null,
@@ -175,7 +177,7 @@ var SubmissionView = function (_React$PureComponent) {
     value: function componentDidMount() {
       var schemas = this.props.schemas;
 
-      if (schemas && _underscore.default.keys(schemas).length > 0) {
+      if (schemas && _underscore["default"].keys(schemas).length > 0) {
         this.initializePrincipal();
       }
     }
@@ -219,7 +221,7 @@ var SubmissionView = function (_React$PureComponent) {
           'keyContext': contextCopy,
           'keyValid': validCopy
         };
-      }, _reactTooltip.default.rebuild);
+      }, _reactTooltip["default"].rebuild);
     }
   }, {
     key: "initializePrincipal",
@@ -237,7 +239,7 @@ var SubmissionView = function (_React$PureComponent) {
       var keyContext = {};
       var contextID = _util.object.itemUtil.atId(context) || null;
 
-      var parsedHref = _url.default.parse(href, true);
+      var parsedHref = _url["default"].parse(href, true);
 
       var principalTypes = context['@type'];
 
@@ -245,7 +247,7 @@ var SubmissionView = function (_React$PureComponent) {
         var typeFromHref = parsedHref.query && parsedHref.query.type || 'Item';
 
         if (Array.isArray(typeFromHref)) {
-          var _$without = _underscore.default.without(typeFromHref, 'Item');
+          var _$without = _underscore["default"].without(typeFromHref, 'Item');
 
           var _$without2 = _slicedToArray(_$without, 1);
 
@@ -279,7 +281,7 @@ var SubmissionView = function (_React$PureComponent) {
       var userHref = null;
 
       if (userInfo && Array.isArray(userInfo.user_actions)) {
-        userHref = _underscore.default.findWhere(userInfo.user_actions, {
+        userHref = _underscore["default"].findWhere(userInfo.user_actions, {
           'id': 'profile'
         }).href;
       } else {
@@ -330,7 +332,7 @@ var SubmissionView = function (_React$PureComponent) {
               currKey: 0,
               callbackHref: callbackHref
             }, function () {
-              _underscore.default.forEach(initObjs, function (initObj) {
+              _underscore["default"].forEach(initObjs, function (initObj) {
                 initObj.display = keyDisplay[initObj.path] || initObj.display;
 
                 _this2.initExistingObj(initObj);
@@ -387,7 +389,7 @@ var SubmissionView = function (_React$PureComponent) {
       }
 
       if (schema && schema.properties.aliases) {
-        this.setState(_underscore.default.extend({
+        this.setState(_underscore["default"].extend({
           'creatingAlias': autoSuggestedAlias,
           'creatingIdx': newIdx,
           'creatingType': type,
@@ -423,7 +425,7 @@ var SubmissionView = function (_React$PureComponent) {
   }, {
     key: "buildAmbiguousEnumEntry",
     value: function buildAmbiguousEnumEntry(val) {
-      return _react.default.createElement(_DropdownButton.DropdownItem, {
+      return _react["default"].createElement(_DropdownButton.DropdownItem, {
         key: val,
         title: val || '',
         eventKey: val,
@@ -531,7 +533,7 @@ var SubmissionView = function (_React$PureComponent) {
         var aliases = keyContext[currKey].aliases || null;
         var name = Array.isArray(aliases) && aliases.length > 1 && aliases[aliases.length - 2] || keyContext[currKey].name || keyContext[currKey].title || null;
 
-        var nextKeyDisplay = _underscore.default.clone(keyDisplay);
+        var nextKeyDisplay = _underscore["default"].clone(keyDisplay);
 
         if (name) {
           nextKeyDisplay[currKey] = name;
@@ -571,19 +573,19 @@ var SubmissionView = function (_React$PureComponent) {
             keyLinks = currState.keyLinks,
             prevKeyDisplay = currState.keyDisplay;
 
-        var contextCopy = _underscore.default.clone(keyContext);
+        var contextCopy = _underscore["default"].clone(keyContext);
 
-        var validCopy = _underscore.default.clone(keyValid);
+        var validCopy = _underscore["default"].clone(keyValid);
 
-        var typesCopy = _underscore.default.clone(keyTypes);
+        var typesCopy = _underscore["default"].clone(keyTypes);
 
         var parentKeyIdx = currKey;
 
-        var bookmarksCopy = _underscore.default.clone(keyLinkBookmarks);
+        var bookmarksCopy = _underscore["default"].clone(keyLinkBookmarks);
 
         var linksCopy = _util.object.deepClone(keyLinks);
 
-        var keyDisplay = _underscore.default.clone(prevKeyDisplay);
+        var keyDisplay = _underscore["default"].clone(prevKeyDisplay);
 
         var bookmarksList = [];
         var keyIdx;
@@ -591,7 +593,7 @@ var SubmissionView = function (_React$PureComponent) {
 
         if (newIdx === 0) {
           keyIdx = 0;
-          newHierarchy = _underscore.default.clone(keyHierarchy);
+          newHierarchy = _underscore["default"].clone(keyHierarchy);
         } else {
           keyIdx = keyIter + 1;
 
@@ -601,7 +603,7 @@ var SubmissionView = function (_React$PureComponent) {
             return;
           }
 
-          newHierarchy = modifyHierarchy(_underscore.default.clone(keyHierarchy), keyIdx, parentKeyIdx);
+          newHierarchy = modifyHierarchy(_underscore["default"].clone(keyHierarchy), keyIdx, parentKeyIdx);
           validCopy[keyIdx] = 1;
           validCopy[parentKeyIdx] = 0;
         }
@@ -610,7 +612,7 @@ var SubmissionView = function (_React$PureComponent) {
         var contextWithAlias = contextCopy && contextCopy[keyIdx] ? contextCopy[keyIdx] : {};
 
         if (Array.isArray(contextWithAlias.aliases)) {
-          contextWithAlias.aliases = _underscore.default.uniq(_underscore.default.filter(contextWithAlias.aliases.slice(0)).concat([alias]));
+          contextWithAlias.aliases = _underscore["default"].uniq(_underscore["default"].filter(contextWithAlias.aliases.slice(0)).concat([alias]));
         } else {
           contextWithAlias.aliases = [alias];
         }
@@ -619,7 +621,7 @@ var SubmissionView = function (_React$PureComponent) {
         bookmarksCopy[keyIdx] = bookmarksList;
         linksCopy[keyIdx] = newLink;
         keyDisplay[keyIdx] = alias;
-        return _underscore.default.extend({
+        return _underscore["default"].extend({
           'keyContext': contextCopy,
           'keyValid': validCopy,
           'keyTypes': typesCopy,
@@ -655,19 +657,19 @@ var SubmissionView = function (_React$PureComponent) {
 
         var keyCompleteCopy = _util.object.deepClone(keyComplete);
 
-        var bookmarksCopy = _underscore.default.clone(keyLinkBookmarks);
+        var bookmarksCopy = _underscore["default"].clone(keyLinkBookmarks);
 
-        var linksCopy = _underscore.default.clone(keyLinks);
+        var linksCopy = _underscore["default"].clone(keyLinks);
 
         var roundTwoCopy = roundTwoKeys.slice();
 
-        var hierarchy = _underscore.default.clone(keyHierarchy);
+        var hierarchy = _underscore["default"].clone(keyHierarchy);
 
         var dummyHierarchy = _util.object.deepClone(hierarchy);
 
         var hierKey = key;
 
-        _underscore.default.keys(keyCompleteCopy).forEach(function (compKey) {
+        _underscore["default"].keys(keyCompleteCopy).forEach(function (compKey) {
           if (keyCompleteCopy[compKey] === key) {
             hierKey = compKey;
           }
@@ -683,10 +685,10 @@ var SubmissionView = function (_React$PureComponent) {
         toDelete.push(key);
         var newHierarchy = trimHierarchy(hierarchy, hierKey);
 
-        _underscore.default.forEach(toDelete, function (keyToDelete) {
+        _underscore["default"].forEach(toDelete, function (keyToDelete) {
           if (isNaN(keyToDelete)) return;
 
-          if (_underscore.default.contains(roundTwoCopy, keyToDelete)) {
+          if (_underscore["default"].contains(roundTwoCopy, keyToDelete)) {
             var rmIdx = roundTwoCopy.indexOf(keyToDelete);
 
             if (rmIdx > -1) {
@@ -735,13 +737,13 @@ var SubmissionView = function (_React$PureComponent) {
             prevKeyLinks = _ref5.keyLinks;
         var parentKeyIdx = init ? 0 : currKey;
 
-        var keyDisplay = _underscore.default.clone(prevKeyDisplay);
+        var keyDisplay = _underscore["default"].clone(prevKeyDisplay);
 
-        var keyTypes = _underscore.default.clone(prevKeyTypes);
+        var keyTypes = _underscore["default"].clone(prevKeyTypes);
 
-        var keyLinks = _underscore.default.clone(prevKeyLinks);
+        var keyLinks = _underscore["default"].clone(prevKeyLinks);
 
-        var keyHierarchy = modifyHierarchy(_underscore.default.clone(prevKeyHierarchy), path, parentKeyIdx);
+        var keyHierarchy = modifyHierarchy(_underscore["default"].clone(prevKeyHierarchy), path, parentKeyIdx);
         keyDisplay[path] = display;
         keyTypes[path] = type;
         keyLinks[path] = field;
@@ -792,7 +794,7 @@ var SubmissionView = function (_React$PureComponent) {
               var validState = SubmissionView.findValidationState(value, keyHierarchy, keyContext, keyComplete);
 
               if (validState === 1) {
-                var nextKeyValid = _underscore.default.clone(keyValid);
+                var nextKeyValid = _underscore["default"].clone(keyValid);
 
                 nextKeyValid[value] = 1;
                 stateToSet['keyValid'] = nextKeyValid;
@@ -865,7 +867,7 @@ var SubmissionView = function (_React$PureComponent) {
               _this4.setState(stateToSet);
             }
           });
-        }).catch(function () {
+        })["catch"](function () {
           stateToSet.uploadStatus = 'MD5 calculation error';
           stateToSet.file = null;
           stateToSet.md5Progress = null;
@@ -895,7 +897,7 @@ var SubmissionView = function (_React$PureComponent) {
   }, {
     key: "checkRoundTwo",
     value: function checkRoundTwo(schema) {
-      var fields = schema.properties ? _underscore.default.keys(schema.properties) : [];
+      var fields = schema.properties ? _underscore["default"].keys(schema.properties) : [];
 
       for (var i = 0; i < fields.length; i++) {
         if (schema.properties[fields[i]]) {
@@ -926,7 +928,7 @@ var SubmissionView = function (_React$PureComponent) {
 
       var userGroups = _util.JWT.getUserGroups();
 
-      _underscore.default.keys(origCopy).forEach(function (field) {
+      _underscore["default"].keys(origCopy).forEach(function (field) {
         if (!(0, _submissionFields.isValueNull)(patchContext[field])) {
           return;
         }
@@ -942,12 +944,12 @@ var SubmissionView = function (_React$PureComponent) {
             return;
           }
 
-          if (fieldSchema.exclude_from && (_underscore.default.contains(fieldSchema.exclude_from, 'FFedit-create') || fieldSchema.exclude_from == 'FFedit-create')) {
+          if (fieldSchema.exclude_from && (_underscore["default"].contains(fieldSchema.exclude_from, 'FFedit-create') || fieldSchema.exclude_from == 'FFedit-create')) {
             return;
           }
 
           if (fieldSchema.permission && fieldSchema.permission == "import_items") {
-            if (_underscore.default.contains(userGroups, 'admin')) deleteFields.push(field);
+            if (_underscore["default"].contains(userGroups, 'admin')) deleteFields.push(field);
             return;
           }
 
@@ -1000,7 +1002,7 @@ var SubmissionView = function (_React$PureComponent) {
       var currType = keyTypes[inKey];
       var currSchema = schemas[currType];
       stateToSet.processingFetch = false;
-      stateToSet.keyValid = _underscore.default.clone(keyValid);
+      stateToSet.keyValid = _underscore["default"].clone(keyValid);
       var finalizedContext = this.removeNullsFromContext(inKey);
       var i;
 
@@ -1037,7 +1039,7 @@ var SubmissionView = function (_React$PureComponent) {
             finalizedContext.lab = _util.object.itemUtil.atId(context.lab);
           }
 
-          if (currentSubmittingUser.groups && _underscore.default.contains(currentSubmittingUser.groups, 'admin')) {
+          if (currentSubmittingUser.groups && _underscore["default"].contains(currentSubmittingUser.groups, 'admin')) {
             if (context.submitted_by) {
               finalizedContext.submitted_by = _util.object.itemUtil.atId(context.submitted_by);
             } else {
@@ -1162,15 +1164,15 @@ var SubmissionView = function (_React$PureComponent) {
               var parentKey = parseInt(findParentFromHierarchy(keyHierarchy, inKey));
               stateToSet.currKey = parentKey !== null && !isNaN(parentKey) ? parentKey : 0;
 
-              var typesCopy = _underscore.default.clone(keyTypes);
+              var typesCopy = _underscore["default"].clone(keyTypes);
 
-              var keyCompleteCopy = _underscore.default.clone(keyComplete);
+              var keyCompleteCopy = _underscore["default"].clone(keyComplete);
 
-              var linksCopy = _underscore.default.clone(keyLinks);
+              var linksCopy = _underscore["default"].clone(keyLinks);
 
-              var displayCopy = _underscore.default.clone(keyDisplay);
+              var displayCopy = _underscore["default"].clone(keyDisplay);
 
-              var contextCopy = _underscore.default.clone(keyContext);
+              var contextCopy = _underscore["default"].clone(keyContext);
 
               var roundTwoCopy = roundTwoKeys.slice();
               keyCompleteCopy[inKey] = submitted_at_id;
@@ -1187,7 +1189,7 @@ var SubmissionView = function (_React$PureComponent) {
 
               var needsRoundTwo = _this6.checkRoundTwo(currSchema);
 
-              if (needsRoundTwo && !_underscore.default.contains(roundTwoCopy, inKey)) {
+              if (needsRoundTwo && !_underscore["default"].contains(roundTwoCopy, inKey)) {
                 roundTwoCopy.push(parseInt(inKey));
                 stateToSet.roundTwoKeys = roundTwoCopy;
               }
@@ -1216,7 +1218,7 @@ var SubmissionView = function (_React$PureComponent) {
               }
             }
 
-            _reactTooltip.default.rebuild();
+            _reactTooltip["default"].rebuild();
           }
         });
       };
@@ -1241,12 +1243,12 @@ var SubmissionView = function (_React$PureComponent) {
             _ref6$roundTwoKeys = _ref6.roundTwoKeys,
             roundTwoKeys = _ref6$roundTwoKeys === void 0 ? [] : _ref6$roundTwoKeys;
 
-        var validationCopy = _underscore.default.clone(keyValid);
+        var validationCopy = _underscore["default"].clone(keyValid);
 
         var roundTwoCopy = roundTwoKeys.slice();
         validationCopy[currKey] = 4;
 
-        if (_underscore.default.contains(roundTwoCopy, currKey)) {
+        if (_underscore["default"].contains(roundTwoCopy, currKey)) {
           var rmIdx = roundTwoCopy.indexOf(currKey);
 
           if (rmIdx > -1) {
@@ -1287,11 +1289,11 @@ var SubmissionView = function (_React$PureComponent) {
             creatingLinkForField = _ref7.creatingLinkForField;
         if (!creatingIdx) return null;
 
-        var nextKeyContext = _underscore.default.clone(keyContext);
+        var nextKeyContext = _underscore["default"].clone(keyContext);
 
         var currentContextPointer = nextKeyContext[currKey];
 
-        _underscore.default.pairs(currentContextPointer).forEach(function (_ref8) {
+        _underscore["default"].pairs(currentContextPointer).forEach(function (_ref8) {
           var _ref9 = _slicedToArray(_ref8, 2),
               field = _ref9[0],
               idx = _ref9[1];
@@ -1341,15 +1343,15 @@ var SubmissionView = function (_React$PureComponent) {
         if (callbackHref) {
           nextURI = callbackHref;
         } else {
-          var parts = _url.default.parse(href, true);
+          var parts = _url["default"].parse(href, true);
 
-          var modifiedQuery = _underscore.default.omit(parts.query, 'currentAction');
+          var modifiedQuery = _underscore["default"].omit(parts.query, 'currentAction');
 
-          var modifiedSearch = _queryString.default.stringify(modifiedQuery);
+          var modifiedSearch = _queryString["default"].stringify(modifiedQuery);
 
           parts.query = modifiedQuery;
           parts.search = (modifiedSearch.length > 0 ? '?' : '') + modifiedSearch;
-          nextURI = _url.default.format(parts);
+          nextURI = _url["default"].format(parts);
           navOpts.skipRequest = true;
         }
 
@@ -1396,46 +1398,46 @@ var SubmissionView = function (_React$PureComponent) {
           propsToPass = _objectWithoutProperties(_this$props5, ["context", "navigate"]);
 
       keyDisplay[currKey] || currType;
-      return _react.default.createElement("div", {
+      return _react["default"].createElement("div", {
         className: "submission-view-page-container container",
         id: "content"
-      }, _react.default.createElement(TypeSelectModal, _extends({
+      }, _react["default"].createElement(TypeSelectModal, _extends({
         show: showAmbiguousModal
-      }, _underscore.default.pick(this.state, 'ambiguousIdx', 'ambiguousType', 'ambiguousSelected', 'currKey', 'creatingIdx'), _underscore.default.pick(this, 'buildAmbiguousEnumEntry', 'submitAmbiguousType', 'cancelCreateNewObject', 'cancelCreatePrimaryObject'), {
+      }, _underscore["default"].pick(this.state, 'ambiguousIdx', 'ambiguousType', 'ambiguousSelected', 'currKey', 'creatingIdx'), _underscore["default"].pick(this, 'buildAmbiguousEnumEntry', 'submitAmbiguousType', 'cancelCreateNewObject', 'cancelCreatePrimaryObject'), {
         schemas: schemas
-      })), _react.default.createElement(AliasSelectModal, _extends({
+      })), _react["default"].createElement(AliasSelectModal, _extends({
         show: !showAmbiguousModal && creatingIdx !== null && creatingType !== null
-      }, _underscore.default.pick(this.state, 'creatingAlias', 'creatingType', 'creatingAliasMessage', 'currKey', 'creatingIdx', 'currentSubmittingUser'), {
+      }, _underscore["default"].pick(this.state, 'creatingAlias', 'creatingType', 'creatingAliasMessage', 'currKey', 'creatingIdx', 'currentSubmittingUser'), {
         handleAliasChange: this.handleAliasChange,
         submitAlias: this.submitAlias,
         cancelCreateNewObject: this.cancelCreateNewObject,
         cancelCreatePrimaryObject: this.cancelCreatePrimaryObject
-      })), _react.default.createElement(WarningBanner, {
+      })), _react["default"].createElement(WarningBanner, {
         cancelCreatePrimaryObject: this.cancelCreatePrimaryObject
-      }, _react.default.createElement("button", {
+      }, _react["default"].createElement("button", {
         type: "button",
         className: "btn btn-danger",
         onClick: this.cancelCreatePrimaryObject
-      }, "Cancel / Exit"), _react.default.createElement(ValidationButton, _extends({}, _underscore.default.pick(this.state, 'currKey', 'keyValid', 'md5Progress', 'upload', 'roundTwo', 'processingFetch'), {
+      }, "Cancel / Exit"), _react["default"].createElement(ValidationButton, _extends({}, _underscore["default"].pick(this.state, 'currKey', 'keyValid', 'md5Progress', 'upload', 'roundTwo', 'processingFetch'), {
         testPostNewContext: this.testPostNewContext,
         finishRoundTwo: this.finishRoundTwo
-      })), _react.default.createElement(SubmitButton, _extends({}, _underscore.default.pick(this.state, 'keyValid', 'currKey', 'roundTwo', 'upload', 'processingFetch', 'md5Progress'), {
+      })), _react["default"].createElement(SubmitButton, _extends({}, _underscore["default"].pick(this.state, 'keyValid', 'currKey', 'roundTwo', 'upload', 'processingFetch', 'md5Progress'), {
         realPostNewContext: this.realPostNewContext
-      }))), _react.default.createElement(DetailTitleBanner, _extends({
+      }))), _react["default"].createElement(DetailTitleBanner, _extends({
         hierarchy: keyHierarchy,
         setSubmissionState: this.setSubmissionState,
         schemas: schemas
-      }, _underscore.default.pick(this.state, 'keyContext', 'keyTypes', 'keyDisplay', 'currKey', 'fullScreen'))), _react.default.createElement("div", {
+      }, _underscore["default"].pick(this.state, 'keyContext', 'keyTypes', 'keyDisplay', 'currKey', 'fullScreen'))), _react["default"].createElement("div", {
         className: "clearfix row"
-      }, _react.default.createElement("div", {
+      }, _react["default"].createElement("div", {
         className: navCol
-      }, _react.default.createElement(_SubmissionTree.SubmissionTree, _extends({
+      }, _react["default"].createElement(_SubmissionTree.SubmissionTree, _extends({
         setSubmissionState: this.setSubmissionState,
         hierarchy: keyHierarchy,
         schemas: schemas
-      }, _underscore.default.pick(this.state, 'keyValid', 'keyTypes', 'keyDisplay', 'keyComplete', 'currKey', 'keyLinkBookmarks', 'keyLinks', 'keyHierarchy')))), _react.default.createElement("div", {
+      }, _underscore["default"].pick(this.state, 'keyValid', 'keyTypes', 'keyDisplay', 'keyComplete', 'currKey', 'keyLinkBookmarks', 'keyLinks', 'keyHierarchy')))), _react["default"].createElement("div", {
         className: bodyCol
-      }, _react.default.createElement(IndividualObjectView, _extends({}, propsToPass, {
+      }, _react["default"].createElement(IndividualObjectView, _extends({}, propsToPass, {
         schemas: schemas,
         currType: currType,
         currContext: currContext,
@@ -1447,16 +1449,16 @@ var SubmissionView = function (_React$PureComponent) {
         modifyAlias: this.modifyAlias,
         updateUpload: this.updateUpload,
         hierarchy: keyHierarchy
-      }, _underscore.default.pick(this.state, 'keyDisplay', 'keyComplete', 'keyIter', 'currKey', 'keyContext', 'upload', 'uploadStatus', 'md5Progress', 'roundTwo', 'currentSubmittingUser'))))));
+      }, _underscore["default"].pick(this.state, 'keyDisplay', 'keyComplete', 'keyIter', 'currKey', 'keyContext', 'upload', 'uploadStatus', 'md5Progress', 'roundTwo', 'currentSubmittingUser'))))));
     }
   }]);
 
   return SubmissionView;
-}(_react.default.PureComponent);
+}(_react["default"].PureComponent);
 
-exports.default = SubmissionView;
+exports["default"] = SubmissionView;
 
-var ValidationButton = _react.default.memo(function (props) {
+var ValidationButton = _react["default"].memo(function (props) {
   var currKey = props.currKey,
       keyValid = props.keyValid,
       md5Progress = props.md5Progress,
@@ -1469,35 +1471,35 @@ var ValidationButton = _react.default.memo(function (props) {
 
   if (roundTwo) {
     if (upload === null && md5Progress === null) {
-      return _react.default.createElement("button", {
+      return _react["default"].createElement("button", {
         type: "button",
         className: "btn btn-warning",
         onClick: finishRoundTwo
       }, "Skip");
     } else {
-      return _react.default.createElement("button", {
+      return _react["default"].createElement("button", {
         type: "button",
         className: "btn btn-warning",
         disabled: true
       }, "Skip");
     }
   } else if (validity === 3 || validity === 4) {
-    return _react.default.createElement("button", {
+    return _react["default"].createElement("button", {
       type: "button",
       className: "btn btn-info",
       disabled: true
     }, "Validated");
   } else if (validity === 2) {
     if (processingFetch) {
-      return _react.default.createElement("button", {
+      return _react["default"].createElement("button", {
         type: "button",
         className: "btn btn-danger",
         disabled: true
-      }, _react.default.createElement("i", {
+      }, _react["default"].createElement("i", {
         className: "icon icon-spin icon-circle-notch fas"
       }));
     } else {
-      return _react.default.createElement("button", {
+      return _react["default"].createElement("button", {
         type: "button",
         className: "btn btn-danger",
         onClick: testPostNewContext
@@ -1505,22 +1507,22 @@ var ValidationButton = _react.default.memo(function (props) {
     }
   } else if (validity === 1) {
     if (processingFetch) {
-      return _react.default.createElement("button", {
+      return _react["default"].createElement("button", {
         type: "button",
         className: "btn btn-info",
         disabled: true
-      }, _react.default.createElement("i", {
+      }, _react["default"].createElement("i", {
         className: "icon icon-spin icon-circle-notch fas"
       }));
     } else {
-      return _react.default.createElement("button", {
+      return _react["default"].createElement("button", {
         type: "button",
         className: "btn btn-info",
         onClick: testPostNewContext
       }, "Validate");
     }
   } else {
-    return _react.default.createElement("button", {
+    return _react["default"].createElement("button", {
       type: "button",
       className: "btn btn-info",
       disabled: true
@@ -1528,7 +1530,7 @@ var ValidationButton = _react.default.memo(function (props) {
   }
 });
 
-var SubmitButton = _react.default.memo(function (props) {
+var SubmitButton = _react["default"].memo(function (props) {
   var keyValid = props.keyValid,
       currKey = props.currKey,
       roundTwo = props.roundTwo,
@@ -1540,15 +1542,15 @@ var SubmitButton = _react.default.memo(function (props) {
 
   if (roundTwo) {
     if (upload !== null || processingFetch || md5Progress !== null) {
-      return _react.default.createElement("button", {
+      return _react["default"].createElement("button", {
         type: "button",
         disabled: true,
         className: "btn btn-success"
-      }, _react.default.createElement("i", {
+      }, _react["default"].createElement("i", {
         className: "icon icon-spin icon-circle-notch fas"
       }));
     } else {
-      return _react.default.createElement("button", {
+      return _react["default"].createElement("button", {
         type: "button",
         className: "btn btn-success",
         onClick: realPostNewContext
@@ -1556,28 +1558,28 @@ var SubmitButton = _react.default.memo(function (props) {
     }
   } else if (validity == 3) {
     if (processingFetch) {
-      return _react.default.createElement("button", {
+      return _react["default"].createElement("button", {
         type: "button",
         disabled: true,
         className: "btn btn-success"
-      }, _react.default.createElement("i", {
+      }, _react["default"].createElement("i", {
         className: "icon icon-spin icon-circle-notch fas"
       }));
     } else {
-      return _react.default.createElement("button", {
+      return _react["default"].createElement("button", {
         type: "button",
         className: "btn btn-success",
         onClick: realPostNewContext
       }, "Submit");
     }
   } else if (validity == 4) {
-    return _react.default.createElement("button", {
+    return _react["default"].createElement("button", {
       type: "button",
       className: "btn btn-success",
       disabled: true
     }, "Submitted");
   } else {
-    return _react.default.createElement("button", {
+    return _react["default"].createElement("button", {
       type: "button",
       className: "btn btn-success",
       disabled: true
@@ -1585,17 +1587,17 @@ var SubmitButton = _react.default.memo(function (props) {
   }
 });
 
-var WarningBanner = _react.default.memo(function (props) {
+var WarningBanner = _react["default"].memo(function (props) {
   var children = props.children;
-  return _react.default.createElement("div", {
+  return _react["default"].createElement("div", {
     className: "mb-2 mt-1 text-400 warning-banner"
-  }, _react.default.createElement("div", {
+  }, _react["default"].createElement("div", {
     className: "row"
-  }, _react.default.createElement("div", {
+  }, _react["default"].createElement("div", {
     className: "col"
-  }, "Please note: your work will be lost if you navigate away from, refresh or close this page while submitting. The submission process is under active development and features may change."), _react.default.createElement("div", {
+  }, "Please note: your work will be lost if you navigate away from, refresh or close this page while submitting. The submission process is under active development and features may change."), _react["default"].createElement("div", {
     className: "col-md-auto"
-  }, _react.default.createElement("div", {
+  }, _react["default"].createElement("div", {
     className: "action-buttons-container text-right"
   }, children))));
 });
@@ -1610,7 +1612,7 @@ var DetailTitleBanner = function (_React$PureComponent2) {
         if (typeof obj[currKey] !== 'undefined') {
           return [currKey];
         } else {
-          var nestedFound = _underscore.default.find(_underscore.default.map(_underscore.default.pairs(obj), function (p) {
+          var nestedFound = _underscore["default"].find(_underscore["default"].map(_underscore["default"].pairs(obj), function (p) {
             return [p[0], findNestedKey(p[1])];
           }), function (p) {
             return typeof p[1] !== 'undefined' && p[1] !== null;
@@ -1631,7 +1633,7 @@ var DetailTitleBanner = function (_React$PureComponent2) {
       var foundPropertyName = null;
       var arrayIdx = null;
 
-      _underscore.default.pairs(context).forEach(function (p) {
+      _underscore["default"].pairs(context).forEach(function (p) {
         if (foundPropertyName) return;
 
         if (p[1] === nextKey) {
@@ -1664,7 +1666,7 @@ var DetailTitleBanner = function (_React$PureComponent2) {
 
     _this8 = _possibleConstructorReturn(this, _getPrototypeOf(DetailTitleBanner).call(this, props));
     _this8.generateCrumbTitle = _this8.generateCrumbTitle.bind(_assertThisInitialized(_this8));
-    _this8.toggleOpen = _underscore.default.throttle(_this8.toggleOpen.bind(_assertThisInitialized(_this8)), 500);
+    _this8.toggleOpen = _underscore["default"].throttle(_this8.toggleOpen.bind(_assertThisInitialized(_this8)), 500);
     _this8.generateHierarchicalTitles = _this8.generateHierarchicalTitles.bind(_assertThisInitialized(_this8));
     _this8.state = {
       'open': true
@@ -1707,7 +1709,7 @@ var DetailTitleBanner = function (_React$PureComponent2) {
         hierarchyKeyList = [numKey];
       }
 
-      var icon = i === 0 ? null : _react.default.createElement("i", {
+      var icon = i === 0 ? null : _react["default"].createElement("i", {
         className: "icon icon-fw"
       }, "\u21B5");
       var isLast = i + 1 === hierarchyKeyList.length;
@@ -1730,21 +1732,21 @@ var DetailTitleBanner = function (_React$PureComponent2) {
         }
       }
 
-      return _react.default.createElement(_Collapse.Collapse, {
-        in: true,
+      return _react["default"].createElement(_Collapse.Collapse, {
+        "in": true,
         appear: hierarchyKeyList.length !== 1,
         key: i
-      }, _react.default.createElement("div", {
+      }, _react["default"].createElement("div", {
         className: "title-crumb depth-level-" + i + (isLast ? ' last-title' : ' mid-title')
-      }, _react.default.createElement("div", {
+      }, _react["default"].createElement("div", {
         className: "submission-working-title"
-      }, _react.default.createElement("span", {
+      }, _react["default"].createElement("span", {
         onClick: this.handleClick.bind(this, numKey)
-      }, icon, parentPropertyName ? _react.default.createElement("span", {
+      }, icon, parentPropertyName ? _react["default"].createElement("span", {
         className: "next-property-name"
-      }, parentPropertyName, ": ") : null, _react.default.createElement("span", {
+      }, parentPropertyName, ": ") : null, _react["default"].createElement("span", {
         className: "working-subtitle"
-      }, _util.schemaTransforms.getTitleForType(keyTypes[numKey], schemas)), " ", _react.default.createElement("span", null, keyDisplay[numKey])))));
+      }, _util.schemaTransforms.getTitleForType(keyTypes[numKey], schemas)), " ", _react["default"].createElement("span", null, keyDisplay[numKey])))));
     }
   }, {
     key: "generateHierarchicalTitles",
@@ -1752,7 +1754,7 @@ var DetailTitleBanner = function (_React$PureComponent2) {
       var _this$props7 = this.props,
           hierarchy = _this$props7.hierarchy,
           currKey = _this$props7.currKey;
-      return _underscore.default.map(DetailTitleBanner.getListOfKeysInPath(hierarchy, currKey), this.generateCrumbTitle);
+      return _underscore["default"].map(DetailTitleBanner.getListOfKeysInPath(hierarchy, currKey), this.generateCrumbTitle);
     }
   }, {
     key: "render",
@@ -1762,21 +1764,21 @@ var DetailTitleBanner = function (_React$PureComponent2) {
           currKey = _this$props8.currKey;
       var open = this.state.open;
       if (fullScreen) return null;
-      return _react.default.createElement("h3", {
+      return _react["default"].createElement("h3", {
         className: "crumbs-title mb-2"
-      }, _react.default.createElement("div", {
+      }, _react["default"].createElement("div", {
         className: "subtitle-heading form-section-heading mb-08"
-      }, _react.default.createElement("span", {
+      }, _react["default"].createElement("span", {
         className: "inline-block clickable",
         onClick: this.toggleOpen
-      }, "Currently Editing ", currKey > 0 ? _react.default.createElement("i", {
+      }, "Currently Editing ", currKey > 0 ? _react["default"].createElement("i", {
         className: "icon icon-fw fas icon-caret-" + (open ? 'down' : 'right')
       }) : null)), open ? this.generateHierarchicalTitles() : this.generateCrumbTitle(currKey));
     }
   }]);
 
   return DetailTitleBanner;
-}(_react.default.PureComponent);
+}(_react["default"].PureComponent);
 
 var TypeSelectModal = function (_React$Component) {
   _inherits(TypeSelectModal, _React$Component);
@@ -1836,24 +1838,24 @@ var TypeSelectModal = function (_React$Component) {
         ambiguousDescrip = schemas[ambiguousSelected].description;
       }
 
-      return _react.default.createElement(_reactBootstrap.Modal, {
+      return _react["default"].createElement(_reactBootstrap.Modal, {
         show: true,
         onHide: this.onHide,
         className: "submission-view-modal"
-      }, _react.default.createElement(_reactBootstrap.Modal.Header, null, _react.default.createElement(_reactBootstrap.Modal.Title, null, 'Multiple object types found for your new ' + ambiguousType)), _react.default.createElement(_reactBootstrap.Modal.Body, null, _react.default.createElement("div", {
+      }, _react["default"].createElement(_reactBootstrap.Modal.Header, null, _react["default"].createElement(_reactBootstrap.Modal.Title, null, 'Multiple object types found for your new ' + ambiguousType)), _react["default"].createElement(_reactBootstrap.Modal.Body, null, _react["default"].createElement("div", {
         onKeyDown: this.onContainerKeyDown.bind(this, submitAmbiguousType)
-      }, _react.default.createElement("p", null, "Please select a specific object type from the menu below."), _react.default.createElement("div", {
+      }, _react["default"].createElement("p", null, "Please select a specific object type from the menu below."), _react["default"].createElement("div", {
         className: "input-wrapper mb-15"
-      }, _react.default.createElement(_DropdownButton.DropdownButton, {
+      }, _react["default"].createElement(_DropdownButton.DropdownButton, {
         id: "dropdown-type-select",
         title: ambiguousSelected || "No value"
-      }, ambiguousType !== null ? _underscore.default.map(_underscore.default.keys(itemTypeHierarchy[ambiguousType]), function (val) {
+      }, ambiguousType !== null ? _underscore["default"].map(_underscore["default"].keys(itemTypeHierarchy[ambiguousType]), function (val) {
         return buildAmbiguousEnumEntry(val);
-      }) : null)), ambiguousDescrip ? _react.default.createElement("div", {
+      }) : null)), ambiguousDescrip ? _react["default"].createElement("div", {
         className: "mb-15 mt-15"
-      }, _react.default.createElement("h5", {
+      }, _react["default"].createElement("h5", {
         className: "text-500 mb-02"
-      }, "Description"), ambiguousDescrip) : null, _react.default.createElement("button", {
+      }, "Description"), ambiguousDescrip) : null, _react["default"].createElement("button", {
         type: "button",
         className: "btn btn-primary",
         disabled: ambiguousSelected === null,
@@ -1863,7 +1865,7 @@ var TypeSelectModal = function (_React$Component) {
   }]);
 
   return TypeSelectModal;
-}(_react.default.Component);
+}(_react["default"].Component);
 
 var AliasSelectModal = function (_TypeSelectModal) {
   _inherits(AliasSelectModal, _TypeSelectModal);
@@ -1887,33 +1889,33 @@ var AliasSelectModal = function (_TypeSelectModal) {
           currentSubmittingUser = _this$props11.currentSubmittingUser;
       if (!show) return null;
       var disabledBtn = creatingAlias.indexOf(':') < 0 || creatingAlias.indexOf(':') + 1 === creatingAlias.length;
-      return _react.default.createElement(_reactBootstrap.Modal, {
+      return _react["default"].createElement(_reactBootstrap.Modal, {
         show: true,
         onHide: this.onHide,
         className: "submission-view-modal"
-      }, _react.default.createElement(_reactBootstrap.Modal.Header, null, _react.default.createElement(_reactBootstrap.Modal.Title, null, "Give your new ", creatingType, " an alias")), _react.default.createElement(_reactBootstrap.Modal.Body, null, _react.default.createElement("div", {
+      }, _react["default"].createElement(_reactBootstrap.Modal.Header, null, _react["default"].createElement(_reactBootstrap.Modal.Title, null, "Give your new ", creatingType, " an alias")), _react["default"].createElement(_reactBootstrap.Modal.Body, null, _react["default"].createElement("div", {
         onKeyDown: this.onContainerKeyDown.bind(this, submitAlias)
-      }, _react.default.createElement("p", {
+      }, _react["default"].createElement("p", {
         className: "mt-0 mb-1"
-      }, "Aliases are lab specific identifiers to reference an object. The format is ", _react.default.createElement("code", null, '<lab-name>:<identifier>'), " - a lab name and an identifier separated by a colon, e.g. ", _react.default.createElement("code", null, "dcic-lab:42"), "."), _react.default.createElement("p", {
+      }, "Aliases are lab specific identifiers to reference an object. The format is ", _react["default"].createElement("code", null, '<lab-name>:<identifier>'), " - a lab name and an identifier separated by a colon, e.g. ", _react["default"].createElement("code", null, "dcic-lab:42"), "."), _react["default"].createElement("p", {
         className: "mt-0 mb-1"
-      }, "Please create your own alias to help you to refer to this Item later."), _react.default.createElement("div", {
+      }, "Please create your own alias to help you to refer to this Item later."), _react["default"].createElement("div", {
         className: "input-wrapper mt-2 mb-2"
-      }, _react.default.createElement(_submissionFields.AliasInputField, {
+      }, _react["default"].createElement(_submissionFields.AliasInputField, {
         value: creatingAlias,
         errorMessage: creatingAliasMessage,
         onAliasChange: handleAliasChange,
         currentSubmittingUser: currentSubmittingUser,
         withinModal: true
-      })), creatingAliasMessage ? _react.default.createElement("div", {
+      })), creatingAliasMessage ? _react["default"].createElement("div", {
         style: {
           'marginBottom': '15px',
           'color': '#7e4544',
           'fontSize': '1.2em'
         }
-      }, creatingAliasMessage) : null, _react.default.createElement("div", {
+      }, creatingAliasMessage) : null, _react["default"].createElement("div", {
         className: "text-right"
-      }, _react.default.createElement("button", {
+      }, _react["default"].createElement("button", {
         type: "button",
         className: "btn btn-primary",
         disabled: disabledBtn,
@@ -1935,7 +1937,7 @@ var IndividualObjectView = function (_React$Component2) {
 
     _this10 = _possibleConstructorReturn(this, _getPrototypeOf(IndividualObjectView).call(this, props));
 
-    _underscore.default.bindAll(_assertThisInitialized(_this10), 'modifyNewContext', 'fetchAndValidateItem', 'checkObjectRemoval', 'selectObj', 'selectComplete', 'selectCancel', 'initiateField');
+    _underscore["default"].bindAll(_assertThisInitialized(_this10), 'modifyNewContext', 'fetchAndValidateItem', 'checkObjectRemoval', 'selectObj', 'selectComplete', 'selectCancel', 'initiateField');
 
     _this10.state = {
       'selectType': null,
@@ -2110,7 +2112,7 @@ var IndividualObjectView = function (_React$Component2) {
           var atId = _step.value;
           var current = selectField && currContext[selectField];
 
-          var isRepeat = Array.isArray(current) && _underscore.default.contains(current, atId);
+          var isRepeat = Array.isArray(current) && _underscore["default"].contains(current, atId);
 
           if (!isRepeat) {
             this.fetchAndValidateItem(atId, selectField, selectType, isMultiSelect ? _toConsumableArray(cloneSelectArrayIdx) : null, null);
@@ -2127,8 +2129,8 @@ var IndividualObjectView = function (_React$Component2) {
         _iteratorError = err;
       } finally {
         try {
-          if (!_iteratorNormalCompletion && _iterator.return != null) {
-            _iterator.return();
+          if (!_iteratorNormalCompletion && _iterator["return"] != null) {
+            _iterator["return"]();
           }
         } finally {
           if (_didIteratorError) {
@@ -2179,7 +2181,7 @@ var IndividualObjectView = function (_React$Component2) {
       if (roundTwo && !secondRoundField) {
         return null;
       } else if (!roundTwo && secondRoundField) {
-        return _react.default.createElement("div", {
+        return _react["default"].createElement("div", {
           key: fieldTitle,
           className: "row field-row",
           required: false,
@@ -2187,15 +2189,15 @@ var IndividualObjectView = function (_React$Component2) {
           style: {
             'overflow': 'visible'
           }
-        }, _react.default.createElement("div", {
+        }, _react["default"].createElement("div", {
           className: "col-12 col-md-4"
-        }, _react.default.createElement("h5", {
+        }, _react["default"].createElement("h5", {
           className: "facet-title submission-field-title"
-        }, fieldTitle)), _react.default.createElement("div", {
+        }, fieldTitle)), _react["default"].createElement("div", {
           className: "col-12 col-md-8"
-        }, _react.default.createElement("div", {
+        }, _react["default"].createElement("div", {
           className: "field-container"
-        }, _react.default.createElement("div", {
+        }, _react["default"].createElement("div", {
           className: "notice-message"
         }, "This field is available after finishing initial submission."))));
       }
@@ -2213,7 +2215,7 @@ var IndividualObjectView = function (_React$Component2) {
           linked = (0, _SubmissionTree.fieldSchemaLinkToType)(fieldSchema);
 
       if (fieldType === 'enum') {
-        enumValues = fieldSchema.enum || fieldSchema.suggested_enum;
+        enumValues = fieldSchema["enum"] || fieldSchema.suggested_enum;
       }
 
       if (linked !== null) {
@@ -2237,7 +2239,7 @@ var IndividualObjectView = function (_React$Component2) {
         }
       }
 
-      return _react.default.createElement(_submissionFields.BuildField, _extends({
+      return _react["default"].createElement(_submissionFields.BuildField, _extends({
         field: field,
         fieldType: fieldType,
         fieldTip: fieldTip,
@@ -2245,7 +2247,7 @@ var IndividualObjectView = function (_React$Component2) {
         isLinked: isLinked,
         currType: currType,
         currContext: currContext
-      }, _underscore.default.pick(this.props, 'md5Progress', 'edit', 'create', 'keyDisplay', 'keyComplete', 'setSubmissionState', 'upload', 'uploadStatus', 'updateUpload', 'currentSubmittingUser', 'roundTwo'), {
+      }, _underscore["default"].pick(this.props, 'md5Progress', 'edit', 'create', 'keyDisplay', 'keyComplete', 'setSubmissionState', 'upload', 'uploadStatus', 'updateUpload', 'currentSubmittingUser', 'roundTwo'), {
         value: fieldValue,
         key: field,
         schema: fieldSchema,
@@ -2255,7 +2257,7 @@ var IndividualObjectView = function (_React$Component2) {
         linkType: linked,
         disabled: false,
         arrayIdx: null,
-        required: _underscore.default.contains(currSchema.required, field),
+        required: _underscore["default"].contains(currSchema.required, field),
         modifyNewContext: this.modifyNewContext,
         selectObj: this.selectObj,
         selectComplete: this.selectComplete,
@@ -2274,14 +2276,14 @@ var IndividualObjectView = function (_React$Component2) {
           currKey = _this$props13.currKey,
           schemas = _this$props13.schemas,
           roundTwo = _this$props13.roundTwo;
-      var fields = currContext ? _underscore.default.keys(currContext) : [];
-      var fieldJSXComponents = sortPropFields(_underscore.default.filter(_underscore.default.map(fields, this.initiateField), function (f) {
+      var fields = currContext ? _underscore["default"].keys(currContext) : [];
+      var fieldJSXComponents = sortPropFields(_underscore["default"].filter(_underscore["default"].map(fields, this.initiateField), function (f) {
         return !!f;
       }));
       var roundTwoDetailContext = roundTwo && keyComplete[currKey] && keyContext[keyComplete[currKey]];
-      return _react.default.createElement("div", null, _react.default.createElement(FormFieldsContainer, {
+      return _react["default"].createElement("div", null, _react["default"].createElement(FormFieldsContainer, {
         currKey: currKey
-      }, fieldJSXComponents), roundTwo ? _react.default.createElement(RoundTwoDetailPanel, {
+      }, fieldJSXComponents), roundTwo ? _react["default"].createElement(RoundTwoDetailPanel, {
         schemas: schemas,
         context: roundTwoDetailContext,
         open: true
@@ -2290,17 +2292,17 @@ var IndividualObjectView = function (_React$Component2) {
   }]);
 
   return IndividualObjectView;
-}(_react.default.Component);
+}(_react["default"].Component);
 
-var FormFieldsContainer = _react.default.memo(function (props) {
+var FormFieldsContainer = _react["default"].memo(function (props) {
   var children = props.children,
       title = props.title;
-  if (_react.default.Children.count(children) === 0) return null;
-  return _react.default.createElement("div", {
+  if (_react["default"].Children.count(children) === 0) return null;
+  return _react["default"].createElement("div", {
     className: "form-fields-container"
-  }, _react.default.createElement("h4", {
+  }, _react["default"].createElement("h4", {
     className: "clearfix page-subtitle form-section-heading submission-field-header"
-  }, title), _react.default.createElement("div", {
+  }, title), _react["default"].createElement("div", {
     className: "form-section-body"
   }, children));
 });
@@ -2344,21 +2346,21 @@ var RoundTwoDetailPanel = function (_React$PureComponent3) {
           context = _this$props14.context,
           schemas = _this$props14.schemas;
       var open = this.state.open;
-      return _react.default.createElement("div", {
+      return _react["default"].createElement("div", {
         className: "current-item-properties round-two-panel"
-      }, _react.default.createElement("h4", {
+      }, _react["default"].createElement("h4", {
         className: "clearfix page-subtitle submission-field-header"
-      }, _react.default.createElement("button", {
+      }, _react["default"].createElement("button", {
         type: "button",
         className: "btn btn-xs icon-container pull-left",
         onClick: this.handleToggle
-      }, _react.default.createElement("i", {
+      }, _react["default"].createElement("i", {
         className: "icon fas " + (open ? "icon-minus" : "icon-plus")
-      })), _react.default.createElement("span", null, "Object Attributes")), _react.default.createElement(_Collapse.Collapse, {
-        in: open
-      }, _react.default.createElement("div", {
+      })), _react["default"].createElement("span", null, "Object Attributes")), _react["default"].createElement(_Collapse.Collapse, {
+        "in": open
+      }, _react["default"].createElement("div", {
         className: "item-page-detail"
-      }, _react.default.createElement(_ItemDetailList.Detail, {
+      }, _react["default"].createElement(_ItemDetailList.Detail, {
         excludedKeys: _ItemDetailList.Detail.defaultProps.excludedKeys.concat('upload_credentials'),
         context: context,
         schemas: schemas,
@@ -2369,7 +2371,7 @@ var RoundTwoDetailPanel = function (_React$PureComponent3) {
   }]);
 
   return RoundTwoDetailPanel;
-}(_react.default.PureComponent);
+}(_react["default"].PureComponent);
 
 function buildContext(context, itemSchema) {
   var objList = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : null;
@@ -2380,16 +2382,16 @@ function buildContext(context, itemSchema) {
 
   var userGroups = _util.JWT.getUserGroups();
 
-  var fields = itemSchema.properties ? _underscore.default.keys(itemSchema.properties) : [];
+  var fields = itemSchema.properties ? _underscore["default"].keys(itemSchema.properties) : [];
 
-  _underscore.default.forEach(fields, function (field) {
+  _underscore["default"].forEach(fields, function (field) {
     var fieldSchema = _util.object.getNestedProperty(itemSchema, ['properties', field], true);
 
     if (!fieldSchema) {
       return;
     }
 
-    if (fieldSchema.exclude_from && (Array.isArray(fieldSchema.exclude_from) && _underscore.default.contains(fieldSchema.exclude_from, 'FFedit-create') || fieldSchema.exclude_from === 'FFedit-create')) {
+    if (fieldSchema.exclude_from && (Array.isArray(fieldSchema.exclude_from) && _underscore["default"].contains(fieldSchema.exclude_from, 'FFedit-create') || fieldSchema.exclude_from === 'FFedit-create')) {
       return;
     }
 
@@ -2398,7 +2400,7 @@ function buildContext(context, itemSchema) {
     }
 
     if (fieldSchema.permission && fieldSchema.permission == "import_items") {
-      if (!_underscore.default.contains(userGroups, 'admin')) {
+      if (!_underscore["default"].contains(userGroups, 'admin')) {
         return;
       }
     }
@@ -2425,7 +2427,7 @@ function buildContext(context, itemSchema) {
 
       if (linkedProperty !== null && typeof linkedProperty !== 'undefined' && !roundTwoExclude) {
         var fieldToStore = field;
-        linkedProperty = _underscore.default.reject(linkedProperty, function (p) {
+        linkedProperty = _underscore["default"].reject(linkedProperty, function (p) {
           return p === 'items' || p === 'properties';
         });
 
@@ -2433,7 +2435,7 @@ function buildContext(context, itemSchema) {
           fieldToStore += '.' + linkedProperty.join('.');
         }
 
-        if (!_underscore.default.contains(objList, fieldToStore)) {
+        if (!_underscore["default"].contains(objList, fieldToStore)) {
           objList.push(fieldToStore);
         }
 
@@ -2458,13 +2460,13 @@ function delvePreExistingObjects(initObjs, json, fieldSchema, listTerm) {
     }
   } else if (json instanceof Object && json) {
     if (fieldSchema.properties) {
-      _underscore.default.keys(json).forEach(function (key) {
+      _underscore["default"].keys(json).forEach(function (key) {
         if (fieldSchema.properties[key]) {
           delvePreExistingObjects(initObjs, json[key], fieldSchema.properties[key], listTerm);
         }
       });
     }
-  } else if (_underscore.default.contains(_underscore.default.keys(fieldSchema), 'linkTo')) {
+  } else if (_underscore["default"].contains(_underscore["default"].keys(fieldSchema), 'linkTo')) {
     initObjs.push({
       'path': json,
       'display': json,
@@ -2501,7 +2503,7 @@ function sortPropFields(fields) {
     return 0;
   }
 
-  _underscore.default.forEach(fields, function (field) {
+  _underscore["default"].forEach(fields, function (field) {
     if (!field) return;
 
     if (field.props.required) {
@@ -2527,7 +2529,7 @@ function gatherLinkToTitlesFromContextEmbedded(context) {
     idsToTitles[context['@id']] = context.display_title;
   }
 
-  _underscore.default.values(context).forEach(function (value) {
+  _underscore["default"].values(context).forEach(function (value) {
     if (Array.isArray(value)) {
       value.forEach(function (arrItem) {
         if (!Array.isArray(arrItem) && arrItem && _typeof(arrItem) === 'object') {
@@ -2543,7 +2545,7 @@ function gatherLinkToTitlesFromContextEmbedded(context) {
 }
 
 var modifyHierarchy = function myself(hierarchy, keyIdx, parentKeyIdx) {
-  _underscore.default.keys(hierarchy).forEach(function (key) {
+  _underscore["default"].keys(hierarchy).forEach(function (key) {
     if (key == parentKeyIdx) {
       hierarchy[parentKeyIdx][keyIdx] = {};
     } else {
@@ -2558,7 +2560,7 @@ var trimHierarchy = function myself(hierarchy, keyIdx) {
   if (hierarchy[keyIdx]) {
     delete hierarchy[keyIdx];
   } else {
-    _underscore.default.keys(hierarchy).forEach(function (key) {
+    _underscore["default"].keys(hierarchy).forEach(function (key) {
       hierarchy[key] = myself(hierarchy[key], keyIdx);
     });
   }
@@ -2570,7 +2572,7 @@ var searchHierarchy = function myself(hierarchy, keyIdx) {
   if (!hierarchy) return null;
   var found_hierarchy = null;
 
-  _underscore.default.keys(hierarchy).forEach(function (key) {
+  _underscore["default"].keys(hierarchy).forEach(function (key) {
     if (key == keyIdx) {
       found_hierarchy = hierarchy[key];
     } else {
@@ -2589,7 +2591,7 @@ var findParentFromHierarchy = function myself(hierarchy, keyIdx) {
   if (isNaN(keyIdx) || !hierarchy) return null;
   var found_parent = null;
 
-  _underscore.default.keys(hierarchy).forEach(function (key) {
+  _underscore["default"].keys(hierarchy).forEach(function (key) {
     if (keyIdx in hierarchy[key]) {
       found_parent = key;
     } else {
@@ -2604,7 +2606,7 @@ var findParentFromHierarchy = function myself(hierarchy, keyIdx) {
 var replaceInHierarchy = function myself(hierarchy, current, toReplace) {
   if (typeof current === 'number') current = current + '';
 
-  _underscore.default.keys(hierarchy).forEach(function (key) {
+  _underscore["default"].keys(hierarchy).forEach(function (key) {
     if (key === current) {
       var downstream = hierarchy[key];
       hierarchy[toReplace] = downstream;
@@ -2620,24 +2622,24 @@ var replaceInHierarchy = function myself(hierarchy, current, toReplace) {
 var flattenHierarchy = function myself(hierarchy) {
   var found_keys = [];
 
-  _underscore.default.keys(hierarchy).forEach(function (key) {
+  _underscore["default"].keys(hierarchy).forEach(function (key) {
     if (!isNaN(key)) key = parseInt(key);
     var sub_keys = myself(hierarchy[key]);
-    found_keys = _underscore.default.union(found_keys, sub_keys, [key]);
+    found_keys = _underscore["default"].union(found_keys, sub_keys, [key]);
   });
 
   return found_keys;
 };
 
 function removeNulls(context) {
-  _underscore.default.keys(context).forEach(function (key) {
+  _underscore["default"].keys(context).forEach(function (key) {
     if ((0, _submissionFields.isValueNull)(context[key])) {
       delete context[key];
     } else if (Array.isArray(context[key])) {
-      context[key] = _underscore.default.filter(context[key], function (v) {
+      context[key] = _underscore["default"].filter(context[key], function (v) {
         return !(0, _submissionFields.isValueNull)(v);
       });
-      context[key] = _underscore.default.map(context[key], function (v) {
+      context[key] = _underscore["default"].map(context[key], function (v) {
         return v && _typeof(v) === 'object' ? removeNulls(v) : v;
       });
     } else if (context[key] instanceof Object) {

--- a/es/components/forms/components/submission-fields.js
+++ b/es/components/forms/components/submission-fields.js
@@ -729,7 +729,7 @@ var LinkedObj = function (_React$PureComponent2) {
       var itemType = schema && schema.linkTo;
       var prettyTitle = schema && (schema.parentSchema && schema.parentSchema.title || schema.title);
 
-      var message = _react["default"].createElement("div", null, isMultiSelect ? _react["default"].createElement("p", {
+      var message = _react["default"].createElement("div", null, !isMultiSelect ? _react["default"].createElement("p", {
         className: "mb-0"
       }, "Please either select an Item below and click ", _react["default"].createElement("em", null, "Apply"), " or ", _react["default"].createElement("em", null, "drag and drop"), " an Item (row) from this window into the submissions window.") : _react["default"].createElement("p", {
         className: "mb-0"

--- a/es/components/forms/components/submission-fields.js
+++ b/es/components/forms/components/submission-fields.js
@@ -32,7 +32,7 @@ var _rcProgress = require("rc-progress");
 
 var _LinkToSelector = require("./LinkToSelector");
 
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
 function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function (obj) { return typeof obj; }; } else { _typeof = function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
@@ -80,7 +80,7 @@ var BuildField = function (_React$PureComponent) {
         }
       }
 
-      if (fieldSchema.enum || fieldSchema.suggested_enum) {
+      if (fieldSchema["enum"] || fieldSchema.suggested_enum) {
         fieldType = 'enum';
       }
 
@@ -101,19 +101,19 @@ var BuildField = function (_React$PureComponent) {
 
     _this = _possibleConstructorReturn(this, _getPrototypeOf(BuildField).call(this, props));
 
-    _underscore.default.bindAll(_assertThisInitialized(_this), 'displayField', 'handleDropdownButtonToggle', 'handleAliasChange', 'buildEnumEntry', 'submitEnumVal', 'handleChange', 'handleAliasChange', 'deleteField', 'pushArrayValue', 'commonRowProps', 'labelTypeDescriptor', 'wrapWithLabel', 'wrapWithNoLabel');
+    _underscore["default"].bindAll(_assertThisInitialized(_this), 'displayField', 'handleDropdownButtonToggle', 'handleAliasChange', 'buildEnumEntry', 'submitEnumVal', 'handleChange', 'handleAliasChange', 'deleteField', 'pushArrayValue', 'commonRowProps', 'labelTypeDescriptor', 'wrapWithLabel', 'wrapWithNoLabel');
 
     _this.state = {
       'dropdownOpen': false
     };
-    _this.inputElementRef = _react.default.createRef();
+    _this.inputElementRef = _react["default"].createRef();
     return _this;
   }
 
   _createClass(BuildField, [{
     key: "componentDidMount",
     value: function componentDidMount() {
-      _reactTooltip.default.rebuild();
+      _reactTooltip["default"].rebuild();
     }
   }, {
     key: "handleDropdownButtonToggle",
@@ -158,7 +158,7 @@ var BuildField = function (_React$PureComponent) {
         var filetype = currContext && currContext.options && currContext.options.filetype;
 
         if (filetype === 'md' || filetype === 'html') {
-          return _react.default.createElement(PreviewField, _extends({}, this.props, {
+          return _react["default"].createElement(PreviewField, _extends({}, this.props, {
             filetype: filetype,
             onChange: this.handleChange
           }));
@@ -168,22 +168,22 @@ var BuildField = function (_React$PureComponent) {
       switch (fieldType) {
         case 'text':
           if (field === 'aliases') {
-            return _react.default.createElement("div", {
+            return _react["default"].createElement("div", {
               className: "input-wrapper"
-            }, _react.default.createElement(AliasInputField, _extends({}, inputProps, {
+            }, _react["default"].createElement(AliasInputField, _extends({}, inputProps, {
               onAliasChange: this.handleAliasChange,
               currentSubmittingUser: currentSubmittingUser
             })));
           }
 
-          return _react.default.createElement("input", _extends({}, inputProps, {
+          return _react["default"].createElement("input", _extends({}, inputProps, {
             type: "text",
             className: "form-control",
             inputMode: "latin"
           }));
 
         case 'textarea':
-          return _react.default.createElement("textarea", _extends({}, inputProps, {
+          return _react["default"].createElement("textarea", _extends({}, inputProps, {
             type: "text",
             inputMode: "latin",
             rows: 4,
@@ -192,7 +192,7 @@ var BuildField = function (_React$PureComponent) {
 
         case 'html':
         case 'code':
-          return _react.default.createElement("textarea", _extends({}, inputProps, {
+          return _react["default"].createElement("textarea", _extends({}, inputProps, {
             type: "text",
             inputMode: "latin",
             rows: 8,
@@ -205,21 +205,21 @@ var BuildField = function (_React$PureComponent) {
           }));
 
         case 'integer':
-          return _react.default.createElement(_reactBootstrap.FormControl, _extends({
+          return _react["default"].createElement(_reactBootstrap.FormControl, _extends({
             type: "number"
           }, inputProps, {
             step: 1
           }));
 
         case 'number':
-          return _react.default.createElement(_reactBootstrap.FormControl, _extends({
+          return _react["default"].createElement(_reactBootstrap.FormControl, _extends({
             type: "number"
           }, inputProps));
 
         case 'boolean':
-          return _react.default.createElement(_Checkbox.Checkbox, _extends({}, _underscore.default.omit(inputProps, 'value', 'placeholder'), {
+          return _react["default"].createElement(_Checkbox.Checkbox, _extends({}, _underscore["default"].omit(inputProps, 'value', 'placeholder'), {
             checked: !!value
-          }), _react.default.createElement("span", {
+          }), _react["default"].createElement("span", {
             style: {
               'verticalAlign': 'middle',
               'textTransform': 'capitalize'
@@ -227,50 +227,50 @@ var BuildField = function (_React$PureComponent) {
           }, typeof value === 'boolean' ? value + '' : null));
 
         case 'enum':
-          return _react.default.createElement("span", {
+          return _react["default"].createElement("span", {
             className: "input-wrapper"
-          }, _react.default.createElement(_DropdownButton.DropdownButton, {
-            title: value || _react.default.createElement("span", {
+          }, _react["default"].createElement(_DropdownButton.DropdownButton, {
+            title: value || _react["default"].createElement("span", {
               className: "text-300"
             }, "No value"),
             onToggle: this.handleDropdownButtonToggle,
             variant: "outline-dark"
-          }, _underscore.default.map(enumValues, function (val) {
+          }, _underscore["default"].map(enumValues, function (val) {
             return _this2.buildEnumEntry(val);
           })));
 
         case 'linked object':
-          return _react.default.createElement(LinkedObj, _extends({
+          return _react["default"].createElement(LinkedObj, _extends({
             key: "linked-item"
           }, this.props));
 
         case 'array':
-          return _react.default.createElement(ArrayField, _extends({}, this.props, {
+          return _react["default"].createElement(ArrayField, _extends({}, this.props, {
             pushArrayValue: this.pushArrayValue,
             value: value || null,
             roundTwo: roundTwo
           }));
 
         case 'object':
-          return _react.default.createElement(ObjectField, this.props);
+          return _react["default"].createElement(ObjectField, this.props);
 
         case 'attachment':
-          return _react.default.createElement("div", {
+          return _react["default"].createElement("div", {
             style: {
               'display': 'inline'
             }
-          }, _react.default.createElement(AttachmentInput, this.props));
+          }, _react["default"].createElement(AttachmentInput, this.props));
 
         case 'file upload':
-          return _react.default.createElement(S3FileInput, this.props);
+          return _react["default"].createElement(S3FileInput, this.props);
       }
 
-      return _react.default.createElement("div", null, "No field for this case yet.");
+      return _react["default"].createElement("div", null, "No field for this case yet.");
     }
   }, {
     key: "buildEnumEntry",
     value: function buildEnumEntry(val) {
-      return _react.default.createElement(_DropdownButton.DropdownItem, {
+      return _react["default"].createElement(_DropdownButton.DropdownItem, {
         key: val,
         title: val || '',
         eventKey: val,
@@ -389,9 +389,9 @@ var BuildField = function (_React$PureComponent) {
     key: "labelTypeDescriptor",
     value: function labelTypeDescriptor() {
       var required = this.props.required;
-      return _react.default.createElement("div", {
+      return _react["default"].createElement("div", {
         className: "field-descriptor"
-      }, required ? _react.default.createElement("span", {
+      }, required ? _react["default"].createElement("span", {
         style: {
           'color': '#a94442'
         }
@@ -405,27 +405,27 @@ var BuildField = function (_React$PureComponent) {
           title = _this$props8.title,
           fieldType = _this$props8.fieldType,
           schema = _this$props8.schema;
-      return _react.default.createElement("div", this.commonRowProps(), _react.default.createElement("div", {
+      return _react["default"].createElement("div", this.commonRowProps(), _react["default"].createElement("div", {
         className: "row"
-      }, _react.default.createElement("div", {
+      }, _react["default"].createElement("div", {
         className: "col-12 col-md-4"
-      }, _react.default.createElement("h5", {
+      }, _react["default"].createElement("h5", {
         className: "submission-field-title text-ellipsis-container"
-      }, this.labelTypeDescriptor(), fieldTip ? _react.default.createElement(InfoIcon, {
+      }, this.labelTypeDescriptor(), fieldTip ? _react["default"].createElement(InfoIcon, {
         className: "mr-07",
         title: title,
         fieldType: fieldType,
         schema: schema
-      }, fieldTip) : null, _react.default.createElement("span", null, title))), _react.default.createElement("div", {
+      }, fieldTip) : null, _react["default"].createElement("span", null, title))), _react["default"].createElement("div", {
         className: "col-12 col-md-8"
-      }, _react.default.createElement("div", {
+      }, _react["default"].createElement("div", {
         className: "row field-container"
       }, Array.prototype.slice.call(arguments)))));
     }
   }, {
     key: "wrapWithNoLabel",
     value: function wrapWithNoLabel() {
-      return _react.default.createElement("div", this.commonRowProps(), Array.prototype.slice.call(arguments));
+      return _react["default"].createElement("div", this.commonRowProps(), Array.prototype.slice.call(arguments));
     }
   }, {
     key: "render",
@@ -444,7 +444,7 @@ var BuildField = function (_React$PureComponent) {
       var disableDelete = false;
       var extClass = '';
 
-      if (!_underscore.default.contains(['filename'], field) && fieldType !== 'array') {
+      if (!_underscore["default"].contains(['filename'], field) && fieldType !== 'array') {
         showDelete = true;
       }
 
@@ -477,9 +477,9 @@ var BuildField = function (_React$PureComponent) {
         extClass += ' in-selection-field';
       }
 
-      return wrapFunc(_react.default.createElement(_react.default.Fragment, null, _react.default.createElement("div", {
+      return wrapFunc(_react["default"].createElement(_react["default"].Fragment, null, _react["default"].createElement("div", {
         className: 'field-column col' + extClass
-      }, fieldToDisplay), fieldType === 'array' || fieldType === 'file upload' ? null : _react.default.createElement(SquareButton, {
+      }, fieldToDisplay), fieldType === 'array' || fieldType === 'file upload' ? null : _react["default"].createElement(SquareButton, {
         show: showDelete,
         disabled: disableDelete,
         tip: isArray ? 'Remove Item' : 'Clear Value',
@@ -489,11 +489,11 @@ var BuildField = function (_React$PureComponent) {
   }]);
 
   return BuildField;
-}(_react.default.PureComponent);
+}(_react["default"].PureComponent);
 
 exports.BuildField = BuildField;
 
-var SquareButton = _react.default.memo(function (props) {
+var SquareButton = _react["default"].memo(function (props) {
   var show = props.show,
       disabled = props.disabled,
       onClick = props.onClick,
@@ -510,21 +510,21 @@ var SquareButton = _react.default.memo(function (props) {
     btnCls += " btn-" + bsStyle;
   }
 
-  return _react.default.createElement("div", {
+  return _react["default"].createElement("div", {
     className: "remove-button-column" + (!show ? ' hidden' : ''),
     style: style
-  }, _react.default.createElement(_Fade.Fade, {
-    in: show
-  }, _react.default.createElement("div", {
+  }, _react["default"].createElement(_Fade.Fade, {
+    "in": show
+  }, _react["default"].createElement("div", {
     className: outerCls
-  }, _react.default.createElement("button", {
+  }, _react["default"].createElement("button", {
     type: "button",
     disabled: disabled || !show,
     onClick: onClick,
     "data-tip": tip,
     tabIndex: 2,
     className: btnCls
-  }, _react.default.createElement("i", {
+  }, _react["default"].createElement("i", {
     className: "icon icon-fw icon-" + icon
   })))));
 });
@@ -550,7 +550,7 @@ var LinkedObj = function (_React$PureComponent2) {
       }
 
       if (Array.isArray(arrayIdx) && Array.isArray(fieldBeingSelectedArrayIdx)) {
-        return _underscore.default.every(arrayIdx, function (arrIdx, arrIdxIdx) {
+        return _underscore["default"].every(arrayIdx, function (arrIdx, arrIdxIdx) {
           return arrIdx === fieldBeingSelectedArrayIdx[arrIdxIdx];
         });
       }
@@ -589,7 +589,7 @@ var LinkedObj = function (_React$PureComponent2) {
     value: function componentDidUpdate() {
       this.updateContext();
 
-      _reactTooltip.default.rebuild();
+      _reactTooltip["default"].rebuild();
     }
   }, {
     key: "updateContext",
@@ -605,7 +605,7 @@ var LinkedObj = function (_React$PureComponent2) {
       if (keyComplete[value] && !isNaN(value)) {
         modifyNewContext(nestedField, keyComplete[value], 'finished linked object', linkType, arrayIdx);
 
-        _reactTooltip.default.rebuild();
+        _reactTooltip["default"].rebuild();
       }
     }
   }, {
@@ -640,7 +640,7 @@ var LinkedObj = function (_React$PureComponent2) {
           selectComplete = _this$props12.selectComplete,
           isMultiSelect = _this$props12.isMultiSelect;
 
-      if (!items || !Array.isArray(items) || items.length === 0 || !_underscore.default.every(items, function (item) {
+      if (!items || !Array.isArray(items) || items.length === 0 || !_underscore["default"].every(items, function (item) {
         return item.id && typeof item.id === 'string' && item.json;
       })) {
         return;
@@ -660,12 +660,12 @@ var LinkedObj = function (_React$PureComponent2) {
 
         atIds = [atId];
       } else {
-        atIds = _underscore.default.pluck(items, "id");
+        atIds = _underscore["default"].pluck(items, "id");
       }
 
       var invalidTitle = "Invalid Item Selected";
 
-      if (_underscore.default.every(atIds, function (atId) {
+      if (_underscore["default"].every(atIds, function (atId) {
         var isValidAtId = _util.object.isValidAtIDFormat(atId);
 
         return atId && isValidAtId;
@@ -724,13 +724,23 @@ var LinkedObj = function (_React$PureComponent2) {
     value: function childWindowAlert() {
       var _this$props14 = this.props,
           schema = _this$props14.schema,
-          nestedField = _this$props14.nestedField;
+          nestedField = _this$props14.nestedField,
+          isMultiSelect = _this$props14.isMultiSelect;
       var itemType = schema && schema.linkTo;
       var prettyTitle = schema && (schema.parentSchema && schema.parentSchema.title || schema.title);
+
+      var message = _react["default"].createElement("div", null, isMultiSelect ? _react["default"].createElement("p", {
+        className: "mb-0"
+      }, "Please either select an Item below and click ", _react["default"].createElement("em", null, "Apply"), " or ", _react["default"].createElement("em", null, "drag and drop"), " an Item (row) from this window into the submissions window.") : _react["default"].createElement("p", {
+        className: "mb-0"
+      }, "Please select the Item(s) you would like and then press ", _react["default"].createElement("em", null, "Apply"), " below."), _react["default"].createElement("p", {
+        className: "mb-0"
+      }, "You may use facets on the left-hand side to narrow down results."));
+
       return {
-        'title': 'Selecting ' + itemType + ' for field ' + (prettyTitle ? prettyTitle + ' ("' + nestedField + '")' : '"' + nestedField + '"'),
-        'message': null,
-        'style': 'info'
+        title: 'Selecting ' + itemType + ' for field ' + (prettyTitle ? prettyTitle + ' ("' + nestedField + '")' : '"' + nestedField + '"'),
+        message: message,
+        style: 'info'
       };
     }
   }, {
@@ -756,11 +766,11 @@ var LinkedObj = function (_React$PureComponent2) {
         }
       }
 
-      return _react.default.createElement(_react.default.Fragment, null, _react.default.createElement("div", {
+      return _react["default"].createElement(_react["default"].Fragment, null, _react["default"].createElement("div", {
         className: "linked-object-text-input-container row flexrow"
-      }, _react.default.createElement("div", {
+      }, _react["default"].createElement("div", {
         className: "field-column col"
-      }, _react.default.createElement("input", {
+      }, _react["default"].createElement("input", {
         onChange: this.handleTextInputChange,
         className: "form-control" + extClass,
         inputMode: "latin",
@@ -768,20 +778,20 @@ var LinkedObj = function (_React$PureComponent2) {
         placeholder: "Drag & drop Item from the search view or type in a valid @ID.",
         value: this.state.textInputValue,
         onDrop: this.handleDrop
-      })), canShowAcceptTypedInput ? _react.default.createElement(SquareButton, {
+      })), canShowAcceptTypedInput ? _react["default"].createElement(SquareButton, {
         show: true,
         onClick: this.handleAcceptTypedID,
         icon: "check fas",
         bsStyle: "success",
         tip: "Accept typed identifier and look it up in database."
-      }) : null, _react.default.createElement(SquareButton, {
+      }) : null, _react["default"].createElement(SquareButton, {
         show: true,
         onClick: selectCancel,
         tip: "Cancel selection",
         style: {
           'marginRight': 9
         }
-      })), _react.default.createElement(_LinkToSelector.LinkToSelector, {
+      })), _react["default"].createElement(_LinkToSelector.LinkToSelector, {
         isSelecting: true,
         onSelect: this.handleFinishSelectItem,
         onCloseChildWindow: selectCancel,
@@ -793,19 +803,19 @@ var LinkedObj = function (_React$PureComponent2) {
   }, {
     key: "renderEmptyField",
     value: function renderEmptyField() {
-      return _react.default.createElement("div", {
+      return _react["default"].createElement("div", {
         className: "linked-object-buttons-container"
-      }, _react.default.createElement("button", {
+      }, _react["default"].createElement("button", {
         type: "button",
         className: "btn btn-outline-dark select-create-linked-item-button",
         onClick: this.handleStartSelectItem
-      }, _react.default.createElement("i", {
+      }, _react["default"].createElement("i", {
         className: "icon icon-fw icon-search fas"
-      }), " Select existing"), _react.default.createElement("button", {
+      }), " Select existing"), _react["default"].createElement("button", {
         type: "button",
         className: "btn btn-outline-dark select-create-linked-item-button",
         onClick: this.handleCreateNewItemClick
-      }, _react.default.createElement("i", {
+      }, _react["default"].createElement("i", {
         className: "icon icon-fw icon-file far"
       }), " Create new"));
     }
@@ -830,40 +840,40 @@ var LinkedObj = function (_React$PureComponent2) {
         var thisDisplay = keyDisplay[value] ? keyDisplay[value] + " (<code>" + value + "</code>)" : "<code>" + value + "</code>";
 
         if (isNaN(value)) {
-          return _react.default.createElement("div", {
+          return _react["default"].createElement("div", {
             className: "submitted-linked-object-display-container text-ellipsis-container"
-          }, _react.default.createElement("i", {
+          }, _react["default"].createElement("i", {
             className: "icon icon-fw icon-hdd far mr-05"
-          }), _react.default.createElement("a", {
+          }), _react["default"].createElement("a", {
             href: value,
             target: "_blank",
             rel: "noopener noreferrer",
             "data-tip": thisDisplay + " is already in the database",
             "data-html": true
-          }, keyDisplay[value] || value), _react.default.createElement("i", {
+          }, keyDisplay[value] || value), _react["default"].createElement("i", {
             className: "icon icon-fw icon-external-link-alt ml-05 fas"
           }));
         } else {
           var intKey = parseInt(value);
 
           if (keyComplete[intKey]) {
-            return _react.default.createElement("div", null, _react.default.createElement("a", {
+            return _react["default"].createElement("div", null, _react["default"].createElement("a", {
               href: keyComplete[intKey],
               target: "_blank",
               rel: "noopener noreferrer"
-            }, thisDisplay), _react.default.createElement("i", {
+            }, thisDisplay), _react["default"].createElement("i", {
               className: "icon icon-fw icon-external-link-alt ml-05 fas"
             }));
           } else {
-            return _react.default.createElement("div", {
+            return _react["default"].createElement("div", {
               className: "incomplete-linked-object-display-container text-ellipsis-container"
-            }, _react.default.createElement("i", {
+            }, _react["default"].createElement("i", {
               className: "icon icon-fw icon-sticky-note far"
-            }), "\xA0\xA0", _react.default.createElement("a", {
+            }), "\xA0\xA0", _react["default"].createElement("a", {
               href: "#",
               onClick: this.setSubmissionStateToLinkedToItem,
               "data-tip": "Continue editing/submitting"
-            }, thisDisplay), "\xA0", _react.default.createElement("i", {
+            }, thisDisplay), "\xA0", _react["default"].createElement("i", {
               style: {
                 'fontSize': '0.85rem'
               },
@@ -878,26 +888,26 @@ var LinkedObj = function (_React$PureComponent2) {
   }]);
 
   return LinkedObj;
-}(_react.default.PureComponent);
+}(_react["default"].PureComponent);
 
-var PreviewField = _react.default.memo(function (props) {
+var PreviewField = _react["default"].memo(function (props) {
   var value = props.value,
       filetype = props.filetype,
       field = props.field,
       onChange = props.onChange;
 
-  var preview = value && _react.default.createElement(_react.default.Fragment, null, _react.default.createElement("h6", {
+  var preview = value && _react["default"].createElement(_react["default"].Fragment, null, _react["default"].createElement("h6", {
     className: "mt-1 text-600"
-  }, "Preview:"), _react.default.createElement("hr", {
+  }, "Preview:"), _react["default"].createElement("hr", {
     className: "mb-1 mt-05"
-  }), _react.default.createElement(_BasicStaticSectionBody.BasicStaticSectionBody, {
+  }), _react["default"].createElement(_BasicStaticSectionBody.BasicStaticSectionBody, {
     content: value || '',
     filetype: filetype
   }));
 
-  return _react.default.createElement("div", {
+  return _react["default"].createElement("div", {
     className: "preview-field-container"
-  }, _react.default.createElement(_reactBootstrap.FormControl, {
+  }, _react["default"].createElement(_reactBootstrap.FormControl, {
     onChange: onChange,
     id: "field_for_" + field,
     name: field,
@@ -926,7 +936,7 @@ var ArrayField = function (_React$Component) {
         fieldType = 'text';
       }
 
-      if (itemSchema.enum) {
+      if (itemSchema["enum"]) {
         fieldType = 'enum';
       }
 
@@ -956,7 +966,7 @@ var ArrayField = function (_React$Component) {
 
     _this4 = _possibleConstructorReturn(this, _getPrototypeOf(ArrayField).call(this, props));
 
-    _underscore.default.bindAll(_assertThisInitialized(_this4), 'initiateArrayField', 'generateAddButton');
+    _underscore["default"].bindAll(_assertThisInitialized(_this4), 'initiateArrayField', 'generateAddButton');
 
     return _this4;
   }
@@ -1015,7 +1025,7 @@ var ArrayField = function (_React$Component) {
 
       var title = fieldSchema.title || 'Item';
       var fieldType = ArrayField.typeOfItems(fieldSchema);
-      var enumValues = fieldSchema.enum ? fieldSchema.enum || [] : [];
+      var enumValues = fieldSchema["enum"] ? fieldSchema["enum"] || [] : [];
       var arrayIdxList;
 
       if (propArrayIdx) {
@@ -1026,21 +1036,21 @@ var ArrayField = function (_React$Component) {
 
       arrayIdxList.push(arrayIdx);
 
-      var childFieldSchema = _underscore.default.extend({}, fieldSchema, {
+      var childFieldSchema = _underscore["default"].extend({}, fieldSchema, {
         'parentSchema': schema
       });
 
-      return _react.default.createElement("div", {
+      return _react["default"].createElement("div", {
         key: arrayIdx,
         className: "array-field-container " + (arrayIdx % 2 === 0 ? 'even' : 'odd'),
         "data-field-type": fieldType
-      }, _react.default.createElement(BuildField, _extends({
+      }, _react["default"].createElement(BuildField, _extends({
         value: inArrValue || null,
         fieldTip: fieldTip,
         fieldType: fieldType,
         title: title,
         enumValues: enumValues
-      }, _underscore.default.pick(this.props, 'field', 'modifyNewContext', 'linkType', 'selectObj', 'selectComplete', 'selectCancel', 'nestedField', 'keyDisplay', 'keyComplete', 'setSubmissionState', 'fieldBeingSelected', 'fieldBeingSelectedArrayIdx', 'updateUpload', 'upload', 'uploadStatus', 'md5Progress', 'currentSubmittingUser', 'roundTwo', 'currType'), {
+      }, _underscore["default"].pick(this.props, 'field', 'modifyNewContext', 'linkType', 'selectObj', 'selectComplete', 'selectCancel', 'nestedField', 'keyDisplay', 'keyComplete', 'setSubmissionState', 'fieldBeingSelected', 'fieldBeingSelectedArrayIdx', 'updateUpload', 'upload', 'uploadStatus', 'md5Progress', 'currentSubmittingUser', 'roundTwo', 'currType'), {
         isArray: true,
         isLastItemInArray: allItems.length - 1 === index,
         arrayIdx: arrayIdxList,
@@ -1058,13 +1068,13 @@ var ArrayField = function (_React$Component) {
           _this$props20$value = _this$props20.value,
           values = _this$props20$value === void 0 ? [] : _this$props20$value,
           pushArrayValue = _this$props20.pushArrayValue;
-      return _react.default.createElement("div", {
+      return _react["default"].createElement("div", {
         className: "add-array-item-button-container"
-      }, _react.default.createElement("button", {
+      }, _react["default"].createElement("button", {
         type: "button",
         className: "btn btn-outline-dark btn-" + (values.length > 0 ? "sm" : "md"),
         onClick: pushArrayValue
-      }, _react.default.createElement("i", {
+      }, _react["default"].createElement("i", {
         className: "icon icon-fw fas icon-plus"
       }), " Add"));
     }
@@ -1077,19 +1087,19 @@ var ArrayField = function (_React$Component) {
       var schema = propSchema.items || {};
       var values = propValue || [];
 
-      var valuesToRender = _underscore.default.map(values.length === 0 ? [null] : values, function (v, i) {
+      var valuesToRender = _underscore["default"].map(values.length === 0 ? [null] : values, function (v, i) {
         return [v, schema, i];
       });
 
       var showAddButton = !isValueNull(values[valuesToRender.length - 1]);
-      return _react.default.createElement("div", {
+      return _react["default"].createElement("div", {
         className: "list-of-array-items"
       }, valuesToRender.map(this.initiateArrayField), showAddButton ? this.generateAddButton() : null);
     }
   }]);
 
   return ArrayField;
-}(_react.default.Component);
+}(_react["default"].Component);
 
 var ObjectField = function (_React$PureComponent3) {
   _inherits(ObjectField, _React$PureComponent3);
@@ -1114,11 +1124,11 @@ var ObjectField = function (_React$PureComponent3) {
 
       if (!schemaVal) return null;
 
-      if (schemaVal.exclude_from && (_underscore.default.contains(schemaVal.exclude_from, 'FFedit-create') || schemaVal.exclude_from == 'FFedit-create')) {
+      if (schemaVal.exclude_from && (_underscore["default"].contains(schemaVal.exclude_from, 'FFedit-create') || schemaVal.exclude_from == 'FFedit-create')) {
         return null;
       }
 
-      if (schemaVal.exclude_from && (_underscore.default.contains(schemaVal.exclude_from, 'FF-calculate') || schemaVal.exclude_from == 'FF-calculate')) {
+      if (schemaVal.exclude_from && (_underscore["default"].contains(schemaVal.exclude_from, 'FF-calculate') || schemaVal.exclude_from == 'FF-calculate')) {
         return null;
       }
 
@@ -1166,17 +1176,17 @@ var ObjectField = function (_React$PureComponent3) {
           parentObject = _this$props23.value,
           propNestedField = _this$props23.nestedField,
           isMultiSelect = _this$props23.isMultiSelect;
-      var allFieldsInSchema = objectSchema['properties'] ? _underscore.default.keys(objectSchema['properties']) : [];
+      var allFieldsInSchema = objectSchema['properties'] ? _underscore["default"].keys(objectSchema['properties']) : [];
 
-      var fieldsToBuild = _underscore.default.filter(_underscore.default.map(allFieldsInSchema, function (f) {
+      var fieldsToBuild = _underscore["default"].filter(_underscore["default"].map(allFieldsInSchema, function (f) {
         var fieldSchemaToUseOrNull = _this6.includeField(objectSchema, f);
 
         return fieldSchemaToUseOrNull && [f, fieldSchemaToUseOrNull] || null;
       }));
 
-      var passProps = _underscore.default.pick(this.props, 'modifyNewContext', 'linkType', 'setSubmissionState', 'selectObj', 'selectComplete', 'selectCancel', 'arrayIdx', 'keyDisplay', 'keyComplete', 'currType', 'updateUpload', 'upload', 'uploadStatus', 'md5Progress', 'fieldBeingSelected', 'fieldBeingSelectedArrayIdx');
+      var passProps = _underscore["default"].pick(this.props, 'modifyNewContext', 'linkType', 'setSubmissionState', 'selectObj', 'selectComplete', 'selectCancel', 'arrayIdx', 'keyDisplay', 'keyComplete', 'currType', 'updateUpload', 'upload', 'uploadStatus', 'md5Progress', 'fieldBeingSelected', 'fieldBeingSelectedArrayIdx');
 
-      var builtFields = _underscore.default.map(fieldsToBuild, function (_ref2) {
+      var builtFields = _underscore["default"].map(fieldsToBuild, function (_ref2) {
         var _ref3 = _slicedToArray(_ref2, 2),
             field = _ref3[0],
             fieldSchema = _ref3[1];
@@ -1200,10 +1210,10 @@ var ObjectField = function (_React$PureComponent3) {
         var enumValues = [];
 
         if (fieldType === 'enum') {
-          enumValues = fieldSchema.enum || fieldSchema.suggested_enum || [];
+          enumValues = fieldSchema["enum"] || fieldSchema.suggested_enum || [];
         }
 
-        return _react.default.createElement(BuildField, _extends({}, passProps, {
+        return _react["default"].createElement(BuildField, _extends({}, passProps, {
           field: field,
           fieldType: fieldType,
           fieldTip: fieldTip,
@@ -1221,14 +1231,14 @@ var ObjectField = function (_React$PureComponent3) {
         }));
       });
 
-      return _react.default.createElement("div", {
+      return _react["default"].createElement("div", {
         className: "object-field-container"
       }, builtFields);
     }
   }]);
 
   return ObjectField;
-}(_react.default.PureComponent);
+}(_react["default"].PureComponent);
 
 var AttachmentInput = function (_React$Component2) {
   _inherits(AttachmentInput, _React$Component2);
@@ -1304,11 +1314,11 @@ var AttachmentInput = function (_React$Component2) {
         attach_title = "No file chosen";
       }
 
-      return _react.default.createElement("div", {
+      return _react["default"].createElement("div", {
         style: {
           'display': 'inherit'
         }
-      }, _react.default.createElement("input", {
+      }, _react["default"].createElement("input", {
         id: "field_for_" + field,
         type: "file",
         onChange: this.handleChange,
@@ -1316,10 +1326,10 @@ var AttachmentInput = function (_React$Component2) {
           'display': 'none'
         },
         accept: this.acceptedTypes()
-      }), _react.default.createElement("button", {
+      }), _react["default"].createElement("button", {
         type: "submit",
         className: "btn btn-outline-dark"
-      }, _react.default.createElement("label", {
+      }, _react["default"].createElement("label", {
         className: "text-400 mb-0",
         htmlFor: "field_for_" + field,
         style: {
@@ -1331,7 +1341,7 @@ var AttachmentInput = function (_React$Component2) {
   }]);
 
   return AttachmentInput;
-}(_react.default.Component);
+}(_react["default"].Component);
 
 var S3FileInput = function (_React$Component3) {
   _inherits(S3FileInput, _React$Component3);
@@ -1343,7 +1353,7 @@ var S3FileInput = function (_React$Component3) {
 
     _this8 = _possibleConstructorReturn(this, _getPrototypeOf(S3FileInput).call(this, props));
 
-    _underscore.default.bindAll(_assertThisInitialized(_this8), 'modifyFile', 'handleChange', 'handleAsyncUpload', 'modifyRunningUploads', 'cancelUpload', 'deleteField');
+    _underscore["default"].bindAll(_assertThisInitialized(_this8), 'modifyFile', 'handleChange', 'handleAsyncUpload', 'modifyRunningUploads', 'cancelUpload', 'deleteField');
 
     _this8.state = {
       'percentDone': null,
@@ -1420,7 +1430,7 @@ var S3FileInput = function (_React$Component3) {
             extensions = extensions.concat(response.other_allowed_extensions);
           }
 
-          if (extensions.indexOf("other") === -1 && !_underscore.default.any(extensions, function (ext) {
+          if (extensions.indexOf("other") === -1 && !_underscore["default"].any(extensions, function (ext) {
             return filename.endsWith(ext);
           })) {
             alert('File extension error! Please enter a file with one of the following extensions: ' + extensions.join(', '));
@@ -1518,7 +1528,7 @@ var S3FileInput = function (_React$Component3) {
       }
 
       var disableFile = md5Progress !== null || upload !== null;
-      return _react.default.createElement("div", null, _react.default.createElement("div", null, _react.default.createElement("input", {
+      return _react["default"].createElement("div", null, _react["default"].createElement("div", null, _react["default"].createElement("input", {
         id: "field_for_" + field,
         type: "file",
         onChange: this.handleChange,
@@ -1526,14 +1536,14 @@ var S3FileInput = function (_React$Component3) {
         style: {
           'display': 'none'
         }
-      }), _react.default.createElement("button", {
+      }), _react["default"].createElement("button", {
         type: "submit",
         disabled: disableFile,
         style: {
           'padding': '0px'
         },
         className: "btn btn-outline-dark"
-      }, _react.default.createElement("label", {
+      }, _react["default"].createElement("label", {
         className: "text-400",
         htmlFor: "field_for_" + field,
         style: {
@@ -1543,44 +1553,44 @@ var S3FileInput = function (_React$Component3) {
           'paddingLeft': '12px',
           'marginBottom': '0px'
         }
-      }, filename_text)), _react.default.createElement(_Fade.Fade, {
-        in: showDelete
-      }, _react.default.createElement("div", {
+      }, filename_text)), _react["default"].createElement(_Fade.Fade, {
+        "in": showDelete
+      }, _react["default"].createElement("div", {
         className: "pull-right"
-      }, _react.default.createElement("button", {
+      }, _react["default"].createElement("button", {
         type: "button",
         className: "btn btn-danger",
         disabled: !showDelete,
         onClick: this.deleteField,
         tabIndex: 2
-      }, _react.default.createElement("i", {
+      }, _react["default"].createElement("i", {
         className: "icon icon-fw icon-times fas"
-      }))))), statusTip ? _react.default.createElement("div", {
+      }))))), statusTip ? _react["default"].createElement("div", {
         style: {
           'color': '#a94442',
           'paddingTop': '10px'
         }
-      }, statusTip) : null, md5Progress ? _react.default.createElement("div", {
+      }, statusTip) : null, md5Progress ? _react["default"].createElement("div", {
         style: {
           'paddingTop': '10px'
         }
-      }, _react.default.createElement("i", {
+      }, _react["default"].createElement("i", {
         className: "icon icon-spin icon-circle-o-notch",
         style: {
           'opacity': '0.5'
         }
-      }), _react.default.createElement("span", {
+      }), _react["default"].createElement("span", {
         style: {
           'paddingLeft': '10px'
         }
-      }, 'Calculating MD5... ' + md5Progress + '%')) : null, percentDone !== null ? _react.default.createElement("div", {
+      }, 'Calculating MD5... ' + md5Progress + '%')) : null, percentDone !== null ? _react["default"].createElement("div", {
         className: "row",
         style: {
           'paddingTop': '10px'
         }
-      }, _react.default.createElement("div", {
+      }, _react["default"].createElement("div", {
         className: "col-3 col-sm-3 pull-left"
-      }, _react.default.createElement("a", {
+      }, _react["default"].createElement("a", {
         href: "",
         style: {
           'color': '#a94442',
@@ -1588,13 +1598,13 @@ var S3FileInput = function (_React$Component3) {
         },
         onClick: this.cancelUpload,
         title: "Cancel"
-      }, 'Cancel upload')), _react.default.createElement("div", {
+      }, 'Cancel upload')), _react["default"].createElement("div", {
         className: "col-9 col-sm-9 pull-right"
-      }, _react.default.createElement("div", null, _react.default.createElement("div", {
+      }, _react["default"].createElement("div", null, _react["default"].createElement("div", {
         className: "pull-left"
-      }, percentDone + "% complete"), _react.default.createElement("div", {
+      }, percentDone + "% complete"), _react["default"].createElement("div", {
         className: "pull-right"
-      }, "Total size: " + sizeUploaded)), _react.default.createElement(_rcProgress.Line, {
+      }, "Total size: " + sizeUploaded)), _react["default"].createElement(_rcProgress.Line, {
         percent: percentDone,
         strokeWidth: "1",
         strokeColor: "#388a92"
@@ -1603,7 +1613,7 @@ var S3FileInput = function (_React$Component3) {
   }]);
 
   return S3FileInput;
-}(_react.default.Component);
+}(_react["default"].Component);
 
 var AliasInputField = function (_React$Component4) {
   _inherits(AliasInputField, _React$Component4);
@@ -1625,7 +1635,7 @@ var AliasInputField = function (_React$Component4) {
         return AliasInputField.emailToString(submitter.email);
       }
 
-      if (primaryLabID && primaryLab.name && _underscore.default.map(submits_for_list, _util.object.itemUtil.atId).indexOf(primaryLabID) > -1) {
+      if (primaryLabID && primaryLab.name && _underscore["default"].map(submits_for_list, _util.object.itemUtil.atId).indexOf(primaryLabID) > -1) {
         return primaryLab.name;
       } else {
         return submits_for_list[0].name;
@@ -1651,7 +1661,7 @@ var AliasInputField = function (_React$Component4) {
 
     _this11 = _possibleConstructorReturn(this, _getPrototypeOf(AliasInputField).call(this, props));
 
-    _underscore.default.bindAll(_assertThisInitialized(_this11), 'onAliasSecondPartChange', 'onAliasFirstPartChange', 'onAliasFirstPartChangeTyped', 'getInitialSubmitsForPart', 'finalizeAliasPartsChange');
+    _underscore["default"].bindAll(_assertThisInitialized(_this11), 'onAliasSecondPartChange', 'onAliasFirstPartChange', 'onAliasFirstPartChangeTyped', 'getInitialSubmitsForPart', 'finalizeAliasPartsChange');
 
     return _this11;
   }
@@ -1719,7 +1729,7 @@ var AliasInputField = function (_React$Component4) {
       var firstPartSelect;
 
       if (currentSubmittingUser && Array.isArray(currentSubmittingUser.groups) && currentSubmittingUser.groups.indexOf('admin') > -1) {
-        firstPartSelect = _react.default.createElement("input", {
+        firstPartSelect = _react["default"].createElement("input", {
           type: "text",
           inputMode: "latin",
           id: "firstPartSelect",
@@ -1733,45 +1743,45 @@ var AliasInputField = function (_React$Component4) {
           className: "form-control" + (errorMessage ? " is-invalid" : isValid ? " is-valid" : "")
         });
       } else if (submits_for_list && submits_for_list.length > 1) {
-        firstPartSelect = _react.default.createElement(_DropdownButton.DropdownButton, {
+        firstPartSelect = _react["default"].createElement(_DropdownButton.DropdownButton, {
           className: "alias-lab-select form-control alias-first-part-input" + (errorMessage ? " is-invalid" : ""),
           id: "firstPartSelect",
           onSelect: this.onAliasFirstPartChange,
           componentClass: _reactBootstrap.InputGroup.Button,
-          title: parts.length > 1 && _react.default.createElement("span", {
+          title: parts.length > 1 && _react["default"].createElement("span", {
             className: "text-400"
-          }, _react.default.createElement("small", {
+          }, _react["default"].createElement("small", {
             className: "pull-left"
-          }, "Lab: "), _react.default.createElement("span", {
+          }, "Lab: "), _react["default"].createElement("span", {
             className: "pull-right text-ellipsis-container",
             style: {
               maxWidth: '80%'
             }
           }, parts[0] !== '' && parts[0] || this.getInitialSubmitsForPart())) || 'Select a Lab'
-        }, _underscore.default.map(submits_for_list, function (lab) {
-          return _react.default.createElement(_DropdownButton.DropdownItem, {
+        }, _underscore["default"].map(submits_for_list, function (lab) {
+          return _react["default"].createElement(_DropdownButton.DropdownItem, {
             key: lab.name,
             eventKey: lab.name
-          }, _react.default.createElement("span", {
+          }, _react["default"].createElement("span", {
             className: "text-500"
           }, lab.name), " (", lab.display_title, ")");
         }));
       } else {
-        firstPartSelect = _react.default.createElement(_reactBootstrap.InputGroup.Addon, {
+        firstPartSelect = _react["default"].createElement(_reactBootstrap.InputGroup.Addon, {
           className: "alias-lab-single-option"
         }, currFirstPartValue);
       }
 
       var outerClassName = "mb-0 alias-input-field form-group has-feedback" + (errorMessage ? " is-invalid has-error" : isValid ? " is-valid" : "");
-      return _react.default.createElement("div", {
+      return _react["default"].createElement("div", {
         className: outerClassName
-      }, _react.default.createElement("div", {
+      }, _react["default"].createElement("div", {
         className: "input-group"
-      }, firstPartSelect, _react.default.createElement("div", {
+      }, firstPartSelect, _react["default"].createElement("div", {
         className: "input-group-prepend input-group-append input-group-addon colon-separator"
-      }, _react.default.createElement("span", {
+      }, _react["default"].createElement("span", {
         className: "input-group-text"
-      }, ":")), _react.default.createElement("input", {
+      }, ":")), _react["default"].createElement("input", {
         type: "text",
         id: "aliasInput",
         inputMode: "latin",
@@ -1780,28 +1790,28 @@ var AliasInputField = function (_React$Component4) {
         placeholder: "Type in a new identifier",
         onChange: this.onAliasSecondPartChange,
         className: "form-control" + (errorMessage ? " is-invalid" : isValid ? " is-valid" : "")
-      })), showErrorMsg && errorMessage ? _react.default.createElement("div", {
+      })), showErrorMsg && errorMessage ? _react["default"].createElement("div", {
         className: "invalid-feedback d-block text-right"
       }, errorMessage) : null);
     }
   }]);
 
   return AliasInputField;
-}(_react.default.Component);
+}(_react["default"].Component);
 
 exports.AliasInputField = AliasInputField;
 
 _defineProperty(AliasInputField, "propTypes", {
-  'value': _propTypes.default.string.isRequired,
-  'onAliasChange': _propTypes.default.func.isRequired,
-  'currentSubmittingUser': _propTypes.default.shape({
-    'submits_for': _propTypes.default.arrayOf(_propTypes.default.shape({
-      'name': _propTypes.default.string,
-      'display_title': _propTypes.default.string
+  'value': _propTypes["default"].string.isRequired,
+  'onAliasChange': _propTypes["default"].func.isRequired,
+  'currentSubmittingUser': _propTypes["default"].shape({
+    'submits_for': _propTypes["default"].arrayOf(_propTypes["default"].shape({
+      'name': _propTypes["default"].string,
+      'display_title': _propTypes["default"].string
     }))
   }).isRequired,
-  'errorMessage': _propTypes.default.string,
-  'isValid': _propTypes.default.bool
+  'errorMessage': _propTypes["default"].string,
+  'isValid': _propTypes["default"].bool
 });
 
 _defineProperty(AliasInputField, "defaultProps", {
@@ -1944,14 +1954,14 @@ var AliasInputFieldValidated = function (_React$PureComponent4) {
   }, {
     key: "render",
     value: function render() {
-      return _react.default.createElement(AliasInputField, _extends({}, this.props, this.state, {
+      return _react["default"].createElement(AliasInputField, _extends({}, this.props, this.state, {
         onAliasChange: this.onAliasChange
       }));
     }
   }]);
 
   return AliasInputFieldValidated;
-}(_react.default.PureComponent);
+}(_react["default"].PureComponent);
 
 exports.AliasInputFieldValidated = AliasInputFieldValidated;
 
@@ -2005,7 +2015,7 @@ var InfoIcon = function (_React$PureComponent5) {
         tip += '<h6 class="mt-07 text-300">Field Type: <span class="text-400">' + this.fieldTypeDescriptor() + '</span></h6>';
       }
 
-      return _react.default.createElement("i", {
+      return _react["default"].createElement("i", {
         className: "icon icon-info-circle fas" + (className ? ' ' + className : ''),
         "data-tip": tip,
         "data-html": true
@@ -2014,7 +2024,7 @@ var InfoIcon = function (_React$PureComponent5) {
   }]);
 
   return InfoIcon;
-}(_react.default.PureComponent);
+}(_react["default"].PureComponent);
 
 function isValueNull(value) {
   if (value === null) return true;
@@ -2023,15 +2033,15 @@ function isValueNull(value) {
   if (value === '') return true;
 
   if (Array.isArray(value)) {
-    if (value.length === 0) return true;else if (_underscore.default.every(value, isValueNull)) {
+    if (value.length === 0) return true;else if (_underscore["default"].every(value, isValueNull)) {
       return true;
     } else return false;
   }
 
   if (_typeof(value) === 'object') {
-    var keys = _underscore.default.keys(value);
+    var keys = _underscore["default"].keys(value);
 
-    if (keys.length === 0) return true;else if (_underscore.default.every(keys, function (k) {
+    if (keys.length === 0) return true;else if (_underscore["default"].every(keys, function (k) {
       return isValueNull(value[k]);
     })) return true;
   }

--- a/es/components/forms/components/submission-fields.js
+++ b/es/components/forms/components/submission-fields.js
@@ -722,18 +722,27 @@ var LinkedObj = function (_React$PureComponent2) {
   }, {
     key: "childWindowAlert",
     value: function childWindowAlert() {
-      return null;
+      var _this$props14 = this.props,
+          schema = _this$props14.schema,
+          nestedField = _this$props14.nestedField;
+      var itemType = schema && schema.linkTo;
+      var prettyTitle = schema && (schema.parentSchema && schema.parentSchema.title || schema.title);
+      return {
+        'title': 'Selecting ' + itemType + ' for field ' + (prettyTitle ? prettyTitle + ' ("' + nestedField + '")' : '"' + nestedField + '"'),
+        'message': null,
+        'style': 'info'
+      };
     }
   }, {
     key: "renderSelectInputField",
     value: function renderSelectInputField() {
-      var _this$props14 = this.props,
-          value = _this$props14.value,
-          selectCancel = _this$props14.selectCancel,
-          schema = _this$props14.schema,
-          currType = _this$props14.currType,
-          nestedField = _this$props14.nestedField,
-          isMultiSelect = _this$props14.isMultiSelect;
+      var _this$props15 = this.props,
+          value = _this$props15.value,
+          selectCancel = _this$props15.selectCancel,
+          schema = _this$props15.schema,
+          currType = _this$props15.currType,
+          nestedField = _this$props15.nestedField,
+          isMultiSelect = _this$props15.isMultiSelect;
       var textInputValue = this.state.textInputValue;
       var canShowAcceptTypedInput = typeof textInputValue === 'string' && textInputValue.length > 3;
       var extClass = !canShowAcceptTypedInput && textInputValue ? ' has-error' : '';
@@ -803,14 +812,14 @@ var LinkedObj = function (_React$PureComponent2) {
   }, {
     key: "render",
     value: function render() {
-      var _this$props15 = this.props,
-          value = _this$props15.value,
-          keyDisplay = _this$props15.keyDisplay,
-          keyComplete = _this$props15.keyComplete,
-          fieldBeingSelected = _this$props15.fieldBeingSelected,
-          nestedField = _this$props15.nestedField,
-          arrayIdx = _this$props15.arrayIdx,
-          fieldBeingSelectedArrayIdx = _this$props15.fieldBeingSelectedArrayIdx;
+      var _this$props16 = this.props,
+          value = _this$props16.value,
+          keyDisplay = _this$props16.keyDisplay,
+          keyComplete = _this$props16.keyComplete,
+          fieldBeingSelected = _this$props16.fieldBeingSelected,
+          nestedField = _this$props16.nestedField,
+          arrayIdx = _this$props16.arrayIdx,
+          fieldBeingSelectedArrayIdx = _this$props16.fieldBeingSelectedArrayIdx;
       var isSelecting = LinkedObj.isInSelectionField(fieldBeingSelected, nestedField, arrayIdx, fieldBeingSelectedArrayIdx);
 
       if (isSelecting) {
@@ -955,10 +964,10 @@ var ArrayField = function (_React$Component) {
   _createClass(ArrayField, [{
     key: "componentDidMount",
     value: function componentDidMount() {
-      var _this$props16 = this.props,
-          value = _this$props16.value,
-          field = _this$props16.field,
-          pushArrayValue = _this$props16.pushArrayValue;
+      var _this$props17 = this.props,
+          value = _this$props17.value,
+          field = _this$props17.field,
+          pushArrayValue = _this$props17.pushArrayValue;
 
       if (ArrayField.shouldPushArrayValue(value, field)) {
         pushArrayValue();
@@ -967,14 +976,14 @@ var ArrayField = function (_React$Component) {
   }, {
     key: "componentDidUpdate",
     value: function componentDidUpdate() {
-      var _this$props17 = this.props,
-          value = _this$props17.value,
-          field = _this$props17.field,
-          pushArrayValue = _this$props17.pushArrayValue,
-          modifyNewContext = _this$props17.modifyNewContext,
-          nestedField = _this$props17.nestedField,
-          schema = _this$props17.schema,
-          linkType = _this$props17.linkType;
+      var _this$props18 = this.props,
+          value = _this$props18.value,
+          field = _this$props18.field,
+          pushArrayValue = _this$props18.pushArrayValue,
+          modifyNewContext = _this$props18.modifyNewContext,
+          nestedField = _this$props18.nestedField,
+          schema = _this$props18.schema,
+          linkType = _this$props18.linkType;
 
       if (ArrayField.shouldPushArrayValue(value, field)) {
         pushArrayValue();
@@ -989,9 +998,9 @@ var ArrayField = function (_React$Component) {
   }, {
     key: "initiateArrayField",
     value: function initiateArrayField(arrayInfo, index, allItems) {
-      var _this$props18 = this.props,
-          propArrayIdx = _this$props18.arrayIdx,
-          schema = _this$props18.schema;
+      var _this$props19 = this.props,
+          propArrayIdx = _this$props19.arrayIdx,
+          schema = _this$props19.schema;
 
       var _arrayInfo = _slicedToArray(arrayInfo, 3),
           inArrValue = _arrayInfo[0],
@@ -1045,10 +1054,10 @@ var ArrayField = function (_React$Component) {
   }, {
     key: "generateAddButton",
     value: function generateAddButton() {
-      var _this$props19 = this.props,
-          _this$props19$value = _this$props19.value,
-          values = _this$props19$value === void 0 ? [] : _this$props19$value,
-          pushArrayValue = _this$props19.pushArrayValue;
+      var _this$props20 = this.props,
+          _this$props20$value = _this$props20.value,
+          values = _this$props20$value === void 0 ? [] : _this$props20$value,
+          pushArrayValue = _this$props20.pushArrayValue;
       return _react.default.createElement("div", {
         className: "add-array-item-button-container"
       }, _react.default.createElement("button", {
@@ -1062,9 +1071,9 @@ var ArrayField = function (_React$Component) {
   }, {
     key: "render",
     value: function render() {
-      var _this$props20 = this.props,
-          propSchema = _this$props20.schema,
-          propValue = _this$props20.value;
+      var _this$props21 = this.props,
+          propSchema = _this$props21.schema,
+          propValue = _this$props21.value;
       var schema = propSchema.items || {};
       var values = propValue || [];
 
@@ -1130,12 +1139,12 @@ var ObjectField = function (_React$PureComponent3) {
   _createClass(ObjectField, [{
     key: "componentDidMount",
     value: function componentDidMount() {
-      var _this$props21 = this.props,
-          value = _this$props21.value,
-          modifyNewContext = _this$props21.modifyNewContext,
-          nestedField = _this$props21.nestedField,
-          linkType = _this$props21.linkType,
-          arrayIdx = _this$props21.arrayIdx;
+      var _this$props22 = this.props,
+          value = _this$props22.value,
+          modifyNewContext = _this$props22.modifyNewContext,
+          nestedField = _this$props22.nestedField,
+          linkType = _this$props22.linkType,
+          arrayIdx = _this$props22.arrayIdx;
       modifyNewContext(nestedField, value || {}, 'object', linkType, arrayIdx);
     }
   }, {
@@ -1152,11 +1161,11 @@ var ObjectField = function (_React$PureComponent3) {
     value: function render() {
       var _this6 = this;
 
-      var _this$props22 = this.props,
-          objectSchema = _this$props22.schema,
-          parentObject = _this$props22.value,
-          propNestedField = _this$props22.nestedField,
-          isMultiSelect = _this$props22.isMultiSelect;
+      var _this$props23 = this.props,
+          objectSchema = _this$props23.schema,
+          parentObject = _this$props23.value,
+          propNestedField = _this$props23.nestedField,
+          isMultiSelect = _this$props23.isMultiSelect;
       var allFieldsInSchema = objectSchema['properties'] ? _underscore.default.keys(objectSchema['properties']) : [];
 
       var fieldsToBuild = _underscore.default.filter(_underscore.default.map(allFieldsInSchema, function (f) {
@@ -1284,9 +1293,9 @@ var AttachmentInput = function (_React$Component2) {
   }, {
     key: "render",
     value: function render() {
-      var _this$props23 = this.props,
-          value = _this$props23.value,
-          field = _this$props23.field;
+      var _this$props24 = this.props,
+          value = _this$props24.value,
+          field = _this$props24.field;
       var attach_title;
 
       if (value && value.download) {
@@ -1348,9 +1357,9 @@ var S3FileInput = function (_React$Component3) {
   _createClass(S3FileInput, [{
     key: "componentDidUpdate",
     value: function componentDidUpdate(pastProps) {
-      var _this$props24 = this.props,
-          upload = _this$props24.upload,
-          uploadStatus = _this$props24.uploadStatus;
+      var _this$props25 = this.props,
+          upload = _this$props25.upload,
+          uploadStatus = _this$props25.uploadStatus;
       var pastUpload = pastProps.upload,
           pastUploadStatus = pastProps.uploadStatus;
 
@@ -1386,12 +1395,12 @@ var S3FileInput = function (_React$Component3) {
     value: function handleChange(e) {
       var _this9 = this;
 
-      var _this$props25 = this.props,
-          modifyNewContext = _this$props25.modifyNewContext,
-          nestedField = _this$props25.nestedField,
-          linkType = _this$props25.linkType,
-          arrayIdx = _this$props25.arrayIdx,
-          currContext = _this$props25.currContext;
+      var _this$props26 = this.props,
+          modifyNewContext = _this$props26.modifyNewContext,
+          nestedField = _this$props26.nestedField,
+          linkType = _this$props26.linkType,
+          arrayIdx = _this$props26.arrayIdx,
+          currContext = _this$props26.currContext;
       var file = e.target.files[0];
       if (!file) return;
       var filename = file.name ? file.name : "unknown";
@@ -1482,11 +1491,11 @@ var S3FileInput = function (_React$Component3) {
   }, {
     key: "render",
     value: function render() {
-      var _this$props26 = this.props,
-          value = _this$props26.value,
-          md5Progress = _this$props26.md5Progress,
-          upload = _this$props26.upload,
-          field = _this$props26.field;
+      var _this$props27 = this.props,
+          value = _this$props27.value,
+          md5Progress = _this$props27.md5Progress,
+          upload = _this$props27.upload,
+          field = _this$props27.field;
       var _this$state = this.state,
           newFile = _this$state.newFile,
           percentDone = _this$state.percentDone,
@@ -1696,13 +1705,13 @@ var AliasInputField = function (_React$Component4) {
   }, {
     key: "render",
     value: function render() {
-      var _this$props27 = this.props,
-          currentSubmittingUser = _this$props27.currentSubmittingUser,
-          errorMessage = _this$props27.errorMessage,
-          withinModal = _this$props27.withinModal,
-          value = _this$props27.value,
-          isValid = _this$props27.isValid,
-          showErrorMsg = _this$props27.showErrorMsg;
+      var _this$props28 = this.props,
+          currentSubmittingUser = _this$props28.currentSubmittingUser,
+          errorMessage = _this$props28.errorMessage,
+          withinModal = _this$props28.withinModal,
+          value = _this$props28.value,
+          isValid = _this$props28.isValid,
+          showErrorMsg = _this$props28.showErrorMsg;
       var parts = AliasInputField.splitInTwo(value);
       var submits_for_list = currentSubmittingUser && Array.isArray(currentSubmittingUser.submits_for) && currentSubmittingUser.submits_for.length > 0 && currentSubmittingUser.submits_for || null;
       var initialDefaultFirstPartValue = this.getInitialSubmitsForPart();
@@ -1824,9 +1833,9 @@ var AliasInputFieldValidated = function (_React$PureComponent4) {
     value: function doValidateAlias(alias) {
       var _this13 = this;
 
-      var _this$props28 = this.props,
-          onAliasChange = _this$props28.onAliasChange,
-          errorValue = _this$props28.errorValue;
+      var _this$props29 = this.props,
+          onAliasChange = _this$props29.onAliasChange,
+          errorValue = _this$props29.errorValue;
 
       if (this.request) {
         this.request.abort();
@@ -1868,13 +1877,13 @@ var AliasInputFieldValidated = function (_React$PureComponent4) {
     value: function (nextAlias) {
       var _this14 = this;
 
-      var _this$props29 = this.props,
-          onAliasChange = _this$props29.onAliasChange,
-          errorValue = _this$props29.errorValue,
-          _this$props29$skipVal = _this$props29.skipValidateAliases,
-          skipValidateAliases = _this$props29$skipVal === void 0 ? [] : _this$props29$skipVal,
-          _this$props29$rejectA = _this$props29.rejectAliases,
-          rejectAliases = _this$props29$rejectA === void 0 ? [] : _this$props29$rejectA;
+      var _this$props30 = this.props,
+          onAliasChange = _this$props30.onAliasChange,
+          errorValue = _this$props30.errorValue,
+          _this$props30$skipVal = _this$props30.skipValidateAliases,
+          skipValidateAliases = _this$props30$skipVal === void 0 ? [] : _this$props30$skipVal,
+          _this$props30$rejectA = _this$props30.rejectAliases,
+          rejectAliases = _this$props30$rejectA === void 0 ? [] : _this$props30$rejectA;
       this.request && this.request.abort();
       this.request = null;
       this.setState({
@@ -1964,9 +1973,9 @@ var InfoIcon = function (_React$PureComponent5) {
   _createClass(InfoIcon, [{
     key: "fieldTypeDescriptor",
     value: function fieldTypeDescriptor() {
-      var _this$props30 = this.props,
-          fieldType = _this$props30.fieldType,
-          schema = _this$props30.schema;
+      var _this$props31 = this.props,
+          fieldType = _this$props31.fieldType,
+          schema = _this$props31.schema;
       if (typeof fieldType !== 'string' || fieldType.length === 0) return null;
 
       var type = _util.valueTransforms.capitalizeSentence(fieldType === 'array' ? ArrayField.typeOfItems(schema.items) : fieldType);
@@ -1980,11 +1989,11 @@ var InfoIcon = function (_React$PureComponent5) {
   }, {
     key: "render",
     value: function render() {
-      var _this$props31 = this.props,
-          children = _this$props31.children,
-          title = _this$props31.title,
-          fieldType = _this$props31.fieldType,
-          className = _this$props31.className;
+      var _this$props32 = this.props,
+          children = _this$props32.children,
+          title = _this$props32.title,
+          fieldType = _this$props32.fieldType,
+          className = _this$props32.className;
       if (!children || typeof children !== 'string') return null;
       var tip = children;
 

--- a/es/components/forms/components/submission-fields.js
+++ b/es/components/forms/components/submission-fields.js
@@ -32,7 +32,7 @@ var _rcProgress = require("rc-progress");
 
 var _LinkToSelector = require("./LinkToSelector");
 
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function (obj) { return typeof obj; }; } else { _typeof = function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
@@ -80,7 +80,7 @@ var BuildField = function (_React$PureComponent) {
         }
       }
 
-      if (fieldSchema["enum"] || fieldSchema.suggested_enum) {
+      if (fieldSchema.enum || fieldSchema.suggested_enum) {
         fieldType = 'enum';
       }
 
@@ -101,19 +101,19 @@ var BuildField = function (_React$PureComponent) {
 
     _this = _possibleConstructorReturn(this, _getPrototypeOf(BuildField).call(this, props));
 
-    _underscore["default"].bindAll(_assertThisInitialized(_this), 'displayField', 'handleDropdownButtonToggle', 'handleAliasChange', 'buildEnumEntry', 'submitEnumVal', 'handleChange', 'handleAliasChange', 'deleteField', 'pushArrayValue', 'commonRowProps', 'labelTypeDescriptor', 'wrapWithLabel', 'wrapWithNoLabel');
+    _underscore.default.bindAll(_assertThisInitialized(_this), 'displayField', 'handleDropdownButtonToggle', 'handleAliasChange', 'buildEnumEntry', 'submitEnumVal', 'handleChange', 'handleAliasChange', 'deleteField', 'pushArrayValue', 'commonRowProps', 'labelTypeDescriptor', 'wrapWithLabel', 'wrapWithNoLabel');
 
     _this.state = {
       'dropdownOpen': false
     };
-    _this.inputElementRef = _react["default"].createRef();
+    _this.inputElementRef = _react.default.createRef();
     return _this;
   }
 
   _createClass(BuildField, [{
     key: "componentDidMount",
     value: function componentDidMount() {
-      _reactTooltip["default"].rebuild();
+      _reactTooltip.default.rebuild();
     }
   }, {
     key: "handleDropdownButtonToggle",
@@ -158,7 +158,7 @@ var BuildField = function (_React$PureComponent) {
         var filetype = currContext && currContext.options && currContext.options.filetype;
 
         if (filetype === 'md' || filetype === 'html') {
-          return _react["default"].createElement(PreviewField, _extends({}, this.props, {
+          return _react.default.createElement(PreviewField, _extends({}, this.props, {
             filetype: filetype,
             onChange: this.handleChange
           }));
@@ -168,22 +168,22 @@ var BuildField = function (_React$PureComponent) {
       switch (fieldType) {
         case 'text':
           if (field === 'aliases') {
-            return _react["default"].createElement("div", {
+            return _react.default.createElement("div", {
               className: "input-wrapper"
-            }, _react["default"].createElement(AliasInputField, _extends({}, inputProps, {
+            }, _react.default.createElement(AliasInputField, _extends({}, inputProps, {
               onAliasChange: this.handleAliasChange,
               currentSubmittingUser: currentSubmittingUser
             })));
           }
 
-          return _react["default"].createElement("input", _extends({}, inputProps, {
+          return _react.default.createElement("input", _extends({}, inputProps, {
             type: "text",
             className: "form-control",
             inputMode: "latin"
           }));
 
         case 'textarea':
-          return _react["default"].createElement("textarea", _extends({}, inputProps, {
+          return _react.default.createElement("textarea", _extends({}, inputProps, {
             type: "text",
             inputMode: "latin",
             rows: 4,
@@ -192,7 +192,7 @@ var BuildField = function (_React$PureComponent) {
 
         case 'html':
         case 'code':
-          return _react["default"].createElement("textarea", _extends({}, inputProps, {
+          return _react.default.createElement("textarea", _extends({}, inputProps, {
             type: "text",
             inputMode: "latin",
             rows: 8,
@@ -205,21 +205,21 @@ var BuildField = function (_React$PureComponent) {
           }));
 
         case 'integer':
-          return _react["default"].createElement(_reactBootstrap.FormControl, _extends({
+          return _react.default.createElement(_reactBootstrap.FormControl, _extends({
             type: "number"
           }, inputProps, {
             step: 1
           }));
 
         case 'number':
-          return _react["default"].createElement(_reactBootstrap.FormControl, _extends({
+          return _react.default.createElement(_reactBootstrap.FormControl, _extends({
             type: "number"
           }, inputProps));
 
         case 'boolean':
-          return _react["default"].createElement(_Checkbox.Checkbox, _extends({}, _underscore["default"].omit(inputProps, 'value', 'placeholder'), {
+          return _react.default.createElement(_Checkbox.Checkbox, _extends({}, _underscore.default.omit(inputProps, 'value', 'placeholder'), {
             checked: !!value
-          }), _react["default"].createElement("span", {
+          }), _react.default.createElement("span", {
             style: {
               'verticalAlign': 'middle',
               'textTransform': 'capitalize'
@@ -227,50 +227,50 @@ var BuildField = function (_React$PureComponent) {
           }, typeof value === 'boolean' ? value + '' : null));
 
         case 'enum':
-          return _react["default"].createElement("span", {
+          return _react.default.createElement("span", {
             className: "input-wrapper"
-          }, _react["default"].createElement(_DropdownButton.DropdownButton, {
-            title: value || _react["default"].createElement("span", {
+          }, _react.default.createElement(_DropdownButton.DropdownButton, {
+            title: value || _react.default.createElement("span", {
               className: "text-300"
             }, "No value"),
             onToggle: this.handleDropdownButtonToggle,
             variant: "outline-dark"
-          }, _underscore["default"].map(enumValues, function (val) {
+          }, _underscore.default.map(enumValues, function (val) {
             return _this2.buildEnumEntry(val);
           })));
 
         case 'linked object':
-          return _react["default"].createElement(LinkedObj, _extends({
+          return _react.default.createElement(LinkedObj, _extends({
             key: "linked-item"
           }, this.props));
 
         case 'array':
-          return _react["default"].createElement(ArrayField, _extends({}, this.props, {
+          return _react.default.createElement(ArrayField, _extends({}, this.props, {
             pushArrayValue: this.pushArrayValue,
             value: value || null,
             roundTwo: roundTwo
           }));
 
         case 'object':
-          return _react["default"].createElement(ObjectField, this.props);
+          return _react.default.createElement(ObjectField, this.props);
 
         case 'attachment':
-          return _react["default"].createElement("div", {
+          return _react.default.createElement("div", {
             style: {
               'display': 'inline'
             }
-          }, _react["default"].createElement(AttachmentInput, this.props));
+          }, _react.default.createElement(AttachmentInput, this.props));
 
         case 'file upload':
-          return _react["default"].createElement(S3FileInput, this.props);
+          return _react.default.createElement(S3FileInput, this.props);
       }
 
-      return _react["default"].createElement("div", null, "No field for this case yet.");
+      return _react.default.createElement("div", null, "No field for this case yet.");
     }
   }, {
     key: "buildEnumEntry",
     value: function buildEnumEntry(val) {
-      return _react["default"].createElement(_DropdownButton.DropdownItem, {
+      return _react.default.createElement(_DropdownButton.DropdownItem, {
         key: val,
         title: val || '',
         eventKey: val,
@@ -389,9 +389,9 @@ var BuildField = function (_React$PureComponent) {
     key: "labelTypeDescriptor",
     value: function labelTypeDescriptor() {
       var required = this.props.required;
-      return _react["default"].createElement("div", {
+      return _react.default.createElement("div", {
         className: "field-descriptor"
-      }, required ? _react["default"].createElement("span", {
+      }, required ? _react.default.createElement("span", {
         style: {
           'color': '#a94442'
         }
@@ -405,27 +405,27 @@ var BuildField = function (_React$PureComponent) {
           title = _this$props8.title,
           fieldType = _this$props8.fieldType,
           schema = _this$props8.schema;
-      return _react["default"].createElement("div", this.commonRowProps(), _react["default"].createElement("div", {
+      return _react.default.createElement("div", this.commonRowProps(), _react.default.createElement("div", {
         className: "row"
-      }, _react["default"].createElement("div", {
+      }, _react.default.createElement("div", {
         className: "col-12 col-md-4"
-      }, _react["default"].createElement("h5", {
+      }, _react.default.createElement("h5", {
         className: "submission-field-title text-ellipsis-container"
-      }, this.labelTypeDescriptor(), fieldTip ? _react["default"].createElement(InfoIcon, {
+      }, this.labelTypeDescriptor(), fieldTip ? _react.default.createElement(InfoIcon, {
         className: "mr-07",
         title: title,
         fieldType: fieldType,
         schema: schema
-      }, fieldTip) : null, _react["default"].createElement("span", null, title))), _react["default"].createElement("div", {
+      }, fieldTip) : null, _react.default.createElement("span", null, title))), _react.default.createElement("div", {
         className: "col-12 col-md-8"
-      }, _react["default"].createElement("div", {
+      }, _react.default.createElement("div", {
         className: "row field-container"
       }, Array.prototype.slice.call(arguments)))));
     }
   }, {
     key: "wrapWithNoLabel",
     value: function wrapWithNoLabel() {
-      return _react["default"].createElement("div", this.commonRowProps(), Array.prototype.slice.call(arguments));
+      return _react.default.createElement("div", this.commonRowProps(), Array.prototype.slice.call(arguments));
     }
   }, {
     key: "render",
@@ -444,7 +444,7 @@ var BuildField = function (_React$PureComponent) {
       var disableDelete = false;
       var extClass = '';
 
-      if (!_underscore["default"].contains(['filename'], field) && fieldType !== 'array') {
+      if (!_underscore.default.contains(['filename'], field) && fieldType !== 'array') {
         showDelete = true;
       }
 
@@ -477,9 +477,9 @@ var BuildField = function (_React$PureComponent) {
         extClass += ' in-selection-field';
       }
 
-      return wrapFunc(_react["default"].createElement(_react["default"].Fragment, null, _react["default"].createElement("div", {
+      return wrapFunc(_react.default.createElement(_react.default.Fragment, null, _react.default.createElement("div", {
         className: 'field-column col' + extClass
-      }, fieldToDisplay), fieldType === 'array' || fieldType === 'file upload' ? null : _react["default"].createElement(SquareButton, {
+      }, fieldToDisplay), fieldType === 'array' || fieldType === 'file upload' ? null : _react.default.createElement(SquareButton, {
         show: showDelete,
         disabled: disableDelete,
         tip: isArray ? 'Remove Item' : 'Clear Value',
@@ -489,11 +489,11 @@ var BuildField = function (_React$PureComponent) {
   }]);
 
   return BuildField;
-}(_react["default"].PureComponent);
+}(_react.default.PureComponent);
 
 exports.BuildField = BuildField;
 
-var SquareButton = _react["default"].memo(function (props) {
+var SquareButton = _react.default.memo(function (props) {
   var show = props.show,
       disabled = props.disabled,
       onClick = props.onClick,
@@ -510,21 +510,21 @@ var SquareButton = _react["default"].memo(function (props) {
     btnCls += " btn-" + bsStyle;
   }
 
-  return _react["default"].createElement("div", {
+  return _react.default.createElement("div", {
     className: "remove-button-column" + (!show ? ' hidden' : ''),
     style: style
-  }, _react["default"].createElement(_Fade.Fade, {
-    "in": show
-  }, _react["default"].createElement("div", {
+  }, _react.default.createElement(_Fade.Fade, {
+    in: show
+  }, _react.default.createElement("div", {
     className: outerCls
-  }, _react["default"].createElement("button", {
+  }, _react.default.createElement("button", {
     type: "button",
     disabled: disabled || !show,
     onClick: onClick,
     "data-tip": tip,
     tabIndex: 2,
     className: btnCls
-  }, _react["default"].createElement("i", {
+  }, _react.default.createElement("i", {
     className: "icon icon-fw icon-" + icon
   })))));
 });
@@ -550,7 +550,7 @@ var LinkedObj = function (_React$PureComponent2) {
       }
 
       if (Array.isArray(arrayIdx) && Array.isArray(fieldBeingSelectedArrayIdx)) {
-        return _underscore["default"].every(arrayIdx, function (arrIdx, arrIdxIdx) {
+        return _underscore.default.every(arrayIdx, function (arrIdx, arrIdxIdx) {
           return arrIdx === fieldBeingSelectedArrayIdx[arrIdxIdx];
         });
       }
@@ -589,7 +589,7 @@ var LinkedObj = function (_React$PureComponent2) {
     value: function componentDidUpdate() {
       this.updateContext();
 
-      _reactTooltip["default"].rebuild();
+      _reactTooltip.default.rebuild();
     }
   }, {
     key: "updateContext",
@@ -605,7 +605,7 @@ var LinkedObj = function (_React$PureComponent2) {
       if (keyComplete[value] && !isNaN(value)) {
         modifyNewContext(nestedField, keyComplete[value], 'finished linked object', linkType, arrayIdx);
 
-        _reactTooltip["default"].rebuild();
+        _reactTooltip.default.rebuild();
       }
     }
   }, {
@@ -636,55 +636,67 @@ var LinkedObj = function (_React$PureComponent2) {
   }, {
     key: "handleFinishSelectItem",
     value: function handleFinishSelectItem(items) {
-      var selectComplete = this.props.selectComplete;
+      var _this$props12 = this.props,
+          selectComplete = _this$props12.selectComplete,
+          isMultiSelect = _this$props12.isMultiSelect;
 
-      if (!items || !Array.isArray(items) || items.length === 0 || !_underscore["default"].every(items, function (item) {
+      if (!items || !Array.isArray(items) || items.length === 0 || !_underscore.default.every(items, function (item) {
         return item.id && typeof item.id === 'string' && item.json;
       })) {
         return;
       }
 
-      var _items = _slicedToArray(items, 1),
-          _items$ = _items[0],
-          atId = _items$.id,
-          itemContext = _items$.json;
+      var atIds;
 
-      if (items.length > 1) {
-        _util.console.warn('Multiple documents selected but we only get a single item, since handler\'s multiple version not implemented yet!');
+      if (!(isMultiSelect || false)) {
+        if (items.length > 1) {
+          _util.console.warn('Multiple items selected but we only get a single item, since handler\'s not supporting multiple items!');
+        }
+
+        var _items = _slicedToArray(items, 1),
+            _items$ = _items[0],
+            atId = _items$.id,
+            itemContext = _items$.json;
+
+        atIds = [atId];
+      } else {
+        atIds = _underscore.default.pluck(items, "id");
       }
-
-      var isValidAtId = _util.object.isValidAtIDFormat(atId);
 
       var invalidTitle = "Invalid Item Selected";
 
-      if (!atId || !isValidAtId) {
+      if (_underscore.default.every(atIds, function (atId) {
+        var isValidAtId = _util.object.isValidAtIDFormat(atId);
+
+        return atId && isValidAtId;
+      })) {
+        _Alerts.Alerts.deQueue({
+          'title': invalidTitle
+        });
+
+        selectComplete(atIds);
+      } else {
         _Alerts.Alerts.queue({
           'title': invalidTitle,
-          'message': "You have dragged & dropped an item or link which doesn't have a valid 4DN ID or URL associated with it. Please try again.",
+          'message': "You have selected an item or link which doesn't have a valid 4DN ID or URL associated with it. Please try again.",
           'style': 'danger'
         });
 
         throw new Error('No valid @id available.');
-      } else {
-        _Alerts.Alerts.deQueue({
-          'title': invalidTitle
-        });
       }
-
-      selectComplete(atId);
     }
   }, {
     key: "handleCreateNewItemClick",
     value: function handleCreateNewItemClick(e) {
       e.preventDefault();
-      var _this$props12 = this.props,
-          fieldBeingSelected = _this$props12.fieldBeingSelected,
-          selectCancel = _this$props12.selectCancel,
-          modifyNewContext = _this$props12.modifyNewContext,
-          nestedField = _this$props12.nestedField,
-          linkType = _this$props12.linkType,
-          arrayIdx = _this$props12.arrayIdx,
-          schema = _this$props12.schema;
+      var _this$props13 = this.props,
+          fieldBeingSelected = _this$props13.fieldBeingSelected,
+          selectCancel = _this$props13.selectCancel,
+          modifyNewContext = _this$props13.modifyNewContext,
+          nestedField = _this$props13.nestedField,
+          linkType = _this$props13.linkType,
+          arrayIdx = _this$props13.arrayIdx,
+          schema = _this$props13.schema;
       if (fieldBeingSelected !== null) selectCancel();
       modifyNewContext(nestedField, null, 'new linked object', linkType, arrayIdx, schema.linkTo);
     }
@@ -697,7 +709,8 @@ var LinkedObj = function (_React$PureComponent2) {
         throw new Error('Invalid @id format.');
       }
 
-      this.props.selectComplete(this.state.textInputValue);
+      var atIds = [this.state.textInputValue];
+      this.props.selectComplete(atIds);
     }
   }, {
     key: "handleTextInputChange",
@@ -709,20 +722,7 @@ var LinkedObj = function (_React$PureComponent2) {
   }, {
     key: "childWindowAlert",
     value: function childWindowAlert() {
-      var _this$props13 = this.props,
-          schema = _this$props13.schema,
-          nestedField = _this$props13.nestedField;
-      var itemType = schema && schema.linkTo;
-      var prettyTitle = schema && (schema.parentSchema && schema.parentSchema.title || schema.title);
-      return {
-        'title': 'Selecting ' + itemType + ' for field ' + (prettyTitle ? prettyTitle + ' ("' + nestedField + '")' : '"' + nestedField + '"'),
-        'message': _react["default"].createElement("div", null, _react["default"].createElement("p", {
-          className: "mb-0"
-        }, "Please either ", _react["default"].createElement("b", null, "drag and drop"), " an Item (row) from this window into the submissions window or click its corresponding select (checkbox) button."), _react["default"].createElement("p", {
-          className: "mb-0"
-        }, "You may also browse around and drag & drop a link into the submissions window as well.")),
-        'style': 'info'
-      };
+      return null;
     }
   }, {
     key: "renderSelectInputField",
@@ -730,16 +730,16 @@ var LinkedObj = function (_React$PureComponent2) {
       var _this$props14 = this.props,
           value = _this$props14.value,
           selectCancel = _this$props14.selectCancel,
-          selectComplete = _this$props14.selectComplete,
           schema = _this$props14.schema,
           currType = _this$props14.currType,
-          nestedField = _this$props14.nestedField;
+          nestedField = _this$props14.nestedField,
+          isMultiSelect = _this$props14.isMultiSelect;
       var textInputValue = this.state.textInputValue;
       var canShowAcceptTypedInput = typeof textInputValue === 'string' && textInputValue.length > 3;
       var extClass = !canShowAcceptTypedInput && textInputValue ? ' has-error' : '';
       var itemType = schema.linkTo;
       var prettyTitle = schema && (schema.parentSchema && schema.parentSchema.title || schema.title);
-      var searchURL = '/search/?currentAction=selection&type=' + itemType;
+      var searchURL = '/search/?currentAction=' + (isMultiSelect ? 'multiselect' : 'selection') + '&type=' + itemType;
 
       if (schema.ff_flag && schema.ff_flag.startsWith('filter:')) {
         if (schema.ff_flag == "filter:valid_item_types") {
@@ -747,11 +747,11 @@ var LinkedObj = function (_React$PureComponent2) {
         }
       }
 
-      return _react["default"].createElement(_react["default"].Fragment, null, _react["default"].createElement("div", {
+      return _react.default.createElement(_react.default.Fragment, null, _react.default.createElement("div", {
         className: "linked-object-text-input-container row flexrow"
-      }, _react["default"].createElement("div", {
+      }, _react.default.createElement("div", {
         className: "field-column col"
-      }, _react["default"].createElement("input", {
+      }, _react.default.createElement("input", {
         onChange: this.handleTextInputChange,
         className: "form-control" + extClass,
         inputMode: "latin",
@@ -759,20 +759,20 @@ var LinkedObj = function (_React$PureComponent2) {
         placeholder: "Drag & drop Item from the search view or type in a valid @ID.",
         value: this.state.textInputValue,
         onDrop: this.handleDrop
-      })), canShowAcceptTypedInput ? _react["default"].createElement(SquareButton, {
+      })), canShowAcceptTypedInput ? _react.default.createElement(SquareButton, {
         show: true,
         onClick: this.handleAcceptTypedID,
         icon: "check fas",
         bsStyle: "success",
         tip: "Accept typed identifier and look it up in database."
-      }) : null, _react["default"].createElement(SquareButton, {
+      }) : null, _react.default.createElement(SquareButton, {
         show: true,
         onClick: selectCancel,
         tip: "Cancel selection",
         style: {
           'marginRight': 9
         }
-      })), _react["default"].createElement(_LinkToSelector.LinkToSelector, {
+      })), _react.default.createElement(_LinkToSelector.LinkToSelector, {
         isSelecting: true,
         onSelect: this.handleFinishSelectItem,
         onCloseChildWindow: selectCancel,
@@ -784,19 +784,19 @@ var LinkedObj = function (_React$PureComponent2) {
   }, {
     key: "renderEmptyField",
     value: function renderEmptyField() {
-      return _react["default"].createElement("div", {
+      return _react.default.createElement("div", {
         className: "linked-object-buttons-container"
-      }, _react["default"].createElement("button", {
+      }, _react.default.createElement("button", {
         type: "button",
         className: "btn btn-outline-dark select-create-linked-item-button",
         onClick: this.handleStartSelectItem
-      }, _react["default"].createElement("i", {
+      }, _react.default.createElement("i", {
         className: "icon icon-fw icon-search fas"
-      }), " Select existing"), _react["default"].createElement("button", {
+      }), " Select existing"), _react.default.createElement("button", {
         type: "button",
         className: "btn btn-outline-dark select-create-linked-item-button",
         onClick: this.handleCreateNewItemClick
-      }, _react["default"].createElement("i", {
+      }, _react.default.createElement("i", {
         className: "icon icon-fw icon-file far"
       }), " Create new"));
     }
@@ -821,40 +821,40 @@ var LinkedObj = function (_React$PureComponent2) {
         var thisDisplay = keyDisplay[value] ? keyDisplay[value] + " (<code>" + value + "</code>)" : "<code>" + value + "</code>";
 
         if (isNaN(value)) {
-          return _react["default"].createElement("div", {
+          return _react.default.createElement("div", {
             className: "submitted-linked-object-display-container text-ellipsis-container"
-          }, _react["default"].createElement("i", {
+          }, _react.default.createElement("i", {
             className: "icon icon-fw icon-hdd far mr-05"
-          }), _react["default"].createElement("a", {
+          }), _react.default.createElement("a", {
             href: value,
             target: "_blank",
             rel: "noopener noreferrer",
             "data-tip": thisDisplay + " is already in the database",
             "data-html": true
-          }, keyDisplay[value] || value), _react["default"].createElement("i", {
+          }, keyDisplay[value] || value), _react.default.createElement("i", {
             className: "icon icon-fw icon-external-link-alt ml-05 fas"
           }));
         } else {
           var intKey = parseInt(value);
 
           if (keyComplete[intKey]) {
-            return _react["default"].createElement("div", null, _react["default"].createElement("a", {
+            return _react.default.createElement("div", null, _react.default.createElement("a", {
               href: keyComplete[intKey],
               target: "_blank",
               rel: "noopener noreferrer"
-            }, thisDisplay), _react["default"].createElement("i", {
+            }, thisDisplay), _react.default.createElement("i", {
               className: "icon icon-fw icon-external-link-alt ml-05 fas"
             }));
           } else {
-            return _react["default"].createElement("div", {
+            return _react.default.createElement("div", {
               className: "incomplete-linked-object-display-container text-ellipsis-container"
-            }, _react["default"].createElement("i", {
+            }, _react.default.createElement("i", {
               className: "icon icon-fw icon-sticky-note far"
-            }), "\xA0\xA0", _react["default"].createElement("a", {
+            }), "\xA0\xA0", _react.default.createElement("a", {
               href: "#",
               onClick: this.setSubmissionStateToLinkedToItem,
               "data-tip": "Continue editing/submitting"
-            }, thisDisplay), "\xA0", _react["default"].createElement("i", {
+            }, thisDisplay), "\xA0", _react.default.createElement("i", {
               style: {
                 'fontSize': '0.85rem'
               },
@@ -869,26 +869,26 @@ var LinkedObj = function (_React$PureComponent2) {
   }]);
 
   return LinkedObj;
-}(_react["default"].PureComponent);
+}(_react.default.PureComponent);
 
-var PreviewField = _react["default"].memo(function (props) {
+var PreviewField = _react.default.memo(function (props) {
   var value = props.value,
       filetype = props.filetype,
       field = props.field,
       onChange = props.onChange;
 
-  var preview = value && _react["default"].createElement(_react["default"].Fragment, null, _react["default"].createElement("h6", {
+  var preview = value && _react.default.createElement(_react.default.Fragment, null, _react.default.createElement("h6", {
     className: "mt-1 text-600"
-  }, "Preview:"), _react["default"].createElement("hr", {
+  }, "Preview:"), _react.default.createElement("hr", {
     className: "mb-1 mt-05"
-  }), _react["default"].createElement(_BasicStaticSectionBody.BasicStaticSectionBody, {
+  }), _react.default.createElement(_BasicStaticSectionBody.BasicStaticSectionBody, {
     content: value || '',
     filetype: filetype
   }));
 
-  return _react["default"].createElement("div", {
+  return _react.default.createElement("div", {
     className: "preview-field-container"
-  }, _react["default"].createElement(_reactBootstrap.FormControl, {
+  }, _react.default.createElement(_reactBootstrap.FormControl, {
     onChange: onChange,
     id: "field_for_" + field,
     name: field,
@@ -917,7 +917,7 @@ var ArrayField = function (_React$Component) {
         fieldType = 'text';
       }
 
-      if (itemSchema["enum"]) {
+      if (itemSchema.enum) {
         fieldType = 'enum';
       }
 
@@ -947,7 +947,7 @@ var ArrayField = function (_React$Component) {
 
     _this4 = _possibleConstructorReturn(this, _getPrototypeOf(ArrayField).call(this, props));
 
-    _underscore["default"].bindAll(_assertThisInitialized(_this4), 'initiateArrayField', 'generateAddButton');
+    _underscore.default.bindAll(_assertThisInitialized(_this4), 'initiateArrayField', 'generateAddButton');
 
     return _this4;
   }
@@ -1006,7 +1006,7 @@ var ArrayField = function (_React$Component) {
 
       var title = fieldSchema.title || 'Item';
       var fieldType = ArrayField.typeOfItems(fieldSchema);
-      var enumValues = fieldSchema["enum"] ? fieldSchema["enum"] || [] : [];
+      var enumValues = fieldSchema.enum ? fieldSchema.enum || [] : [];
       var arrayIdxList;
 
       if (propArrayIdx) {
@@ -1017,28 +1017,29 @@ var ArrayField = function (_React$Component) {
 
       arrayIdxList.push(arrayIdx);
 
-      var childFieldSchema = _underscore["default"].extend({}, fieldSchema, {
+      var childFieldSchema = _underscore.default.extend({}, fieldSchema, {
         'parentSchema': schema
       });
 
-      return _react["default"].createElement("div", {
+      return _react.default.createElement("div", {
         key: arrayIdx,
         className: "array-field-container " + (arrayIdx % 2 === 0 ? 'even' : 'odd'),
         "data-field-type": fieldType
-      }, _react["default"].createElement(BuildField, _extends({
+      }, _react.default.createElement(BuildField, _extends({
         value: inArrValue || null,
         fieldTip: fieldTip,
         fieldType: fieldType,
         title: title,
         enumValues: enumValues
-      }, _underscore["default"].pick(this.props, 'field', 'modifyNewContext', 'linkType', 'selectObj', 'selectComplete', 'selectCancel', 'nestedField', 'keyDisplay', 'keyComplete', 'setSubmissionState', 'fieldBeingSelected', 'fieldBeingSelectedArrayIdx', 'updateUpload', 'upload', 'uploadStatus', 'md5Progress', 'currentSubmittingUser', 'roundTwo', 'currType'), {
+      }, _underscore.default.pick(this.props, 'field', 'modifyNewContext', 'linkType', 'selectObj', 'selectComplete', 'selectCancel', 'nestedField', 'keyDisplay', 'keyComplete', 'setSubmissionState', 'fieldBeingSelected', 'fieldBeingSelectedArrayIdx', 'updateUpload', 'upload', 'uploadStatus', 'md5Progress', 'currentSubmittingUser', 'roundTwo', 'currType'), {
         isArray: true,
         isLastItemInArray: allItems.length - 1 === index,
         arrayIdx: arrayIdxList,
         schema: childFieldSchema,
         disabled: false,
         required: false,
-        key: arrayIdx
+        key: arrayIdx,
+        isMultiSelect: true
       })));
     }
   }, {
@@ -1048,13 +1049,13 @@ var ArrayField = function (_React$Component) {
           _this$props19$value = _this$props19.value,
           values = _this$props19$value === void 0 ? [] : _this$props19$value,
           pushArrayValue = _this$props19.pushArrayValue;
-      return _react["default"].createElement("div", {
+      return _react.default.createElement("div", {
         className: "add-array-item-button-container"
-      }, _react["default"].createElement("button", {
+      }, _react.default.createElement("button", {
         type: "button",
         className: "btn btn-outline-dark btn-" + (values.length > 0 ? "sm" : "md"),
         onClick: pushArrayValue
-      }, _react["default"].createElement("i", {
+      }, _react.default.createElement("i", {
         className: "icon icon-fw fas icon-plus"
       }), " Add"));
     }
@@ -1067,19 +1068,19 @@ var ArrayField = function (_React$Component) {
       var schema = propSchema.items || {};
       var values = propValue || [];
 
-      var valuesToRender = _underscore["default"].map(values.length === 0 ? [null] : values, function (v, i) {
+      var valuesToRender = _underscore.default.map(values.length === 0 ? [null] : values, function (v, i) {
         return [v, schema, i];
       });
 
       var showAddButton = !isValueNull(values[valuesToRender.length - 1]);
-      return _react["default"].createElement("div", {
+      return _react.default.createElement("div", {
         className: "list-of-array-items"
       }, valuesToRender.map(this.initiateArrayField), showAddButton ? this.generateAddButton() : null);
     }
   }]);
 
   return ArrayField;
-}(_react["default"].Component);
+}(_react.default.Component);
 
 var ObjectField = function (_React$PureComponent3) {
   _inherits(ObjectField, _React$PureComponent3);
@@ -1104,11 +1105,11 @@ var ObjectField = function (_React$PureComponent3) {
 
       if (!schemaVal) return null;
 
-      if (schemaVal.exclude_from && (_underscore["default"].contains(schemaVal.exclude_from, 'FFedit-create') || schemaVal.exclude_from == 'FFedit-create')) {
+      if (schemaVal.exclude_from && (_underscore.default.contains(schemaVal.exclude_from, 'FFedit-create') || schemaVal.exclude_from == 'FFedit-create')) {
         return null;
       }
 
-      if (schemaVal.exclude_from && (_underscore["default"].contains(schemaVal.exclude_from, 'FF-calculate') || schemaVal.exclude_from == 'FF-calculate')) {
+      if (schemaVal.exclude_from && (_underscore.default.contains(schemaVal.exclude_from, 'FF-calculate') || schemaVal.exclude_from == 'FF-calculate')) {
         return null;
       }
 
@@ -1154,18 +1155,19 @@ var ObjectField = function (_React$PureComponent3) {
       var _this$props22 = this.props,
           objectSchema = _this$props22.schema,
           parentObject = _this$props22.value,
-          propNestedField = _this$props22.nestedField;
-      var allFieldsInSchema = objectSchema['properties'] ? _underscore["default"].keys(objectSchema['properties']) : [];
+          propNestedField = _this$props22.nestedField,
+          isMultiSelect = _this$props22.isMultiSelect;
+      var allFieldsInSchema = objectSchema['properties'] ? _underscore.default.keys(objectSchema['properties']) : [];
 
-      var fieldsToBuild = _underscore["default"].filter(_underscore["default"].map(allFieldsInSchema, function (f) {
+      var fieldsToBuild = _underscore.default.filter(_underscore.default.map(allFieldsInSchema, function (f) {
         var fieldSchemaToUseOrNull = _this6.includeField(objectSchema, f);
 
         return fieldSchemaToUseOrNull && [f, fieldSchemaToUseOrNull] || null;
       }));
 
-      var passProps = _underscore["default"].pick(this.props, 'modifyNewContext', 'linkType', 'setSubmissionState', 'selectObj', 'selectComplete', 'selectCancel', 'arrayIdx', 'keyDisplay', 'keyComplete', 'currType', 'updateUpload', 'upload', 'uploadStatus', 'md5Progress', 'fieldBeingSelected', 'fieldBeingSelectedArrayIdx');
+      var passProps = _underscore.default.pick(this.props, 'modifyNewContext', 'linkType', 'setSubmissionState', 'selectObj', 'selectComplete', 'selectCancel', 'arrayIdx', 'keyDisplay', 'keyComplete', 'currType', 'updateUpload', 'upload', 'uploadStatus', 'md5Progress', 'fieldBeingSelected', 'fieldBeingSelectedArrayIdx');
 
-      var builtFields = _underscore["default"].map(fieldsToBuild, function (_ref2) {
+      var builtFields = _underscore.default.map(fieldsToBuild, function (_ref2) {
         var _ref3 = _slicedToArray(_ref2, 2),
             field = _ref3[0],
             fieldSchema = _ref3[1];
@@ -1189,10 +1191,10 @@ var ObjectField = function (_React$PureComponent3) {
         var enumValues = [];
 
         if (fieldType === 'enum') {
-          enumValues = fieldSchema["enum"] || fieldSchema.suggested_enum || [];
+          enumValues = fieldSchema.enum || fieldSchema.suggested_enum || [];
         }
 
-        return _react["default"].createElement(BuildField, _extends({}, passProps, {
+        return _react.default.createElement(BuildField, _extends({}, passProps, {
           field: field,
           fieldType: fieldType,
           fieldTip: fieldTip,
@@ -1205,18 +1207,19 @@ var ObjectField = function (_React$PureComponent3) {
           schema: fieldSchema,
           disabled: false,
           required: false,
-          isArray: false
+          isArray: false,
+          isMultiSelect: isMultiSelect || false
         }));
       });
 
-      return _react["default"].createElement("div", {
+      return _react.default.createElement("div", {
         className: "object-field-container"
       }, builtFields);
     }
   }]);
 
   return ObjectField;
-}(_react["default"].PureComponent);
+}(_react.default.PureComponent);
 
 var AttachmentInput = function (_React$Component2) {
   _inherits(AttachmentInput, _React$Component2);
@@ -1292,11 +1295,11 @@ var AttachmentInput = function (_React$Component2) {
         attach_title = "No file chosen";
       }
 
-      return _react["default"].createElement("div", {
+      return _react.default.createElement("div", {
         style: {
           'display': 'inherit'
         }
-      }, _react["default"].createElement("input", {
+      }, _react.default.createElement("input", {
         id: "field_for_" + field,
         type: "file",
         onChange: this.handleChange,
@@ -1304,10 +1307,10 @@ var AttachmentInput = function (_React$Component2) {
           'display': 'none'
         },
         accept: this.acceptedTypes()
-      }), _react["default"].createElement("button", {
+      }), _react.default.createElement("button", {
         type: "submit",
         className: "btn btn-outline-dark"
-      }, _react["default"].createElement("label", {
+      }, _react.default.createElement("label", {
         className: "text-400 mb-0",
         htmlFor: "field_for_" + field,
         style: {
@@ -1319,7 +1322,7 @@ var AttachmentInput = function (_React$Component2) {
   }]);
 
   return AttachmentInput;
-}(_react["default"].Component);
+}(_react.default.Component);
 
 var S3FileInput = function (_React$Component3) {
   _inherits(S3FileInput, _React$Component3);
@@ -1331,7 +1334,7 @@ var S3FileInput = function (_React$Component3) {
 
     _this8 = _possibleConstructorReturn(this, _getPrototypeOf(S3FileInput).call(this, props));
 
-    _underscore["default"].bindAll(_assertThisInitialized(_this8), 'modifyFile', 'handleChange', 'handleAsyncUpload', 'modifyRunningUploads', 'cancelUpload', 'deleteField');
+    _underscore.default.bindAll(_assertThisInitialized(_this8), 'modifyFile', 'handleChange', 'handleAsyncUpload', 'modifyRunningUploads', 'cancelUpload', 'deleteField');
 
     _this8.state = {
       'percentDone': null,
@@ -1408,7 +1411,7 @@ var S3FileInput = function (_React$Component3) {
             extensions = extensions.concat(response.other_allowed_extensions);
           }
 
-          if (extensions.indexOf("other") === -1 && !_underscore["default"].any(extensions, function (ext) {
+          if (extensions.indexOf("other") === -1 && !_underscore.default.any(extensions, function (ext) {
             return filename.endsWith(ext);
           })) {
             alert('File extension error! Please enter a file with one of the following extensions: ' + extensions.join(', '));
@@ -1506,7 +1509,7 @@ var S3FileInput = function (_React$Component3) {
       }
 
       var disableFile = md5Progress !== null || upload !== null;
-      return _react["default"].createElement("div", null, _react["default"].createElement("div", null, _react["default"].createElement("input", {
+      return _react.default.createElement("div", null, _react.default.createElement("div", null, _react.default.createElement("input", {
         id: "field_for_" + field,
         type: "file",
         onChange: this.handleChange,
@@ -1514,14 +1517,14 @@ var S3FileInput = function (_React$Component3) {
         style: {
           'display': 'none'
         }
-      }), _react["default"].createElement("button", {
+      }), _react.default.createElement("button", {
         type: "submit",
         disabled: disableFile,
         style: {
           'padding': '0px'
         },
         className: "btn btn-outline-dark"
-      }, _react["default"].createElement("label", {
+      }, _react.default.createElement("label", {
         className: "text-400",
         htmlFor: "field_for_" + field,
         style: {
@@ -1531,44 +1534,44 @@ var S3FileInput = function (_React$Component3) {
           'paddingLeft': '12px',
           'marginBottom': '0px'
         }
-      }, filename_text)), _react["default"].createElement(_Fade.Fade, {
-        "in": showDelete
-      }, _react["default"].createElement("div", {
+      }, filename_text)), _react.default.createElement(_Fade.Fade, {
+        in: showDelete
+      }, _react.default.createElement("div", {
         className: "pull-right"
-      }, _react["default"].createElement("button", {
+      }, _react.default.createElement("button", {
         type: "button",
         className: "btn btn-danger",
         disabled: !showDelete,
         onClick: this.deleteField,
         tabIndex: 2
-      }, _react["default"].createElement("i", {
+      }, _react.default.createElement("i", {
         className: "icon icon-fw icon-times fas"
-      }))))), statusTip ? _react["default"].createElement("div", {
+      }))))), statusTip ? _react.default.createElement("div", {
         style: {
           'color': '#a94442',
           'paddingTop': '10px'
         }
-      }, statusTip) : null, md5Progress ? _react["default"].createElement("div", {
+      }, statusTip) : null, md5Progress ? _react.default.createElement("div", {
         style: {
           'paddingTop': '10px'
         }
-      }, _react["default"].createElement("i", {
+      }, _react.default.createElement("i", {
         className: "icon icon-spin icon-circle-o-notch",
         style: {
           'opacity': '0.5'
         }
-      }), _react["default"].createElement("span", {
+      }), _react.default.createElement("span", {
         style: {
           'paddingLeft': '10px'
         }
-      }, 'Calculating MD5... ' + md5Progress + '%')) : null, percentDone !== null ? _react["default"].createElement("div", {
+      }, 'Calculating MD5... ' + md5Progress + '%')) : null, percentDone !== null ? _react.default.createElement("div", {
         className: "row",
         style: {
           'paddingTop': '10px'
         }
-      }, _react["default"].createElement("div", {
+      }, _react.default.createElement("div", {
         className: "col-3 col-sm-3 pull-left"
-      }, _react["default"].createElement("a", {
+      }, _react.default.createElement("a", {
         href: "",
         style: {
           'color': '#a94442',
@@ -1576,13 +1579,13 @@ var S3FileInput = function (_React$Component3) {
         },
         onClick: this.cancelUpload,
         title: "Cancel"
-      }, 'Cancel upload')), _react["default"].createElement("div", {
+      }, 'Cancel upload')), _react.default.createElement("div", {
         className: "col-9 col-sm-9 pull-right"
-      }, _react["default"].createElement("div", null, _react["default"].createElement("div", {
+      }, _react.default.createElement("div", null, _react.default.createElement("div", {
         className: "pull-left"
-      }, percentDone + "% complete"), _react["default"].createElement("div", {
+      }, percentDone + "% complete"), _react.default.createElement("div", {
         className: "pull-right"
-      }, "Total size: " + sizeUploaded)), _react["default"].createElement(_rcProgress.Line, {
+      }, "Total size: " + sizeUploaded)), _react.default.createElement(_rcProgress.Line, {
         percent: percentDone,
         strokeWidth: "1",
         strokeColor: "#388a92"
@@ -1591,7 +1594,7 @@ var S3FileInput = function (_React$Component3) {
   }]);
 
   return S3FileInput;
-}(_react["default"].Component);
+}(_react.default.Component);
 
 var AliasInputField = function (_React$Component4) {
   _inherits(AliasInputField, _React$Component4);
@@ -1613,7 +1616,7 @@ var AliasInputField = function (_React$Component4) {
         return AliasInputField.emailToString(submitter.email);
       }
 
-      if (primaryLabID && primaryLab.name && _underscore["default"].map(submits_for_list, _util.object.itemUtil.atId).indexOf(primaryLabID) > -1) {
+      if (primaryLabID && primaryLab.name && _underscore.default.map(submits_for_list, _util.object.itemUtil.atId).indexOf(primaryLabID) > -1) {
         return primaryLab.name;
       } else {
         return submits_for_list[0].name;
@@ -1639,7 +1642,7 @@ var AliasInputField = function (_React$Component4) {
 
     _this11 = _possibleConstructorReturn(this, _getPrototypeOf(AliasInputField).call(this, props));
 
-    _underscore["default"].bindAll(_assertThisInitialized(_this11), 'onAliasSecondPartChange', 'onAliasFirstPartChange', 'onAliasFirstPartChangeTyped', 'getInitialSubmitsForPart', 'finalizeAliasPartsChange');
+    _underscore.default.bindAll(_assertThisInitialized(_this11), 'onAliasSecondPartChange', 'onAliasFirstPartChange', 'onAliasFirstPartChangeTyped', 'getInitialSubmitsForPart', 'finalizeAliasPartsChange');
 
     return _this11;
   }
@@ -1707,7 +1710,7 @@ var AliasInputField = function (_React$Component4) {
       var firstPartSelect;
 
       if (currentSubmittingUser && Array.isArray(currentSubmittingUser.groups) && currentSubmittingUser.groups.indexOf('admin') > -1) {
-        firstPartSelect = _react["default"].createElement("input", {
+        firstPartSelect = _react.default.createElement("input", {
           type: "text",
           inputMode: "latin",
           id: "firstPartSelect",
@@ -1721,45 +1724,45 @@ var AliasInputField = function (_React$Component4) {
           className: "form-control" + (errorMessage ? " is-invalid" : isValid ? " is-valid" : "")
         });
       } else if (submits_for_list && submits_for_list.length > 1) {
-        firstPartSelect = _react["default"].createElement(_DropdownButton.DropdownButton, {
+        firstPartSelect = _react.default.createElement(_DropdownButton.DropdownButton, {
           className: "alias-lab-select form-control alias-first-part-input" + (errorMessage ? " is-invalid" : ""),
           id: "firstPartSelect",
           onSelect: this.onAliasFirstPartChange,
           componentClass: _reactBootstrap.InputGroup.Button,
-          title: parts.length > 1 && _react["default"].createElement("span", {
+          title: parts.length > 1 && _react.default.createElement("span", {
             className: "text-400"
-          }, _react["default"].createElement("small", {
+          }, _react.default.createElement("small", {
             className: "pull-left"
-          }, "Lab: "), _react["default"].createElement("span", {
+          }, "Lab: "), _react.default.createElement("span", {
             className: "pull-right text-ellipsis-container",
             style: {
               maxWidth: '80%'
             }
           }, parts[0] !== '' && parts[0] || this.getInitialSubmitsForPart())) || 'Select a Lab'
-        }, _underscore["default"].map(submits_for_list, function (lab) {
-          return _react["default"].createElement(_DropdownButton.DropdownItem, {
+        }, _underscore.default.map(submits_for_list, function (lab) {
+          return _react.default.createElement(_DropdownButton.DropdownItem, {
             key: lab.name,
             eventKey: lab.name
-          }, _react["default"].createElement("span", {
+          }, _react.default.createElement("span", {
             className: "text-500"
           }, lab.name), " (", lab.display_title, ")");
         }));
       } else {
-        firstPartSelect = _react["default"].createElement(_reactBootstrap.InputGroup.Addon, {
+        firstPartSelect = _react.default.createElement(_reactBootstrap.InputGroup.Addon, {
           className: "alias-lab-single-option"
         }, currFirstPartValue);
       }
 
       var outerClassName = "mb-0 alias-input-field form-group has-feedback" + (errorMessage ? " is-invalid has-error" : isValid ? " is-valid" : "");
-      return _react["default"].createElement("div", {
+      return _react.default.createElement("div", {
         className: outerClassName
-      }, _react["default"].createElement("div", {
+      }, _react.default.createElement("div", {
         className: "input-group"
-      }, firstPartSelect, _react["default"].createElement("div", {
+      }, firstPartSelect, _react.default.createElement("div", {
         className: "input-group-prepend input-group-append input-group-addon colon-separator"
-      }, _react["default"].createElement("span", {
+      }, _react.default.createElement("span", {
         className: "input-group-text"
-      }, ":")), _react["default"].createElement("input", {
+      }, ":")), _react.default.createElement("input", {
         type: "text",
         id: "aliasInput",
         inputMode: "latin",
@@ -1768,28 +1771,28 @@ var AliasInputField = function (_React$Component4) {
         placeholder: "Type in a new identifier",
         onChange: this.onAliasSecondPartChange,
         className: "form-control" + (errorMessage ? " is-invalid" : isValid ? " is-valid" : "")
-      })), showErrorMsg && errorMessage ? _react["default"].createElement("div", {
+      })), showErrorMsg && errorMessage ? _react.default.createElement("div", {
         className: "invalid-feedback d-block text-right"
       }, errorMessage) : null);
     }
   }]);
 
   return AliasInputField;
-}(_react["default"].Component);
+}(_react.default.Component);
 
 exports.AliasInputField = AliasInputField;
 
 _defineProperty(AliasInputField, "propTypes", {
-  'value': _propTypes["default"].string.isRequired,
-  'onAliasChange': _propTypes["default"].func.isRequired,
-  'currentSubmittingUser': _propTypes["default"].shape({
-    'submits_for': _propTypes["default"].arrayOf(_propTypes["default"].shape({
-      'name': _propTypes["default"].string,
-      'display_title': _propTypes["default"].string
+  'value': _propTypes.default.string.isRequired,
+  'onAliasChange': _propTypes.default.func.isRequired,
+  'currentSubmittingUser': _propTypes.default.shape({
+    'submits_for': _propTypes.default.arrayOf(_propTypes.default.shape({
+      'name': _propTypes.default.string,
+      'display_title': _propTypes.default.string
     }))
   }).isRequired,
-  'errorMessage': _propTypes["default"].string,
-  'isValid': _propTypes["default"].bool
+  'errorMessage': _propTypes.default.string,
+  'isValid': _propTypes.default.bool
 });
 
 _defineProperty(AliasInputField, "defaultProps", {
@@ -1932,14 +1935,14 @@ var AliasInputFieldValidated = function (_React$PureComponent4) {
   }, {
     key: "render",
     value: function render() {
-      return _react["default"].createElement(AliasInputField, _extends({}, this.props, this.state, {
+      return _react.default.createElement(AliasInputField, _extends({}, this.props, this.state, {
         onAliasChange: this.onAliasChange
       }));
     }
   }]);
 
   return AliasInputFieldValidated;
-}(_react["default"].PureComponent);
+}(_react.default.PureComponent);
 
 exports.AliasInputFieldValidated = AliasInputFieldValidated;
 
@@ -1993,7 +1996,7 @@ var InfoIcon = function (_React$PureComponent5) {
         tip += '<h6 class="mt-07 text-300">Field Type: <span class="text-400">' + this.fieldTypeDescriptor() + '</span></h6>';
       }
 
-      return _react["default"].createElement("i", {
+      return _react.default.createElement("i", {
         className: "icon icon-info-circle fas" + (className ? ' ' + className : ''),
         "data-tip": tip,
         "data-html": true
@@ -2002,7 +2005,7 @@ var InfoIcon = function (_React$PureComponent5) {
   }]);
 
   return InfoIcon;
-}(_react["default"].PureComponent);
+}(_react.default.PureComponent);
 
 function isValueNull(value) {
   if (value === null) return true;
@@ -2011,15 +2014,15 @@ function isValueNull(value) {
   if (value === '') return true;
 
   if (Array.isArray(value)) {
-    if (value.length === 0) return true;else if (_underscore["default"].every(value, isValueNull)) {
+    if (value.length === 0) return true;else if (_underscore.default.every(value, isValueNull)) {
       return true;
     } else return false;
   }
 
   if (_typeof(value) === 'object') {
-    var keys = _underscore["default"].keys(value);
+    var keys = _underscore.default.keys(value);
 
-    if (keys.length === 0) return true;else if (_underscore["default"].every(keys, function (k) {
+    if (keys.length === 0) return true;else if (_underscore.default.every(keys, function (k) {
       return isValueNull(value[k]);
     })) return true;
   }

--- a/src/components/browse/SearchView.js
+++ b/src/components/browse/SearchView.js
@@ -383,10 +383,11 @@ const SelectStickyFooter = React.memo(function SelectStickyFooter(props){
                         ) :
                         (
                             <h3 className="mt-03 mb-0">
-                                <span style={{ 'fontSize': '80%' }}>{selectedItemDisplayTitle}</span>
+                                &nbsp;
+                                {/* <span style={{ 'fontSize': '80%' }}>{selectedItemDisplayTitle}</span>
                                 <small className="text-muted ml-08">
                                     {selectedItems.size === 1 ? '' : (itemTypeFriendlyName + 's')} selected
-                                </small>
+                                </small> */}
                             </h3>
                         )}
                 </div>

--- a/src/components/browse/components/SearchResultTable.js
+++ b/src/components/browse/components/SearchResultTable.js
@@ -936,7 +936,7 @@ class DimensioningContainer extends React.PureComponent {
 
     stickyHeaderTopOffset(){
         const { windowWidth, stickyHeaderTopOffset, currentAction, href } = this.props;
-        const displayNavBar = !(href && typeof href === 'string' && (href.indexOf('/search/') >= 0) && (currentAction === 'multiselect'));
+        const displayNavBar = !(href && typeof href === 'string' && (href.indexOf('/search/') >= 0) && isSelectAction(currentAction));
         const rgs = responsiveGridState(windowWidth);
         switch (rgs){
             case 'xs':

--- a/src/components/forms/SubmissionView.js
+++ b/src/components/forms/SubmissionView.js
@@ -1938,19 +1938,27 @@ class IndividualObjectView extends React.Component {
      * object selection state, modifies context, and initializes the fetchAndValidateItem
      * process.
      */
-    selectComplete(value){
+    selectComplete(atIds) {
         const { currContext } = this.props;
         const { selectField, selectArrayIdx, selectType } = this.state;
+
         if (!selectField) throw new Error('No field being selected for');
 
-        const current = selectField && currContext[selectField];
-        const isRepeat = (Array.isArray(current) && _.contains(current, value));
+        const isMultiSelect = selectArrayIdx && Array.isArray(selectArrayIdx);
+        const cloneSelectArrayIdx = isMultiSelect ? [...selectArrayIdx] : null;
+        for (const atId of atIds) {
+            const current = selectField && currContext[selectField];
+            const isRepeat = (Array.isArray(current) && _.contains(current, atId));
 
-        if (!isRepeat) {
-            //this.modifyNewContext(selectField, value, 'existing linked object', null, selectArrayIdx);
-            this.fetchAndValidateItem(value, selectField, selectType, selectArrayIdx, null);
-        } else {
-            this.modifyNewContext(selectField, null, 'existing linked object', null, selectArrayIdx);
+            if (!isRepeat) {
+                //this.modifyNewContext(selectField, value, 'existing linked object', null, selectArrayIdx);
+                this.fetchAndValidateItem(atId, selectField, selectType, isMultiSelect ? [...cloneSelectArrayIdx] : null, null);
+                if (isMultiSelect) {
+                    cloneSelectArrayIdx[cloneSelectArrayIdx.length - 1]++;
+                }
+            } else {
+                this.modifyNewContext(selectField, null, 'existing linked object', null, cloneSelectArrayIdx);
+            }
         }
 
         this.setState({ 'selectField': null, 'selectArrayIdx': null, 'selectType': null });

--- a/src/components/forms/components/submission-fields.js
+++ b/src/components/forms/components/submission-fields.js
@@ -528,22 +528,22 @@ class LinkedObj extends React.PureComponent {
     }
 
     childWindowAlert(){
-        return null;
-        // const { schema, nestedField } = this.props;
-        // const itemType = schema && schema.linkTo;
-        // const prettyTitle = schema && ((schema.parentSchema && schema.parentSchema.title) || schema.title);
-        // return {
-        //     'title' : 'Selecting ' + itemType + ' for field ' + (prettyTitle ? prettyTitle + ' ("' + nestedField + '")' : '"' + nestedField + '"'),
-        //     'message' : (
-        //         <div>
-        //             <p className="mb-0">
-        //                 Please either <b>drag and drop</b> an Item (row) from this window into the submissions window or click its corresponding select (checkbox) button.
-        //             </p>
-        //             <p className="mb-0">You may also browse around and drag & drop a link into the submissions window as well.</p>
-        //         </div>
-        //     ),
-        //     'style' : 'info'
-        // };
+        const { schema, nestedField } = this.props;
+        const itemType = schema && schema.linkTo;
+        const prettyTitle = schema && ((schema.parentSchema && schema.parentSchema.title) || schema.title);
+        return {
+            'title': 'Selecting ' + itemType + ' for field ' + (prettyTitle ? prettyTitle + ' ("' + nestedField + '")' : '"' + nestedField + '"'),
+            'message': null,
+            // 'message' : (
+            //     <div>
+            //         <p className="mb-0">
+            //             Please either <b>drag and drop</b> an Item (row) from this window into the submissions window or click its corresponding select (checkbox) button.
+            //         </p>
+            //         <p className="mb-0">You may also browse around and drag & drop a link into the submissions window as well.</p>
+            //     </div>
+            // ),
+            'style': 'info'
+        };
     }
 
     renderSelectInputField(){

--- a/src/components/forms/components/submission-fields.js
+++ b/src/components/forms/components/submission-fields.js
@@ -528,21 +528,27 @@ class LinkedObj extends React.PureComponent {
     }
 
     childWindowAlert(){
-        const { schema, nestedField } = this.props;
+        const { schema, nestedField, isMultiSelect } = this.props;
         const itemType = schema && schema.linkTo;
         const prettyTitle = schema && ((schema.parentSchema && schema.parentSchema.title) || schema.title);
+        const message = (
+            <div>
+                { isMultiSelect?
+                    <p className="mb-0">
+                        Please either select an Item below and click <em>Apply</em> or <em>drag and drop</em> an Item (row) from this window into the submissions window.
+                    </p>
+                    :
+                    <p className="mb-0">
+                        Please select the Item(s) you would like and then press <em>Apply</em> below.
+                    </p>
+                }
+                <p className="mb-0">You may use facets on the left-hand side to narrow down results.</p>
+            </div>
+        );
         return {
-            'title': 'Selecting ' + itemType + ' for field ' + (prettyTitle ? prettyTitle + ' ("' + nestedField + '")' : '"' + nestedField + '"'),
-            'message': null,
-            // 'message' : (
-            //     <div>
-            //         <p className="mb-0">
-            //             Please either <b>drag and drop</b> an Item (row) from this window into the submissions window or click its corresponding select (checkbox) button.
-            //         </p>
-            //         <p className="mb-0">You may also browse around and drag & drop a link into the submissions window as well.</p>
-            //     </div>
-            // ),
-            'style': 'info'
+            title: 'Selecting ' + itemType + ' for field ' + (prettyTitle ? prettyTitle + ' ("' + nestedField + '")' : '"' + nestedField + '"'),
+            message,
+            style: 'info'
         };
     }
 

--- a/src/components/forms/components/submission-fields.js
+++ b/src/components/forms/components/submission-fields.js
@@ -533,7 +533,7 @@ class LinkedObj extends React.PureComponent {
         const prettyTitle = schema && ((schema.parentSchema && schema.parentSchema.title) || schema.title);
         const message = (
             <div>
-                { isMultiSelect?
+                { !isMultiSelect?
                     <p className="mb-0">
                         Please either select an Item below and click <em>Apply</em> or <em>drag and drop</em> an Item (row) from this window into the submissions window.
                     </p>


### PR DESCRIPTION
**Note:** this PR should be handled with PR https://github.com/4dn-dcic/fourfront/pull/1174

1. Single selection's UI is changed, so both `multi select` and `single select` popup UIs are alike.
2. `SubmissionView` is updated to open `multi` or `single selection` popup according to the field type.

<img width="1187" alt="Screen Shot 2019-09-30 at 17 42 53" src="https://user-images.githubusercontent.com/49978017/65890996-8367aa80-e3ac-11e9-99a2-4a2add1e6b7b.png">
