### PR TITLE
Facet grouping

### DIFF
--- a/es/components/browse/components/FacetList/FacetOfFacets.js
+++ b/es/components/browse/components/FacetList/FacetOfFacets.js
@@ -220,7 +220,7 @@ function (_React$PureComponent) {
       })))), _react["default"].createElement(_Collapse.Collapse, {
         "in": facetOpen && !facetClosing
       }, _react["default"].createElement("div", {
-        className: "ml-2"
+        className: "facet-group-list-container"
       }, extendedFacets)));
     }
   }]);

--- a/es/components/browse/components/FacetList/FacetOfFacets.js
+++ b/es/components/browse/components/FacetList/FacetOfFacets.js
@@ -1,0 +1,260 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.FacetOfFacets = void 0;
+
+var _react = _interopRequireDefault(require("react"));
+
+var _propTypes = _interopRequireDefault(require("prop-types"));
+
+var _underscore = _interopRequireDefault(require("underscore"));
+
+var _memoizeOne = _interopRequireDefault(require("memoize-one"));
+
+var _index = require("./index");
+
+var _Collapse = require("./../../../ui/Collapse");
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+
+function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function (obj) { return typeof obj; }; } else { _typeof = function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function (o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function (o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
+/**
+ * Used to render individual facet fields and their available terms in FacetList.
+ *
+ * @memberof module:facetlist
+ * @class Facet
+ * @type {Component}
+ */
+var FacetOfFacets =
+/*#__PURE__*/
+function (_React$PureComponent) {
+  _inherits(FacetOfFacets, _React$PureComponent);
+
+  function FacetOfFacets(props) {
+    var _this;
+
+    _classCallCheck(this, FacetOfFacets);
+
+    _this = _possibleConstructorReturn(this, _getPrototypeOf(FacetOfFacets).call(this, props));
+    _this.handleOpenToggleClick = _this.handleOpenToggleClick.bind(_assertThisInitialized(_this));
+    _this.handleExpandListToggleClick = _this.handleExpandListToggleClick.bind(_assertThisInitialized(_this));
+    _this.state = {
+      'facetOpen': typeof props.defaultFacetOpen === 'boolean' ? props.defaultFacetOpen : true,
+      'facetClosing': false,
+      'expanded': false
+    };
+    return _this;
+  }
+
+  _createClass(FacetOfFacets, [{
+    key: "componentDidUpdate",
+    value: function componentDidUpdate() {
+      var _this$props = this.props,
+          mounted = _this$props.mounted,
+          defaultFacetOpen = _this$props.defaultFacetOpen,
+          isStatic = _this$props.isStatic; // this.setState(({ facetOpen: currFacetOpen }) => {
+      //     if (!pastProps.mounted && mounted && typeof defaultFacetOpen === 'boolean' && defaultFacetOpen !== pastProps.defaultFacetOpen) {
+      //         return { 'facetOpen' : true };
+      //     }
+      //     if (defaultFacetOpen === true && !pastProps.defaultFacetOpen && !currFacetOpen){
+      //         return { 'facetOpen' : true };
+      //     }
+      //     if (currFacetOpen && isStatic && !pastProps.isStatic){
+      //         return { 'facetOpen' : false };
+      //     }
+      //     return null;
+      // }, ()=>{
+      //     const { facetOpen } = this.state;
+      //     if (pastState.facetOpen !== facetOpen){
+      //         ReactTooltip.rebuild();
+      //     }
+      // });
+    }
+  }, {
+    key: "handleOpenToggleClick",
+    value: function handleOpenToggleClick(e) {
+      var _this2 = this;
+
+      e.preventDefault();
+      this.setState(function (_ref) {
+        var facetOpen = _ref.facetOpen;
+
+        if (!facetOpen) {
+          return {
+            'facetOpen': true
+          };
+        } else {
+          return {
+            'facetClosing': true
+          };
+        }
+      }, function () {
+        setTimeout(function () {
+          _this2.setState(function (_ref2) {
+            var facetOpen = _ref2.facetOpen,
+                facetClosing = _ref2.facetClosing;
+
+            if (facetClosing) {
+              return {
+                'facetOpen': false,
+                'facetClosing': false
+              };
+            }
+
+            return null;
+          });
+        }, 350);
+      });
+    }
+  }, {
+    key: "handleExpandListToggleClick",
+    value: function handleExpandListToggleClick(e) {
+      e.preventDefault();
+      this.setState(function (_ref3) {
+        var expanded = _ref3.expanded;
+        return {
+          'expanded': !expanded
+        };
+      });
+    }
+  }, {
+    key: "render",
+    value: function render() {
+      var _this$props2 = this.props,
+          title = _this$props2.title,
+          facetList = _this$props2.facets,
+          tooltip = _this$props2.tooltip;
+      var _this$state = this.state,
+          facetOpen = _this$state.facetOpen,
+          facetClosing = _this$state.facetClosing;
+      console.log("log1: facetList[0]", facetList[0]);
+      console.log("log1: mapped", facetList.map(function (facet) {
+        return facet.title;
+      }));
+      return _react["default"].createElement("div", {
+        className: "facet" + (facetOpen ? ' open' : ' closed') + (facetClosing ? ' closing' : ''),
+        "data-field": title
+      }, _react["default"].createElement("h5", {
+        className: "facet-title",
+        onClick: this.handleOpenToggleClick
+      }, _react["default"].createElement("span", {
+        className: "expand-toggle col-auto px-0"
+      }, _react["default"].createElement("i", {
+        className: "icon icon-fw fas " + (facetOpen && !facetClosing ? "icon-minus" : "icon-plus")
+      })), _react["default"].createElement("span", {
+        className: "inline-block col px-0",
+        "data-tip": tooltip,
+        "data-place": "right"
+      }, title)), _react["default"].createElement(_Collapse.Collapse, {
+        "in": facetOpen && !facetClosing
+      }, _react["default"].createElement("div", {
+        className: "ml-1"
+      }, facetList)));
+    } // static isStatic(facet){
+    //     const { terms = null, total = 0, aggregation_type = "terms", min = null, max = null } = facet;
+    //     return (
+    //         aggregation_type === "terms" &&
+    //         Array.isArray(terms) &&
+    //         terms.length === 1 &&
+    //         total <= _.reduce(terms, function(m, t){ return m + (t.doc_count || 0); }, 0)
+    //     ) || (
+    //         aggregation_type == "stats" &&
+    //         min === max
+    //     );
+    // }
+    // constructor(props){
+    //     super(props);
+    //     this.handleStaticClick = this.handleStaticClick.bind(this);
+    //     this.handleTermClick = this.handleTermClick.bind(this);
+    //     this.state = { 'filtering' : false };
+    // }
+    // /**
+    //  * For cases when there is only one option for a facet - we render a 'static' row.
+    //  * This may change in response to design.
+    //  * Unlike in `handleTermClick`, we handle own state/UI here.
+    //  *
+    //  * @todo Allow to specify interval for histogram & date_histogram in schema instead of hard-coding 'month' interval.
+    //  */
+    // handleStaticClick(e) {
+    //     const { facet, isStatic } = this.props;
+    //     const term = facet.terms[0]; // Would only have 1
+    //     e.preventDefault();
+    //     if (!isStatic) return false;
+    //     this.setState({ 'filtering' : true }, () => {
+    //         this.handleTermClick(facet, term, e, () =>
+    //             this.setState({ 'filtering' : false })
+    //         );
+    //     });
+    // }
+    // /**
+    //  * Each Term component instance provides their own callback, we just route the navigation request.
+    //  *
+    //  * @todo Allow to specify interval for histogram & date_histogram in schema instead of hard-coding 'month' interval.
+    //  */
+    // handleTermClick(facet, term, e, callback) {
+    //     const { onFilter, href } = this.props;
+    //     onFilter(facet, term, callback, false, href);
+    // }
+    // render() {
+    //     const {
+    //         facet, getTermStatus, extraClassname, termTransformFxn, separateSingleTermFacets,
+    //         defaultFacetOpen, filters, onFilter, mounted, isStatic
+    //     } = this.props;
+    //     const { filtering } = this.state;
+    //     const { description = null, field, title, terms = [], aggregation_type = "terms" } = facet;
+    //     const showTitle = title || field;
+    //     if (aggregation_type === "stats") {
+    //         return <RangeFacet {...{ facet, filtering, defaultFacetOpen, termTransformFxn, filters, onFilter, mounted, isStatic }} tooltip={description} title={showTitle} />;
+    //     }
+    //     // Default case for "terms" buckets/facets
+    //     if (separateSingleTermFacets && isStatic){
+    //         // Only one term exists.
+    //         return <StaticSingleTerm {...{ facet, term : terms[0], filtering, showTitle, onClick : this.handleStaticClick, getTermStatus, extraClassname, termTransformFxn }} />;
+    //     } else {
+    //         return <FacetTermsList {...this.props} onTermClick={this.handleTermClick} tooltip={description} title={showTitle} />;
+    //     }
+    // }
+
+  }]);
+
+  return FacetOfFacets;
+}(_react["default"].PureComponent); // FacetOfFacets.propTypes = {
+//     'facet'                 : PropTypes.shape({
+//         'field'                 : PropTypes.string.isRequired,    // Name of nested field property in experiment objects, using dot-notation.
+//         'title'                 : PropTypes.string,               // Human-readable Facet Term
+//         'total'                 : PropTypes.number,               // Total experiments (or terms??) w/ field
+//         'terms'                 : PropTypes.array.isRequired,     // Possible terms,
+//         'description'           : PropTypes.string,
+//         'aggregation_type'      : PropTypes.oneOf(["stats", "terms"])
+//     }),
+//     'defaultFacetOpen'      : PropTypes.bool,
+//     'onFilter'              : PropTypes.func,           // Executed on term click
+//     'extraClassname'        : PropTypes.string,
+//     'schemas'               : PropTypes.object,
+//     'getTermStatus'         : PropTypes.func.isRequired,
+//     'href'                  : PropTypes.string.isRequired,
+//     'filters'               : PropTypes.arrayOf(PropTypes.object).isRequired,
+//     'mounted'               : PropTypes.bool
+// };
+
+
+exports.FacetOfFacets = FacetOfFacets;

--- a/es/components/browse/components/FacetList/FacetOfFacets.js
+++ b/es/components/browse/components/FacetList/FacetOfFacets.js
@@ -9,9 +9,13 @@ var _react = _interopRequireDefault(require("react"));
 
 var _propTypes = _interopRequireDefault(require("prop-types"));
 
+var _memoizeOne = _interopRequireDefault(require("memoize-one"));
+
 var _Collapse = require("./../../../ui/Collapse");
 
 var _Fade = require("./../../../ui/Fade");
+
+var _index = require("./index");
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
@@ -53,10 +57,16 @@ function (_React$PureComponent) {
     _this = _possibleConstructorReturn(this, _getPrototypeOf(FacetOfFacets).call(this, props));
     _this.handleOpenToggleClick = _this.handleOpenToggleClick.bind(_assertThisInitialized(_this));
     _this.handleExpandListToggleClick = _this.handleExpandListToggleClick.bind(_assertThisInitialized(_this));
+    _this.checkAllTerms = _this.checkAllTerms.bind(_assertThisInitialized(_this));
     _this.state = {
       'facetOpen': typeof props.defaultFacetOpen === 'boolean' ? props.defaultFacetOpen : true,
       'facetClosing': false,
       'expanded': false
+    };
+    _this.memoized = {
+      checkAllTerms: (0, _memoizeOne["default"])(_this.checkAllTerms),
+      anyTermsSelectedPerFacet: (0, _memoizeOne["default"])(_index.anyTermsSelected),
+      mergeTerms: (0, _memoizeOne["default"])(_index.mergeTerms)
     };
     return _this;
   }
@@ -109,15 +119,42 @@ function (_React$PureComponent) {
       });
     }
   }, {
+    key: "checkAllTerms",
+    value: function checkAllTerms() {
+      var _this3 = this;
+
+      var _this$props = this.props,
+          _this$props$facets = _this$props.facets,
+          facets = _this$props$facets === void 0 ? [] : _this$props$facets,
+          _this$props$filters = _this$props.filters,
+          filters = _this$props$filters === void 0 ? [] : _this$props$filters;
+      var anySelected = false; // console.log("log1: running CheckAllTerms on facetList: ", facets);
+
+      facets.forEach(function (facet) {
+        // console.log("log1: examining this facet for selected terms: ", facet.props.facet);
+        // console.log("log1: seeking match with these filters", filters);
+        var terms = _this3.memoized.mergeTerms(facet.props.facet, filters); // console.log("log1: merged terms, ", terms);
+
+
+        var anyTermsSelectedThisFacet = _this3.memoized.anyTermsSelectedPerFacet(terms, facet.props.facet, filters);
+
+        if (anyTermsSelectedThisFacet === true) {
+          anySelected = true;
+        }
+      });
+      return anySelected;
+    }
+  }, {
     key: "render",
     value: function render() {
-      var _this$props = this.props,
-          title = _this$props.title,
-          facetList = _this$props.facets,
-          tooltip = _this$props.tooltip;
+      var _this$props2 = this.props,
+          title = _this$props2.title,
+          facets = _this$props2.facets,
+          tooltip = _this$props2.tooltip;
       var _this$state = this.state,
           facetOpen = _this$state.facetOpen,
           facetClosing = _this$state.facetClosing;
+      var anyTermsSelected = this.memoized.checkAllTerms();
       return _react["default"].createElement("div", {
         className: "facet" + (facetOpen ? ' open' : ' closed') + (facetClosing ? ' closing' : ''),
         "data-field": title
@@ -135,18 +172,18 @@ function (_React$PureComponent) {
       }, title), _react["default"].createElement(_Fade.Fade, {
         "in": facetClosing || !facetOpen
       }, _react["default"].createElement("span", {
-        className: "closed-terms-count col-auto px-0",
-        "data-tip": "Nested filters (".concat(facetList.length, ")")
+        className: "closed-terms-count col-auto px-0" + (anyTermsSelected ? " some-selected" : ""),
+        "data-tip": "Nested filters (".concat(facets.length, ") ").concat(anyTermsSelected ? " with at least 1 selected." : "")
       }, _react["default"].createElement("i", {
         className: "icon fas icon-layer-group",
         style: {
-          opacity: 0.25
+          opacity: anyTermsSelected ? 0.75 : 0.25
         }
       })))), _react["default"].createElement(_Collapse.Collapse, {
         "in": facetOpen && !facetClosing
       }, _react["default"].createElement("div", {
         className: "ml-2"
-      }, facetList)));
+      }, facets)));
     }
   }]);
 

--- a/es/components/browse/components/FacetList/FacetOfFacets.js
+++ b/es/components/browse/components/FacetList/FacetOfFacets.js
@@ -9,13 +9,9 @@ var _react = _interopRequireDefault(require("react"));
 
 var _propTypes = _interopRequireDefault(require("prop-types"));
 
-var _memoizeOne = _interopRequireDefault(require("memoize-one"));
-
 var _Collapse = require("./../../../ui/Collapse");
 
 var _Fade = require("./../../../ui/Fade");
-
-var _index = require("./index");
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
@@ -57,16 +53,10 @@ function (_React$PureComponent) {
     _this = _possibleConstructorReturn(this, _getPrototypeOf(FacetOfFacets).call(this, props));
     _this.handleOpenToggleClick = _this.handleOpenToggleClick.bind(_assertThisInitialized(_this));
     _this.handleExpandListToggleClick = _this.handleExpandListToggleClick.bind(_assertThisInitialized(_this));
-    _this.checkAllTerms = _this.checkAllTerms.bind(_assertThisInitialized(_this));
     _this.state = {
       'facetOpen': typeof props.defaultFacetOpen === 'boolean' ? props.defaultFacetOpen : true,
       'facetClosing': false,
       'expanded': false
-    };
-    _this.memoized = {
-      checkAllTerms: (0, _memoizeOne["default"])(_this.checkAllTerms),
-      anyTermsSelectedPerFacet: (0, _memoizeOne["default"])(_index.anyTermsSelected),
-      mergeTerms: (0, _memoizeOne["default"])(_index.mergeTerms)
     };
     return _this;
   }
@@ -119,42 +109,16 @@ function (_React$PureComponent) {
       });
     }
   }, {
-    key: "checkAllTerms",
-    value: function checkAllTerms() {
-      var _this3 = this;
-
-      var _this$props = this.props,
-          _this$props$facets = _this$props.facets,
-          facets = _this$props$facets === void 0 ? [] : _this$props$facets,
-          _this$props$filters = _this$props.filters,
-          filters = _this$props$filters === void 0 ? [] : _this$props$filters;
-      var anySelected = false; // console.log("log1: running CheckAllTerms on facetList: ", facets);
-
-      facets.forEach(function (facet) {
-        // console.log("log1: examining this facet for selected terms: ", facet.props.facet);
-        // console.log("log1: seeking match with these filters", filters);
-        var terms = _this3.memoized.mergeTerms(facet.props.facet, filters); // console.log("log1: merged terms, ", terms);
-
-
-        var anyTermsSelectedThisFacet = _this3.memoized.anyTermsSelectedPerFacet(terms, facet.props.facet, filters);
-
-        if (anyTermsSelectedThisFacet === true) {
-          anySelected = true;
-        }
-      });
-      return anySelected;
-    }
-  }, {
     key: "render",
     value: function render() {
-      var _this$props2 = this.props,
-          title = _this$props2.title,
-          facets = _this$props2.facets,
-          tooltip = _this$props2.tooltip;
+      var _this$props = this.props,
+          title = _this$props.title,
+          facets = _this$props.facets,
+          tooltip = _this$props.tooltip,
+          areTermsSelected = _this$props.areTermsSelected;
       var _this$state = this.state,
           facetOpen = _this$state.facetOpen,
           facetClosing = _this$state.facetClosing;
-      var anyTermsSelected = this.memoized.checkAllTerms();
       return _react["default"].createElement("div", {
         className: "facet" + (facetOpen ? ' open' : ' closed') + (facetClosing ? ' closing' : ''),
         "data-field": title
@@ -172,12 +136,12 @@ function (_React$PureComponent) {
       }, title), _react["default"].createElement(_Fade.Fade, {
         "in": facetClosing || !facetOpen
       }, _react["default"].createElement("span", {
-        className: "closed-terms-count col-auto px-0" + (anyTermsSelected ? " some-selected" : ""),
-        "data-tip": "Nested filters (".concat(facets.length, ") ").concat(anyTermsSelected ? " with at least 1 selected." : "")
+        className: "closed-terms-count col-auto px-0" + (areTermsSelected ? " some-selected" : ""),
+        "data-tip": "Nested filters (".concat(facets.length, ") ").concat(areTermsSelected ? " with at least 1 selected." : "")
       }, _react["default"].createElement("i", {
         className: "icon fas icon-layer-group",
         style: {
-          opacity: anyTermsSelected ? 0.75 : 0.25
+          opacity: areTermsSelected ? 0.75 : 0.25
         }
       })))), _react["default"].createElement(_Collapse.Collapse, {
         "in": facetOpen && !facetClosing

--- a/es/components/browse/components/FacetList/FacetOfFacets.js
+++ b/es/components/browse/components/FacetList/FacetOfFacets.js
@@ -9,6 +9,10 @@ var _react = _interopRequireDefault(require("react"));
 
 var _propTypes = _interopRequireDefault(require("prop-types"));
 
+var _memoizeOne = _interopRequireDefault(require("memoize-one"));
+
+var _reactTooltip = _interopRequireDefault(require("react-tooltip"));
+
 var _Collapse = require("./../../../ui/Collapse");
 
 var _Fade = require("./../../../ui/Fade");
@@ -19,15 +23,15 @@ function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterat
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
-
-function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
-
 function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function (o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
 
@@ -35,15 +39,28 @@ function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || func
 
 /**
  * Used to render individual facet fields and their available terms in FacetList.
- *
- * @memberof module:facetlist
- * @class Facet
- * @type {Component}
  */
 var FacetOfFacets =
 /*#__PURE__*/
 function (_React$PureComponent) {
   _inherits(FacetOfFacets, _React$PureComponent);
+
+  _createClass(FacetOfFacets, null, [{
+    key: "anyFacetsHaveSelection",
+    value: function anyFacetsHaveSelection(renderedFacets) {
+      for (var facetIdx = 0; facetIdx < renderedFacets.length; facetIdx++) {
+        var renderedFacet = renderedFacets[facetIdx]; // We have rendered facets as `props.facets`
+
+        var anySelected = renderedFacet.props.anyTermsSelected;
+
+        if (anySelected) {
+          return true;
+        }
+      }
+
+      return false;
+    }
+  }]);
 
   function FacetOfFacets(props) {
     var _this;
@@ -53,8 +70,13 @@ function (_React$PureComponent) {
     _this = _possibleConstructorReturn(this, _getPrototypeOf(FacetOfFacets).call(this, props));
     _this.handleOpenToggleClick = _this.handleOpenToggleClick.bind(_assertThisInitialized(_this));
     _this.handleExpandListToggleClick = _this.handleExpandListToggleClick.bind(_assertThisInitialized(_this));
+    _this.memoized = {
+      anyFacetsHaveSelection: (0, _memoizeOne["default"])(FacetOfFacets.anyFacetsHaveSelection)
+    }; // Most of this logic (facetOpen/facetClosing at least) is same between this and FacetTermsList.
+    // Maybe we could pull it out into reusable controller component. Maybe. Very low priority.
+
     _this.state = {
-      'facetOpen': typeof props.defaultFacetOpen === 'boolean' ? props.defaultFacetOpen : true,
+      'facetOpen': typeof props.defaultGroupOpen === 'boolean' ? props.defaultGroupOpen : true,
       'facetClosing': false,
       'expanded': false
     };
@@ -62,13 +84,56 @@ function (_React$PureComponent) {
   }
 
   _createClass(FacetOfFacets, [{
-    key: "handleOpenToggleClick",
-    value: function handleOpenToggleClick(e) {
+    key: "componentDidUpdate",
+    value: function componentDidUpdate(pastProps, pastState) {
       var _this2 = this;
 
-      e.preventDefault();
+      var _this$props = this.props,
+          renderedFacets = _this$props.facets,
+          mounted = _this$props.mounted,
+          defaultGroupOpen = _this$props.defaultGroupOpen,
+          isStatic = _this$props.isStatic;
+      var pastMounted = pastProps.mounted,
+          pastDefaultOpen = pastProps.defaultGroupOpen,
+          pastStatic = pastProps.isStatic;
       this.setState(function (_ref) {
-        var facetOpen = _ref.facetOpen;
+        var currFacetOpen = _ref.facetOpen;
+
+        if (!pastMounted && mounted && typeof defaultGroupOpen === 'boolean' && defaultGroupOpen !== pastDefaultOpen) {
+          return {
+            'facetOpen': true
+          };
+        }
+
+        if (defaultGroupOpen === true && !pastDefaultOpen && !currFacetOpen) {
+          return {
+            'facetOpen': true
+          };
+        }
+
+        if (currFacetOpen && isStatic && !pastStatic && !_this2.memoized.anyFacetsHaveSelection(renderedFacets)) {
+          return {
+            'facetOpen': false
+          };
+        }
+
+        return null;
+      }, function () {
+        var facetOpen = _this2.state.facetOpen;
+
+        if (pastState.facetOpen !== facetOpen) {
+          _reactTooltip["default"].rebuild();
+        }
+      });
+    }
+  }, {
+    key: "handleOpenToggleClick",
+    value: function handleOpenToggleClick(e) {
+      var _this3 = this;
+
+      e.preventDefault();
+      this.setState(function (_ref2) {
+        var facetOpen = _ref2.facetOpen;
 
         if (!facetOpen) {
           return {
@@ -81,9 +146,9 @@ function (_React$PureComponent) {
         }
       }, function () {
         setTimeout(function () {
-          _this2.setState(function (_ref2) {
-            var facetOpen = _ref2.facetOpen,
-                facetClosing = _ref2.facetClosing;
+          _this3.setState(function (_ref3) {
+            var facetOpen = _ref3.facetOpen,
+                facetClosing = _ref3.facetClosing;
 
             if (facetClosing) {
               return {
@@ -101,8 +166,8 @@ function (_React$PureComponent) {
     key: "handleExpandListToggleClick",
     value: function handleExpandListToggleClick(e) {
       e.preventDefault();
-      this.setState(function (_ref3) {
-        var expanded = _ref3.expanded;
+      this.setState(function (_ref4) {
+        var expanded = _ref4.expanded;
         return {
           'expanded': !expanded
         };
@@ -111,14 +176,23 @@ function (_React$PureComponent) {
   }, {
     key: "render",
     value: function render() {
-      var _this$props = this.props,
-          title = _this$props.title,
-          facets = _this$props.facets,
-          tooltip = _this$props.tooltip,
-          areTermsSelected = _this$props.areTermsSelected;
+      var _this$props2 = this.props,
+          title = _this$props2.title,
+          renderedFacets = _this$props2.facets,
+          filters = _this$props2.filters,
+          tooltip = _this$props2.tooltip,
+          defaultGroupOpen = _this$props2.defaultGroupOpen;
       var _this$state = this.state,
           facetOpen = _this$state.facetOpen,
           facetClosing = _this$state.facetClosing;
+      var anySelections = this.memoized.anyFacetsHaveSelection(renderedFacets); // Ensure all facets within group are not "static single terms".
+
+      var extendedFacets = _react["default"].Children.map(renderedFacets, function (renderedFacet) {
+        return _react["default"].cloneElement(renderedFacet, {
+          isStatic: false
+        });
+      });
+
       return _react["default"].createElement("div", {
         className: "facet" + (facetOpen ? ' open' : ' closed') + (facetClosing ? ' closing' : ''),
         "data-field": title
@@ -136,18 +210,18 @@ function (_React$PureComponent) {
       }, title), _react["default"].createElement(_Fade.Fade, {
         "in": facetClosing || !facetOpen
       }, _react["default"].createElement("span", {
-        className: "closed-terms-count col-auto px-0" + (areTermsSelected ? " some-selected" : ""),
-        "data-tip": "Nested filters (".concat(facets.length, ") ").concat(areTermsSelected ? " with at least 1 selected." : "")
+        className: "closed-terms-count col-auto px-0" + (anySelections ? " some-selected" : ""),
+        "data-tip": "Nested filters (".concat(extendedFacets.length, ") ").concat(anySelections ? " with at least 1 selected." : "")
       }, _react["default"].createElement("i", {
         className: "icon fas icon-layer-group",
         style: {
-          opacity: areTermsSelected ? 0.75 : 0.25
+          opacity: anySelections ? 0.75 : 0.25
         }
       })))), _react["default"].createElement(_Collapse.Collapse, {
         "in": facetOpen && !facetClosing
       }, _react["default"].createElement("div", {
         className: "ml-2"
-      }, facets)));
+      }, extendedFacets)));
     }
   }]);
 
@@ -156,13 +230,9 @@ function (_React$PureComponent) {
 
 exports.FacetOfFacets = FacetOfFacets;
 FacetOfFacets.propTypes = {
-  'areTermsSelected': _propTypes["default"].bool,
-  'defaultFacetOpen': _propTypes["default"].bool,
+  'defaultGroupOpen': _propTypes["default"].bool,
   'facets': _propTypes["default"].arrayOf(_propTypes["default"].element),
   'filters': _propTypes["default"].arrayOf(_propTypes["default"].object).isRequired,
-  'getTermStatus': _propTypes["default"].func.isRequired,
-  'href': _propTypes["default"].string.isRequired,
-  // @todo: should this be required?
   'isStatic': _propTypes["default"].bool,
   'itemTypeForSchemas': _propTypes["default"].string,
   'mounted': _propTypes["default"].bool,

--- a/es/components/browse/components/FacetList/FacetOfFacets.js
+++ b/es/components/browse/components/FacetList/FacetOfFacets.js
@@ -9,13 +9,9 @@ var _react = _interopRequireDefault(require("react"));
 
 var _propTypes = _interopRequireDefault(require("prop-types"));
 
-var _underscore = _interopRequireDefault(require("underscore"));
-
-var _memoizeOne = _interopRequireDefault(require("memoize-one"));
-
-var _index = require("./index");
-
 var _Collapse = require("./../../../ui/Collapse");
+
+var _Fade = require("./../../../ui/Fade");
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
@@ -66,30 +62,6 @@ function (_React$PureComponent) {
   }
 
   _createClass(FacetOfFacets, [{
-    key: "componentDidUpdate",
-    value: function componentDidUpdate() {
-      var _this$props = this.props,
-          mounted = _this$props.mounted,
-          defaultFacetOpen = _this$props.defaultFacetOpen,
-          isStatic = _this$props.isStatic; // this.setState(({ facetOpen: currFacetOpen }) => {
-      //     if (!pastProps.mounted && mounted && typeof defaultFacetOpen === 'boolean' && defaultFacetOpen !== pastProps.defaultFacetOpen) {
-      //         return { 'facetOpen' : true };
-      //     }
-      //     if (defaultFacetOpen === true && !pastProps.defaultFacetOpen && !currFacetOpen){
-      //         return { 'facetOpen' : true };
-      //     }
-      //     if (currFacetOpen && isStatic && !pastProps.isStatic){
-      //         return { 'facetOpen' : false };
-      //     }
-      //     return null;
-      // }, ()=>{
-      //     const { facetOpen } = this.state;
-      //     if (pastState.facetOpen !== facetOpen){
-      //         ReactTooltip.rebuild();
-      //     }
-      // });
-    }
-  }, {
     key: "handleOpenToggleClick",
     value: function handleOpenToggleClick(e) {
       var _this2 = this;
@@ -139,17 +111,13 @@ function (_React$PureComponent) {
   }, {
     key: "render",
     value: function render() {
-      var _this$props2 = this.props,
-          title = _this$props2.title,
-          facetList = _this$props2.facets,
-          tooltip = _this$props2.tooltip;
+      var _this$props = this.props,
+          title = _this$props.title,
+          facetList = _this$props.facets,
+          tooltip = _this$props.tooltip;
       var _this$state = this.state,
           facetOpen = _this$state.facetOpen,
           facetClosing = _this$state.facetClosing;
-      console.log("log1: facetList[0]", facetList[0]);
-      console.log("log1: mapped", facetList.map(function (facet) {
-        return facet.title;
-      }));
       return _react["default"].createElement("div", {
         className: "facet" + (facetOpen ? ' open' : ' closed') + (facetClosing ? ' closing' : ''),
         "data-field": title
@@ -164,76 +132,22 @@ function (_React$PureComponent) {
         className: "inline-block col px-0",
         "data-tip": tooltip,
         "data-place": "right"
-      }, title)), _react["default"].createElement(_Collapse.Collapse, {
+      }, title), _react["default"].createElement(_Fade.Fade, {
+        "in": facetClosing || !facetOpen
+      }, _react["default"].createElement("span", {
+        className: "closed-terms-count col-auto px-0",
+        "data-tip": "Nested filters (".concat(facetList.length, ")")
+      }, _react["default"].createElement("i", {
+        className: "icon fas icon-layer-group",
+        style: {
+          opacity: 0.25
+        }
+      })))), _react["default"].createElement(_Collapse.Collapse, {
         "in": facetOpen && !facetClosing
       }, _react["default"].createElement("div", {
-        className: "ml-1"
+        className: "ml-2"
       }, facetList)));
-    } // static isStatic(facet){
-    //     const { terms = null, total = 0, aggregation_type = "terms", min = null, max = null } = facet;
-    //     return (
-    //         aggregation_type === "terms" &&
-    //         Array.isArray(terms) &&
-    //         terms.length === 1 &&
-    //         total <= _.reduce(terms, function(m, t){ return m + (t.doc_count || 0); }, 0)
-    //     ) || (
-    //         aggregation_type == "stats" &&
-    //         min === max
-    //     );
-    // }
-    // constructor(props){
-    //     super(props);
-    //     this.handleStaticClick = this.handleStaticClick.bind(this);
-    //     this.handleTermClick = this.handleTermClick.bind(this);
-    //     this.state = { 'filtering' : false };
-    // }
-    // /**
-    //  * For cases when there is only one option for a facet - we render a 'static' row.
-    //  * This may change in response to design.
-    //  * Unlike in `handleTermClick`, we handle own state/UI here.
-    //  *
-    //  * @todo Allow to specify interval for histogram & date_histogram in schema instead of hard-coding 'month' interval.
-    //  */
-    // handleStaticClick(e) {
-    //     const { facet, isStatic } = this.props;
-    //     const term = facet.terms[0]; // Would only have 1
-    //     e.preventDefault();
-    //     if (!isStatic) return false;
-    //     this.setState({ 'filtering' : true }, () => {
-    //         this.handleTermClick(facet, term, e, () =>
-    //             this.setState({ 'filtering' : false })
-    //         );
-    //     });
-    // }
-    // /**
-    //  * Each Term component instance provides their own callback, we just route the navigation request.
-    //  *
-    //  * @todo Allow to specify interval for histogram & date_histogram in schema instead of hard-coding 'month' interval.
-    //  */
-    // handleTermClick(facet, term, e, callback) {
-    //     const { onFilter, href } = this.props;
-    //     onFilter(facet, term, callback, false, href);
-    // }
-    // render() {
-    //     const {
-    //         facet, getTermStatus, extraClassname, termTransformFxn, separateSingleTermFacets,
-    //         defaultFacetOpen, filters, onFilter, mounted, isStatic
-    //     } = this.props;
-    //     const { filtering } = this.state;
-    //     const { description = null, field, title, terms = [], aggregation_type = "terms" } = facet;
-    //     const showTitle = title || field;
-    //     if (aggregation_type === "stats") {
-    //         return <RangeFacet {...{ facet, filtering, defaultFacetOpen, termTransformFxn, filters, onFilter, mounted, isStatic }} tooltip={description} title={showTitle} />;
-    //     }
-    //     // Default case for "terms" buckets/facets
-    //     if (separateSingleTermFacets && isStatic){
-    //         // Only one term exists.
-    //         return <StaticSingleTerm {...{ facet, term : terms[0], filtering, showTitle, onClick : this.handleStaticClick, getTermStatus, extraClassname, termTransformFxn }} />;
-    //     } else {
-    //         return <FacetTermsList {...this.props} onTermClick={this.handleTermClick} tooltip={description} title={showTitle} />;
-    //     }
-    // }
-
+    }
   }]);
 
   return FacetOfFacets;

--- a/es/components/browse/components/FacetList/FacetOfFacets.js
+++ b/es/components/browse/components/FacetList/FacetOfFacets.js
@@ -195,7 +195,7 @@ function (_React$PureComponent) {
 
       return _react["default"].createElement("div", {
         className: "facet" + (facetOpen ? ' open' : ' closed') + (facetClosing ? ' closing' : ''),
-        "data-field": title
+        "data-group": title
       }, _react["default"].createElement("h5", {
         className: "facet-title",
         onClick: this.handleOpenToggleClick
@@ -211,7 +211,7 @@ function (_React$PureComponent) {
         "in": facetClosing || !facetOpen
       }, _react["default"].createElement("span", {
         className: "closed-terms-count col-auto px-0" + (anySelections ? " some-selected" : ""),
-        "data-tip": "Nested filters (".concat(extendedFacets.length, ") ").concat(anySelections ? " with at least 1 selected." : "")
+        "data-tip": "Group of filters (".concat(extendedFacets.length, ") ").concat(anySelections ? " with at least 1 having a selection." : "")
       }, _react["default"].createElement("i", {
         className: "icon fas icon-layer-group",
         style: {

--- a/es/components/browse/components/FacetList/FacetOfFacets.js
+++ b/es/components/browse/components/FacetList/FacetOfFacets.js
@@ -152,24 +152,25 @@ function (_React$PureComponent) {
   }]);
 
   return FacetOfFacets;
-}(_react["default"].PureComponent); // FacetOfFacets.propTypes = {
-//     'facet'                 : PropTypes.shape({
-//         'field'                 : PropTypes.string.isRequired,    // Name of nested field property in experiment objects, using dot-notation.
-//         'title'                 : PropTypes.string,               // Human-readable Facet Term
-//         'total'                 : PropTypes.number,               // Total experiments (or terms??) w/ field
-//         'terms'                 : PropTypes.array.isRequired,     // Possible terms,
-//         'description'           : PropTypes.string,
-//         'aggregation_type'      : PropTypes.oneOf(["stats", "terms"])
-//     }),
-//     'defaultFacetOpen'      : PropTypes.bool,
-//     'onFilter'              : PropTypes.func,           // Executed on term click
-//     'extraClassname'        : PropTypes.string,
-//     'schemas'               : PropTypes.object,
-//     'getTermStatus'         : PropTypes.func.isRequired,
-//     'href'                  : PropTypes.string.isRequired,
-//     'filters'               : PropTypes.arrayOf(PropTypes.object).isRequired,
-//     'mounted'               : PropTypes.bool
-// };
-
+}(_react["default"].PureComponent);
 
 exports.FacetOfFacets = FacetOfFacets;
+FacetOfFacets.propTypes = {
+  'areTermsSelected': _propTypes["default"].bool,
+  'defaultFacetOpen': _propTypes["default"].bool,
+  'facets': _propTypes["default"].arrayOf(_propTypes["default"].element),
+  'filters': _propTypes["default"].arrayOf(_propTypes["default"].object).isRequired,
+  'getTermStatus': _propTypes["default"].func.isRequired,
+  'href': _propTypes["default"].string.isRequired,
+  // @todo: should this be required?
+  'isStatic': _propTypes["default"].bool,
+  'itemTypeForSchemas': _propTypes["default"].string,
+  'mounted': _propTypes["default"].bool,
+  'onFilter': _propTypes["default"].func,
+  // Executed on term click
+  'schemas': _propTypes["default"].object,
+  'separateSingleTermFacets': _propTypes["default"].bool,
+  'termTransformFxn': _propTypes["default"].func,
+  'title': _propTypes["default"].string,
+  'extraClassname': _propTypes["default"].string
+};

--- a/es/components/browse/components/FacetList/FacetTermsList.js
+++ b/es/components/browse/components/FacetList/FacetTermsList.js
@@ -21,6 +21,8 @@ var _Fade = require("./../../../ui/Fade");
 
 var _PartialList = require("./../../../ui/PartialList");
 
+var _index = require("./index");
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
 function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function (obj) { return typeof obj; }; } else { _typeof = function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
@@ -191,64 +193,6 @@ var FacetTermsList =
 function (_React$PureComponent2) {
   _inherits(FacetTermsList, _React$PureComponent2);
 
-  _createClass(FacetTermsList, null, [{
-    key: "anyTermsSelected",
-    value: function anyTermsSelected() {
-      var terms = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : [];
-      var facet = arguments.length > 1 ? arguments[1] : undefined;
-      var filters = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : [];
-      var activeTermsForField = {};
-      filters.forEach(function (f) {
-        if (f.field !== facet.field) return;
-        activeTermsForField[f.term] = true;
-      });
-
-      for (var i = 0; i < terms.length; i++) {
-        if (activeTermsForField[terms[i].key]) {
-          return true;
-        }
-      }
-
-      return false;
-    }
-  }, {
-    key: "mergeTerms",
-    value: function mergeTerms(facet, filters) {
-      var activeTermsForField = {};
-      filters.forEach(function (f) {
-        if (f.field !== facet.field) return;
-        activeTermsForField[f.term] = true;
-      }); // Filter out terms w/ 0 counts (in case).
-
-      var terms = facet.terms.filter(function (term) {
-        if (term.doc_count > 0) return true;
-        if (activeTermsForField[term.key]) return true;
-        return false;
-      });
-      terms.forEach(function (_ref) {
-        var key = _ref.key;
-        delete activeTermsForField[key];
-      }); // Filter out type=Item for now (hardcode)
-
-      if (facet.field === "type") {
-        terms = terms.filter(function (t) {
-          return t !== 'Item' && t && t.key !== 'Item';
-        });
-      } // These are terms which might have been manually defined in URL but are not present in data at all.
-      // Include them so we can unselect them.
-
-
-      var unseenTerms = _underscore["default"].keys(activeTermsForField).map(function (term) {
-        return {
-          key: term,
-          doc_count: 0
-        };
-      });
-
-      return terms.concat(unseenTerms);
-    }
-  }]);
-
   function FacetTermsList(props) {
     var _this3;
 
@@ -264,8 +208,8 @@ function (_React$PureComponent2) {
       'expanded': false
     };
     _this3.memoized = {
-      anyTermsSelected: (0, _memoizeOne["default"])(FacetTermsList.anyTermsSelected),
-      mergeTerms: (0, _memoizeOne["default"])(FacetTermsList.mergeTerms)
+      anyTermsSelected: (0, _memoizeOne["default"])(_index.anyTermsSelected),
+      mergeTerms: (0, _memoizeOne["default"])(_index.mergeTerms)
     };
     return _this3;
   }
@@ -281,8 +225,8 @@ function (_React$PureComponent2) {
           isStatic = _this$props3.isStatic,
           facet = _this$props3.facet,
           filters = _this$props3.filters;
-      this.setState(function (_ref2) {
-        var currFacetOpen = _ref2.facetOpen;
+      this.setState(function (_ref) {
+        var currFacetOpen = _ref.facetOpen;
 
         if (!pastProps.mounted && mounted && typeof defaultFacetOpen === 'boolean' && defaultFacetOpen !== pastProps.defaultFacetOpen) {
           return {
@@ -317,8 +261,8 @@ function (_React$PureComponent2) {
       var _this5 = this;
 
       e.preventDefault();
-      this.setState(function (_ref3) {
-        var facetOpen = _ref3.facetOpen;
+      this.setState(function (_ref2) {
+        var facetOpen = _ref2.facetOpen;
 
         if (!facetOpen) {
           return {
@@ -331,9 +275,9 @@ function (_React$PureComponent2) {
         }
       }, function () {
         setTimeout(function () {
-          _this5.setState(function (_ref4) {
-            var facetOpen = _ref4.facetOpen,
-                facetClosing = _ref4.facetClosing;
+          _this5.setState(function (_ref3) {
+            var facetOpen = _ref3.facetOpen,
+                facetClosing = _ref3.facetClosing;
 
             if (facetClosing) {
               return {
@@ -351,8 +295,8 @@ function (_React$PureComponent2) {
     key: "handleExpandListToggleClick",
     value: function handleExpandListToggleClick(e) {
       e.preventDefault();
-      this.setState(function (_ref5) {
-        var expanded = _ref5.expanded;
+      this.setState(function (_ref4) {
+        var expanded = _ref4.expanded;
         return {
           'expanded': !expanded
         };

--- a/es/components/browse/components/FacetList/FacetTermsList.js
+++ b/es/components/browse/components/FacetList/FacetTermsList.js
@@ -373,7 +373,7 @@ function (_React$PureComponent2) {
       var terms = this.memoized.mergeTerms(facet, filters);
       var anyTermsSelected = this.memoized.anyTermsSelected(terms, facet, filters);
       var termsLen = terms.length;
-      var indicator;
+      var indicator; // @todo: much of this code (including mergeTerms and anyTermsSelected above) were moved to index; consider moving these too
 
       if (isStatic || termsLen === 1) {
         indicator = // Small indicator to help represent how many terms there are available for this Facet.

--- a/es/components/browse/components/FacetList/FacetTermsList.js
+++ b/es/components/browse/components/FacetList/FacetTermsList.js
@@ -3,6 +3,8 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+exports.anyTermsSelected = anyTermsSelected;
+exports.mergeTerms = mergeTerms;
 exports.FacetTermsList = exports.Term = void 0;
 
 var _react = _interopRequireDefault(require("react"));
@@ -20,8 +22,6 @@ var _Collapse = require("./../../../ui/Collapse");
 var _Fade = require("./../../../ui/Fade");
 
 var _PartialList = require("./../../../ui/PartialList");
-
-var _index = require("./index");
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
@@ -45,9 +45,67 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function (o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
+/* used in FacetList and FacetTermsList */
+function anyTermsSelected() {
+  var terms = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : [];
+  var facet = arguments.length > 1 ? arguments[1] : undefined;
+  var filters = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : [];
+  var activeTermsForField = {};
+  filters.forEach(function (f) {
+    if (f.field !== facet.field) return;
+    activeTermsForField[f.term] = true;
+  });
+
+  for (var i = 0; i < terms.length; i++) {
+    if (activeTermsForField[terms[i].key]) {
+      return true;
+    }
+  }
+
+  return false;
+}
+/* used in FacetList and FacetTermsList */
+
+
+function mergeTerms(facet, filters) {
+  var activeTermsForField = {};
+  filters.forEach(function (f) {
+    if (f.field !== facet.field) return;
+    activeTermsForField[f.term] = true;
+  }); // Filter out terms w/ 0 counts (in case).
+
+  var terms = facet.terms.filter(function (term) {
+    if (term.doc_count > 0) return true;
+    if (activeTermsForField[term.key]) return true;
+    return false;
+  });
+  terms.forEach(function (_ref) {
+    var key = _ref.key;
+    delete activeTermsForField[key];
+  }); // Filter out type=Item for now (hardcode)
+
+  if (facet.field === "type") {
+    terms = terms.filter(function (t) {
+      return t !== 'Item' && t && t.key !== 'Item';
+    });
+  } // These are terms which might have been manually defined in URL but are not present in data at all.
+  // Include them so we can unselect them.
+
+
+  var unseenTerms = _underscore["default"].keys(activeTermsForField).map(function (term) {
+    return {
+      key: term,
+      doc_count: 0
+    };
+  });
+
+  return terms.concat(unseenTerms);
+}
 /**
  * Used to render individual terms in FacetList.
  */
+
+
 var Term =
 /*#__PURE__*/
 function (_React$PureComponent) {
@@ -207,10 +265,6 @@ function (_React$PureComponent2) {
       'facetClosing': false,
       'expanded': false
     };
-    _this3.memoized = {
-      anyTermsSelected: (0, _memoizeOne["default"])(_index.anyTermsSelected),
-      mergeTerms: (0, _memoizeOne["default"])(_index.mergeTerms)
-    };
     return _this3;
   }
 
@@ -220,27 +274,29 @@ function (_React$PureComponent2) {
       var _this4 = this;
 
       var _this$props3 = this.props,
+          anySelected = _this$props3.anyTermsSelected,
           mounted = _this$props3.mounted,
           defaultFacetOpen = _this$props3.defaultFacetOpen,
-          isStatic = _this$props3.isStatic,
-          facet = _this$props3.facet,
-          filters = _this$props3.filters;
-      this.setState(function (_ref) {
-        var currFacetOpen = _ref.facetOpen;
+          isStatic = _this$props3.isStatic;
+      var pastMounted = pastProps.mounted,
+          pastDefaultOpen = pastProps.defaultFacetOpen,
+          pastStatic = pastProps.isStatic;
+      this.setState(function (_ref2) {
+        var currFacetOpen = _ref2.facetOpen;
 
-        if (!pastProps.mounted && mounted && typeof defaultFacetOpen === 'boolean' && defaultFacetOpen !== pastProps.defaultFacetOpen) {
+        if (!pastMounted && mounted && typeof defaultFacetOpen === 'boolean' && defaultFacetOpen !== pastDefaultOpen) {
           return {
             'facetOpen': true
           };
         }
 
-        if (defaultFacetOpen === true && !pastProps.defaultFacetOpen && !currFacetOpen) {
+        if (defaultFacetOpen === true && !pastDefaultOpen && !currFacetOpen) {
           return {
             'facetOpen': true
           };
         }
 
-        if (currFacetOpen && isStatic && !pastProps.isStatic && !_this4.memoized.anyTermsSelected(_this4.memoized.mergeTerms(facet, filters), facet, filters)) {
+        if (currFacetOpen && isStatic && !pastStatic && !anySelected) {
           return {
             'facetOpen': false
           };
@@ -261,8 +317,8 @@ function (_React$PureComponent2) {
       var _this5 = this;
 
       e.preventDefault();
-      this.setState(function (_ref2) {
-        var facetOpen = _ref2.facetOpen;
+      this.setState(function (_ref3) {
+        var facetOpen = _ref3.facetOpen;
 
         if (!facetOpen) {
           return {
@@ -275,9 +331,9 @@ function (_React$PureComponent2) {
         }
       }, function () {
         setTimeout(function () {
-          _this5.setState(function (_ref3) {
-            var facetOpen = _ref3.facetOpen,
-                facetClosing = _ref3.facetClosing;
+          _this5.setState(function (_ref4) {
+            var facetOpen = _ref4.facetOpen,
+                facetClosing = _ref4.facetClosing;
 
             if (facetClosing) {
               return {
@@ -295,8 +351,8 @@ function (_React$PureComponent2) {
     key: "handleExpandListToggleClick",
     value: function handleExpandListToggleClick(e) {
       e.preventDefault();
-      this.setState(function (_ref4) {
-        var expanded = _ref4.expanded;
+      this.setState(function (_ref5) {
+        var expanded = _ref5.expanded;
         return {
           'expanded': !expanded
         };
@@ -363,15 +419,14 @@ function (_React$PureComponent2) {
     value: function render() {
       var _this$props5 = this.props,
           facet = _this$props5.facet,
-          filters = _this$props5.filters,
+          terms = _this$props5.terms,
           tooltip = _this$props5.tooltip,
           title = _this$props5.title,
-          isStatic = _this$props5.isStatic;
+          isStatic = _this$props5.isStatic,
+          anySelected = _this$props5.anyTermsSelected;
       var _this$state = this.state,
           facetOpen = _this$state.facetOpen,
           facetClosing = _this$state.facetClosing;
-      var terms = this.memoized.mergeTerms(facet, filters);
-      var anyTermsSelected = this.memoized.anyTermsSelected(terms, facet, filters);
       var termsLen = terms.length;
       var indicator; // @todo: much of this code (including mergeTerms and anyTermsSelected above) were moved to index; consider moving these too
 
@@ -380,13 +435,13 @@ function (_React$PureComponent2) {
         _react["default"].createElement(_Fade.Fade, {
           "in": facetClosing || !facetOpen
         }, _react["default"].createElement("span", {
-          className: "closed-terms-count col-auto px-0" + (anyTermsSelected ? " some-selected" : ""),
-          "data-tip": "No useful options (1 total)" + (anyTermsSelected ? "; is selected" : ""),
-          "data-any-selected": anyTermsSelected
+          className: "closed-terms-count col-auto px-0" + (anySelected ? " some-selected" : ""),
+          "data-tip": "No useful options (1 total)" + (anySelected ? "; is selected" : ""),
+          "data-any-selected": anySelected
         }, _react["default"].createElement("i", {
-          className: "icon fas icon-" + (anyTermsSelected ? "circle" : "minus-circle"),
+          className: "icon fas icon-" + (anySelected ? "circle" : "minus-circle"),
           style: {
-            opacity: anyTermsSelected ? 0.75 : 0.25
+            opacity: anySelected ? 0.75 : 0.25
           }
         })));
       } else {
@@ -394,9 +449,9 @@ function (_React$PureComponent2) {
         _react["default"].createElement(_Fade.Fade, {
           "in": facetClosing || !facetOpen
         }, _react["default"].createElement("span", {
-          className: "closed-terms-count col-auto px-0" + (anyTermsSelected ? " some-selected" : ""),
-          "data-tip": termsLen + " options" + (anyTermsSelected ? " with at least one selected" : ""),
-          "data-any-selected": anyTermsSelected
+          className: "closed-terms-count col-auto px-0" + (anySelected ? " some-selected" : ""),
+          "data-tip": termsLen + " options" + (anySelected ? " with at least one selected" : ""),
+          "data-any-selected": anySelected
         }, _underscore["default"].range(0, Math.min(Math.ceil(termsLen / 3), 8)).map(function (c) {
           return _react["default"].createElement("i", {
             className: "icon icon-ellipsis-v fas",

--- a/es/components/browse/components/FacetList/TermsFacet.js
+++ b/es/components/browse/components/FacetList/TermsFacet.js
@@ -1,0 +1,198 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.TermsFacet = void 0;
+
+var _react = _interopRequireDefault(require("react"));
+
+var _propTypes = _interopRequireDefault(require("prop-types"));
+
+var _underscore = _interopRequireDefault(require("underscore"));
+
+var _FacetTermsList = require("./FacetTermsList");
+
+var _StaticSingleTerm = require("./StaticSingleTerm");
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+
+function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function (obj) { return typeof obj; }; } else { _typeof = function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
+function _extends() { _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function (o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function (o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
+/**
+ * Component to render out the FacetList for the Browse and ExperimentSet views.
+ * It can work with AJAX-ed in back-end data, as is used for the Browse page, or
+ * with client-side data from back-end-provided Experiments, as is used for the ExperimentSet view.
+ *
+ * Some of this code is not super clean and eventually could use some refactoring.
+ *
+ * @module {Component} facetlist
+ */
+
+/**
+ * Used to render individual facet fields and their available terms in FacetList.
+ */
+var TermsFacet =
+/*#__PURE__*/
+function (_React$PureComponent) {
+  _inherits(TermsFacet, _React$PureComponent);
+
+  _createClass(TermsFacet, null, [{
+    key: "isStatic",
+    value: function isStatic(facet) {
+      var _facet$terms = facet.terms,
+          terms = _facet$terms === void 0 ? null : _facet$terms,
+          _facet$total = facet.total,
+          total = _facet$total === void 0 ? 0 : _facet$total;
+      return Array.isArray(terms) && terms.length === 1 && total <= _underscore["default"].reduce(terms, function (m, t) {
+        return m + (t.doc_count || 0);
+      }, 0);
+    }
+  }]);
+
+  function TermsFacet(props) {
+    var _this;
+
+    _classCallCheck(this, TermsFacet);
+
+    _this = _possibleConstructorReturn(this, _getPrototypeOf(TermsFacet).call(this, props));
+    _this.handleStaticClick = _this.handleStaticClick.bind(_assertThisInitialized(_this));
+    _this.handleTermClick = _this.handleTermClick.bind(_assertThisInitialized(_this));
+    _this.state = {
+      'filtering': false
+    };
+    return _this;
+  }
+  /**
+   * For cases when there is only one option for a facet - we render a 'static' row.
+   * This may change in response to design.
+   * Unlike in `handleTermClick`, we handle own state/UI here.
+   *
+   * @todo Allow to specify interval for histogram & date_histogram in schema instead of hard-coding 'month' interval.
+   */
+
+
+  _createClass(TermsFacet, [{
+    key: "handleStaticClick",
+    value: function handleStaticClick(e) {
+      var _this2 = this;
+
+      var _this$props = this.props,
+          facet = _this$props.facet,
+          isStatic = _this$props.isStatic;
+      var term = facet.terms[0]; // Would only have 1
+
+      e.preventDefault();
+      if (!isStatic) return false;
+      this.setState({
+        'filtering': true
+      }, function () {
+        _this2.handleTermClick(facet, term, e, function () {
+          return _this2.setState({
+            'filtering': false
+          });
+        });
+      });
+    }
+    /**
+     * Each Term component instance provides their own callback, we just route the navigation request.
+     *
+     * @todo Allow to specify interval for histogram & date_histogram in schema instead of hard-coding 'month' interval.
+     */
+
+  }, {
+    key: "handleTermClick",
+    value: function handleTermClick(facet, term, e, callback) {
+      var _this$props2 = this.props,
+          onFilter = _this$props2.onFilter,
+          href = _this$props2.href;
+      onFilter(facet, term, callback, false, href);
+    }
+  }, {
+    key: "render",
+    value: function render() {
+      var _this$props3 = this.props,
+          facet = _this$props3.facet,
+          terms = _this$props3.terms,
+          getTermStatus = _this$props3.getTermStatus,
+          extraClassname = _this$props3.extraClassname,
+          termTransformFxn = _this$props3.termTransformFxn,
+          separateSingleTermFacets = _this$props3.separateSingleTermFacets,
+          isStatic = _this$props3.isStatic;
+      var filtering = this.state.filtering;
+
+      var _ref = facet || {},
+          field = _ref.field,
+          title = _ref.title,
+          _ref$description = _ref.description,
+          description = _ref$description === void 0 ? null : _ref$description;
+
+      var showTitle = title || field;
+
+      if (separateSingleTermFacets && isStatic) {
+        // Only one term exists.
+        return _react["default"].createElement(_StaticSingleTerm.StaticSingleTerm, {
+          facet: facet,
+          term: terms[0],
+          filtering: filtering,
+          showTitle: showTitle,
+          onClick: this.handleStaticClick,
+          getTermStatus: getTermStatus,
+          extraClassname: extraClassname,
+          termTransformFxn: termTransformFxn
+        });
+      } else {
+        return _react["default"].createElement(_FacetTermsList.FacetTermsList, _extends({}, this.props, {
+          onTermClick: this.handleTermClick,
+          tooltip: description,
+          title: showTitle
+        }));
+      }
+    }
+  }]);
+
+  return TermsFacet;
+}(_react["default"].PureComponent);
+
+exports.TermsFacet = TermsFacet;
+TermsFacet.propTypes = {
+  'facet': _propTypes["default"].shape({
+    'field': _propTypes["default"].string.isRequired,
+    // Name of nested field property in experiment objects, using dot-notation.
+    'title': _propTypes["default"].string,
+    // Human-readable Facet Term
+    'total': _propTypes["default"].number,
+    // Total experiments (or terms??) w/ field
+    'terms': _propTypes["default"].array.isRequired,
+    // Possible terms,
+    'description': _propTypes["default"].string,
+    'aggregation_type': _propTypes["default"].oneOf(["stats", "terms"])
+  }),
+  'defaultFacetOpen': _propTypes["default"].bool,
+  'onFilter': _propTypes["default"].func,
+  // Executed on term click
+  'extraClassname': _propTypes["default"].string,
+  'schemas': _propTypes["default"].object,
+  'getTermStatus': _propTypes["default"].func.isRequired,
+  'href': _propTypes["default"].string.isRequired,
+  'filters': _propTypes["default"].arrayOf(_propTypes["default"].object).isRequired,
+  'mounted': _propTypes["default"].bool
+};

--- a/es/components/browse/components/FacetList/index.js
+++ b/es/components/browse/components/FacetList/index.js
@@ -16,8 +16,6 @@ var _queryString = _interopRequireDefault(require("query-string"));
 
 var _underscore = _interopRequireDefault(require("underscore"));
 
-var _memoizeOne = _interopRequireDefault(require("memoize-one"));
-
 var _patchedConsole = require("./../../../util/patched-console");
 
 var _searchFilters = require("./../../../util/search-filters");
@@ -28,11 +26,11 @@ var analytics = _interopRequireWildcard(require("./../../../util/analytics"));
 
 var _layout = require("./../../../util/layout");
 
+var _TermsFacet = require("./TermsFacet");
+
 var _RangeFacet = require("./RangeFacet");
 
 var _FacetTermsList = require("./FacetTermsList");
-
-var _StaticSingleTerm = require("./StaticSingleTerm");
 
 var _FacetOfFacets = require("./FacetOfFacets");
 
@@ -41,6 +39,8 @@ function _getRequireWildcardCache() { if (typeof WeakMap !== "function") return 
 function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } var cache = _getRequireWildcardCache(); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; if (obj != null) { var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj["default"] = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+
+function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function (obj) { return typeof obj; }; } else { _typeof = function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
 function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _nonIterableRest(); }
 
@@ -58,21 +58,19 @@ function _iterableToArray(iter) { if (Symbol.iterator in Object(iter) || Object.
 
 function _arrayWithoutHoles(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = new Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } }
 
-function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function (obj) { return typeof obj; }; } else { _typeof = function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
-
 function _extends() { _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
 
 function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function (o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
-
-function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
-
-function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
 
@@ -89,154 +87,6 @@ function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || func
  */
 
 /**
- * Used to render individual facet fields and their available terms in FacetList.
- */
-var TermsFacet =
-/*#__PURE__*/
-function (_React$PureComponent) {
-  _inherits(TermsFacet, _React$PureComponent);
-
-  _createClass(TermsFacet, null, [{
-    key: "isStatic",
-    value: function isStatic(facet) {
-      var _facet$terms = facet.terms,
-          terms = _facet$terms === void 0 ? null : _facet$terms,
-          _facet$total = facet.total,
-          total = _facet$total === void 0 ? 0 : _facet$total;
-      return Array.isArray(terms) && terms.length === 1 && total <= _underscore["default"].reduce(terms, function (m, t) {
-        return m + (t.doc_count || 0);
-      }, 0);
-    }
-  }]);
-
-  function TermsFacet(props) {
-    var _this;
-
-    _classCallCheck(this, TermsFacet);
-
-    _this = _possibleConstructorReturn(this, _getPrototypeOf(TermsFacet).call(this, props));
-    _this.handleStaticClick = _this.handleStaticClick.bind(_assertThisInitialized(_this));
-    _this.handleTermClick = _this.handleTermClick.bind(_assertThisInitialized(_this));
-    _this.state = {
-      'filtering': false
-    };
-    return _this;
-  }
-  /**
-   * For cases when there is only one option for a facet - we render a 'static' row.
-   * This may change in response to design.
-   * Unlike in `handleTermClick`, we handle own state/UI here.
-   *
-   * @todo Allow to specify interval for histogram & date_histogram in schema instead of hard-coding 'month' interval.
-   */
-
-
-  _createClass(TermsFacet, [{
-    key: "handleStaticClick",
-    value: function handleStaticClick(e) {
-      var _this2 = this;
-
-      var _this$props = this.props,
-          facet = _this$props.facet,
-          isStatic = _this$props.isStatic;
-      var term = facet.terms[0]; // Would only have 1
-
-      e.preventDefault();
-      if (!isStatic) return false;
-      this.setState({
-        'filtering': true
-      }, function () {
-        _this2.handleTermClick(facet, term, e, function () {
-          return _this2.setState({
-            'filtering': false
-          });
-        });
-      });
-    }
-    /**
-     * Each Term component instance provides their own callback, we just route the navigation request.
-     *
-     * @todo Allow to specify interval for histogram & date_histogram in schema instead of hard-coding 'month' interval.
-     */
-
-  }, {
-    key: "handleTermClick",
-    value: function handleTermClick(facet, term, e, callback) {
-      var _this$props2 = this.props,
-          onFilter = _this$props2.onFilter,
-          href = _this$props2.href;
-      onFilter(facet, term, callback, false, href);
-    }
-  }, {
-    key: "render",
-    value: function render() {
-      var _this$props3 = this.props,
-          facet = _this$props3.facet,
-          terms = _this$props3.terms,
-          getTermStatus = _this$props3.getTermStatus,
-          extraClassname = _this$props3.extraClassname,
-          termTransformFxn = _this$props3.termTransformFxn,
-          separateSingleTermFacets = _this$props3.separateSingleTermFacets,
-          isStatic = _this$props3.isStatic;
-      var filtering = this.state.filtering;
-
-      var _ref = facet || {},
-          field = _ref.field,
-          title = _ref.title,
-          _ref$description = _ref.description,
-          description = _ref$description === void 0 ? null : _ref$description;
-
-      var showTitle = title || field;
-
-      if (separateSingleTermFacets && isStatic) {
-        // Only one term exists.
-        return _react["default"].createElement(_StaticSingleTerm.StaticSingleTerm, {
-          facet: facet,
-          term: terms[0],
-          filtering: filtering,
-          showTitle: showTitle,
-          onClick: this.handleStaticClick,
-          getTermStatus: getTermStatus,
-          extraClassname: extraClassname,
-          termTransformFxn: termTransformFxn
-        });
-      } else {
-        return _react["default"].createElement(_FacetTermsList.FacetTermsList, _extends({}, this.props, {
-          onTermClick: this.handleTermClick,
-          tooltip: description,
-          title: showTitle
-        }));
-      }
-    }
-  }]);
-
-  return TermsFacet;
-}(_react["default"].PureComponent);
-
-TermsFacet.propTypes = {
-  'facet': _propTypes["default"].shape({
-    'field': _propTypes["default"].string.isRequired,
-    // Name of nested field property in experiment objects, using dot-notation.
-    'title': _propTypes["default"].string,
-    // Human-readable Facet Term
-    'total': _propTypes["default"].number,
-    // Total experiments (or terms??) w/ field
-    'terms': _propTypes["default"].array.isRequired,
-    // Possible terms,
-    'description': _propTypes["default"].string,
-    'aggregation_type': _propTypes["default"].oneOf(["stats", "terms"])
-  }),
-  'defaultFacetOpen': _propTypes["default"].bool,
-  'onFilter': _propTypes["default"].func,
-  // Executed on term click
-  'extraClassname': _propTypes["default"].string,
-  'schemas': _propTypes["default"].object,
-  'getTermStatus': _propTypes["default"].func.isRequired,
-  'href': _propTypes["default"].string.isRequired,
-  'filters': _propTypes["default"].arrayOf(_propTypes["default"].object).isRequired,
-  'mounted': _propTypes["default"].bool
-};
-/**
  * Use this function as part of SearchView and BrowseView to be passed down to FacetList.
  * Should be bound to a component instance, with `this` providing 'href', 'context' (with 'filters' property), and 'navigate'.
  *
@@ -248,7 +98,6 @@ TermsFacet.propTypes = {
  * @param {function} callback - Any function to execute afterwards.
  * @param {boolean} [skipNavigation=false] - If true, will return next targetSearchHref instead of going to it. Use to e.g. batch up filter changes on multiple fields.
  */
-
 function performFilteringQuery(props, facet, term, callback) {
   var skipNavigation = arguments.length > 4 && arguments[4] !== undefined ? arguments[4] : false;
   var currentHref = arguments.length > 5 && arguments[5] !== undefined ? arguments[5] : null;
@@ -338,20 +187,20 @@ function performFilteringQuery(props, facet, term, callback) {
 
 var FacetList =
 /*#__PURE__*/
-function (_React$PureComponent2) {
-  _inherits(FacetList, _React$PureComponent2);
+function (_React$PureComponent) {
+  _inherits(FacetList, _React$PureComponent);
 
   function FacetList(props) {
-    var _this3;
+    var _this;
 
     _classCallCheck(this, FacetList);
 
-    _this3 = _possibleConstructorReturn(this, _getPrototypeOf(FacetList).call(this, props));
-    _this3.state = {
+    _this = _possibleConstructorReturn(this, _getPrototypeOf(FacetList).call(this, props));
+    _this.renderFacets = _this.renderFacets.bind(_assertThisInitialized(_this));
+    _this.state = {
       'mounted': false
     };
-    _this3.renderFacets = _this3.renderFacets.bind(_assertThisInitialized(_this3));
-    return _this3;
+    return _this;
   }
 
   _createClass(FacetList, [{
@@ -364,19 +213,19 @@ function (_React$PureComponent2) {
   }, {
     key: "renderFacets",
     value: function renderFacets() {
-      var _this$props4 = this.props,
-          facets = _this$props4.facets,
-          href = _this$props4.href,
-          onFilter = _this$props4.onFilter,
-          schemas = _this$props4.schemas,
-          getTermStatus = _this$props4.getTermStatus,
-          filters = _this$props4.filters,
-          itemTypeForSchemas = _this$props4.itemTypeForSchemas,
-          windowWidth = _this$props4.windowWidth,
-          persistentCount = _this$props4.persistentCount,
-          termTransformFxn = _this$props4.termTransformFxn,
-          separateSingleTermFacets = _this$props4.separateSingleTermFacets,
-          windowHeight = _this$props4.windowHeight;
+      var _this$props = this.props,
+          facets = _this$props.facets,
+          href = _this$props.href,
+          onFilter = _this$props.onFilter,
+          schemas = _this$props.schemas,
+          getTermStatus = _this$props.getTermStatus,
+          filters = _this$props.filters,
+          itemTypeForSchemas = _this$props.itemTypeForSchemas,
+          windowWidth = _this$props.windowWidth,
+          persistentCount = _this$props.persistentCount,
+          termTransformFxn = _this$props.termTransformFxn,
+          separateSingleTermFacets = _this$props.separateSingleTermFacets,
+          windowHeight = _this$props.windowHeight;
       var mounted = this.state.mounted; // Ensure each facets has an `order` property and default it to 0 if not.
       // And then sort by `order`.
 
@@ -468,12 +317,12 @@ function (_React$PureComponent2) {
 
           var _anySelected = (0, _FacetTermsList.anyTermsSelected)(terms, facet, filters);
 
-          var _isStatic = TermsFacet.isStatic(facet);
+          var _isStatic = _TermsFacet.TermsFacet.isStatic(facet);
 
           defaultFacetOpen = defaultFacetOpen || !_isStatic && _underscore["default"].any(filters || [], function (fltr) {
             return fltr.field === facetField;
           }) || false;
-          return _react["default"].createElement(TermsFacet, _extends({}, commonProps, {
+          return _react["default"].createElement(_TermsFacet.TermsFacet, _extends({}, commonProps, {
             facet: facet,
             key: facetField,
             anyTermsSelected: _anySelected
@@ -521,10 +370,10 @@ function (_React$PureComponent2) {
       var groupsArr = _toConsumableArray(groups); // Check, render, and add groups into `componentsToReturn`
 
 
-      groupsArr.forEach(function (_ref2) {
-        var _ref3 = _slicedToArray(_ref2, 2),
-            groupTitle = _ref3[0],
-            facetGroup = _ref3[1];
+      groupsArr.forEach(function (_ref) {
+        var _ref2 = _slicedToArray(_ref, 2),
+            groupTitle = _ref2[0],
+            facetGroup = _ref2[1];
 
         var facetsInGroup = facetGroup.facets,
             index = facetGroup.index;
@@ -536,9 +385,9 @@ function (_React$PureComponent2) {
           // so `fromIdx` / `groupIndex` should always stay stable.
           // We increment facetGroup.index which is the index in `componentsToReturn`.
 
-          groupsArr.slice(fromIdx).forEach(function (_ref4) {
-            var _ref5 = _slicedToArray(_ref4, 2),
-                subsequentFacetGroup = _ref5[1];
+          groupsArr.slice(fromIdx).forEach(function (_ref3) {
+            var _ref4 = _slicedToArray(_ref3, 2),
+                subsequentFacetGroup = _ref4[1];
 
             subsequentFacetGroup.index++;
           });
@@ -558,15 +407,14 @@ function (_React$PureComponent2) {
   }, {
     key: "render",
     value: function render() {
-      var _this$props5 = this.props,
-          debug = _this$props5.debug,
-          facets = _this$props5.facets,
-          className = _this$props5.className,
-          title = _this$props5.title,
-          showClearFiltersButton = _this$props5.showClearFiltersButton,
-          onClearFilters = _this$props5.onClearFilters,
-          windowHeight = _this$props5.windowHeight,
-          separateSingleTermFacets = _this$props5.separateSingleTermFacets;
+      var _this$props2 = this.props,
+          debug = _this$props2.debug,
+          facets = _this$props2.facets,
+          className = _this$props2.className,
+          title = _this$props2.title,
+          showClearFiltersButton = _this$props2.showClearFiltersButton,
+          onClearFilters = _this$props2.onClearFilters,
+          separateSingleTermFacets = _this$props2.separateSingleTermFacets;
       if (debug) _patchedConsole.patchedConsoleInstance.log('render facetlist');
 
       if (!facets || !Array.isArray(facets) || facets.length === 0) {

--- a/es/components/browse/components/FacetList/index.js
+++ b/es/components/browse/components/FacetList/index.js
@@ -385,27 +385,7 @@ function (_React$PureComponent2) {
       this.setState({
         'mounted': true
       });
-    } // groupFacets() {
-    //     const { facets } = this.props;
-    //     const grouped = []; // { field: green, }
-    //     const groupIndices = {}; // green : 0 where in grouped
-    //     facets.forEach((facet)=> {
-    //         if (facet.grouping) {
-    //             // check if there's a facet group in grouped;
-    //             if (groupIndices.hasOwnProperty(facet.grouping)) {
-    //                 const i = groupIndices[facet.grouping];
-    //                 grouped[i].facetList.push(facet);
-    //             } else  {
-    //                 grouped.push({ field: facet.grouping, facetList: [facet] });
-    //                 groupIndices[facet.grouping] = grouped.length - 1;
-    //             }
-    //         } else {
-    //             grouped.push({ field: facet.field, facet: facet });
-    //         }
-    //     });
-    //     return grouped;
-    // }
-
+    }
   }, {
     key: "renderFacets",
     value: function renderFacets() {
@@ -422,11 +402,8 @@ function (_React$PureComponent2) {
           persistentCount = _this$props4.persistentCount,
           termTransformFxn = _this$props4.termTransformFxn,
           separateSingleTermFacets = _this$props4.separateSingleTermFacets;
-      var mounted = this.state.mounted;
-
-      _patchedConsole.patchedConsoleInstance.log("log1: ", facets); // Ensure each facets has an `order` property and default it to 0 if not.
+      var mounted = this.state.mounted; // Ensure each facets has an `order` property and default it to 0 if not.
       // And then sort by `order`.
-
 
       var useFacets = _underscore["default"].sortBy(_underscore["default"].map(_underscore["default"].uniq(facets, false, function (f) {
         return f.field;
@@ -439,11 +416,7 @@ function (_React$PureComponent2) {
         }
 
         return f;
-      }), 'order'); // console.log("log1: equal?" , facets === useFacets);
-      // console.log("log1: this.groupFacets() ", this.groupFacets());,
-
-
-      _patchedConsole.patchedConsoleInstance.log("log1: usefacets: ", useFacets);
+      }), 'order');
 
       var commonProps = {
         onFilter: onFilter,
@@ -511,12 +484,12 @@ function (_React$PureComponent2) {
           if (inGroupIndices.hasOwnProperty(facet.grouping)) {
             var _i = inGroupIndices[facet.grouping];
 
-            groupedOnly[_i].facets.push(generateFacet(facet, _i - 1));
+            groupedOnly[_i].facets.push(generateFacet(facet, _i));
           } else {
             groupedOnly.push({
               key: facet.grouping,
               title: facet.grouping,
-              facets: [generateFacet(facet, i - 1)]
+              facets: [generateFacet(facet, i)]
             });
             inGroupIndices[facet.grouping] = groupedOnly.length - 1;
           }
@@ -524,8 +497,7 @@ function (_React$PureComponent2) {
       }); // splice back in the nested facets
 
       groupedOnly.forEach(function (group, i) {
-        //facetsWithGroupings.splice(genFacetIndices[group.field] + i, 0, <Facet {...commonProps} {...group} key={group.field} defaultFacetOpen={false} isStatic={false} />);
-        facetsWithGroupings.splice(genFacetIndices[group.field] + i, 0, _react["default"].createElement(_FacetOfFacets.FacetOfFacets, _extends({}, commonProps, group, {
+        facetsWithGroupings.splice(genFacetIndices[group.title] + i, 0, _react["default"].createElement(_FacetOfFacets.FacetOfFacets, _extends({}, commonProps, group, {
           defaultFacetOpen: false,
           isStatic: false
         })));

--- a/es/components/browse/components/FacetList/index.js
+++ b/es/components/browse/components/FacetList/index.js
@@ -4,8 +4,6 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.performFilteringQuery = performFilteringQuery;
-exports.anyTermsSelected = anyTermsSelected;
-exports.mergeTerms = mergeTerms;
 exports.FacetList = void 0;
 
 var _react = _interopRequireDefault(require("react"));
@@ -44,6 +42,22 @@ function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj;
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
+function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _nonIterableRest(); }
+
+function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance"); }
+
+function _iterableToArrayLimit(arr, i) { if (!(Symbol.iterator in Object(arr) || Object.prototype.toString.call(arr) === "[object Arguments]")) { return; } var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
+function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
+
+function _toConsumableArray(arr) { return _arrayWithoutHoles(arr) || _iterableToArray(arr) || _nonIterableSpread(); }
+
+function _nonIterableSpread() { throw new TypeError("Invalid attempt to spread non-iterable instance"); }
+
+function _iterableToArray(iter) { if (Symbol.iterator in Object(iter) || Object.prototype.toString.call(iter) === "[object Arguments]") return Array.from(iter); }
+
+function _arrayWithoutHoles(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = new Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } }
+
 function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function (obj) { return typeof obj; }; } else { _typeof = function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
 function _extends() { _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
@@ -76,41 +90,31 @@ function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || func
 
 /**
  * Used to render individual facet fields and their available terms in FacetList.
- *
- * @memberof module:facetlist
- * @class Facet
- * @type {Component}
  */
-var Facet =
+var TermsFacet =
 /*#__PURE__*/
 function (_React$PureComponent) {
-  _inherits(Facet, _React$PureComponent);
+  _inherits(TermsFacet, _React$PureComponent);
 
-  _createClass(Facet, null, [{
+  _createClass(TermsFacet, null, [{
     key: "isStatic",
     value: function isStatic(facet) {
       var _facet$terms = facet.terms,
           terms = _facet$terms === void 0 ? null : _facet$terms,
           _facet$total = facet.total,
-          total = _facet$total === void 0 ? 0 : _facet$total,
-          _facet$aggregation_ty = facet.aggregation_type,
-          aggregation_type = _facet$aggregation_ty === void 0 ? "terms" : _facet$aggregation_ty,
-          _facet$min = facet.min,
-          min = _facet$min === void 0 ? null : _facet$min,
-          _facet$max = facet.max,
-          max = _facet$max === void 0 ? null : _facet$max;
-      return aggregation_type === "terms" && Array.isArray(terms) && terms.length === 1 && total <= _underscore["default"].reduce(terms, function (m, t) {
+          total = _facet$total === void 0 ? 0 : _facet$total;
+      return Array.isArray(terms) && terms.length === 1 && total <= _underscore["default"].reduce(terms, function (m, t) {
         return m + (t.doc_count || 0);
-      }, 0) || aggregation_type == "stats" && min === max;
+      }, 0);
     }
   }]);
 
-  function Facet(props) {
+  function TermsFacet(props) {
     var _this;
 
-    _classCallCheck(this, Facet);
+    _classCallCheck(this, TermsFacet);
 
-    _this = _possibleConstructorReturn(this, _getPrototypeOf(Facet).call(this, props));
+    _this = _possibleConstructorReturn(this, _getPrototypeOf(TermsFacet).call(this, props));
     _this.handleStaticClick = _this.handleStaticClick.bind(_assertThisInitialized(_this));
     _this.handleTermClick = _this.handleTermClick.bind(_assertThisInitialized(_this));
     _this.state = {
@@ -127,7 +131,7 @@ function (_React$PureComponent) {
    */
 
 
-  _createClass(Facet, [{
+  _createClass(TermsFacet, [{
     key: "handleStaticClick",
     value: function handleStaticClick(e) {
       var _this2 = this;
@@ -168,55 +172,21 @@ function (_React$PureComponent) {
     value: function render() {
       var _this$props3 = this.props,
           facet = _this$props3.facet,
+          terms = _this$props3.terms,
           getTermStatus = _this$props3.getTermStatus,
           extraClassname = _this$props3.extraClassname,
           termTransformFxn = _this$props3.termTransformFxn,
           separateSingleTermFacets = _this$props3.separateSingleTermFacets,
-          defaultFacetOpen = _this$props3.defaultFacetOpen,
-          filters = _this$props3.filters,
-          onFilter = _this$props3.onFilter,
-          mounted = _this$props3.mounted,
-          isStatic = _this$props3.isStatic,
-          facetList = _this$props3.facetList;
+          isStatic = _this$props3.isStatic;
       var filtering = this.state.filtering;
 
       var _ref = facet || {},
-          _ref$description = _ref.description,
-          description = _ref$description === void 0 ? null : _ref$description,
           field = _ref.field,
           title = _ref.title,
-          _ref$terms = _ref.terms,
-          terms = _ref$terms === void 0 ? [] : _ref$terms,
-          _ref$aggregation_type = _ref.aggregation_type,
-          aggregation_type = _ref$aggregation_type === void 0 ? "terms" : _ref$aggregation_type;
+          _ref$description = _ref.description,
+          description = _ref$description === void 0 ? null : _ref$description;
 
       var showTitle = title || field;
-
-      if (Array.isArray(facetList)) {
-        return _react["default"].createElement(_FacetOfFacets.FacetOfFacets, _extends({
-          facets: facetList,
-          title: field
-        }, {
-          filters: filters
-        }));
-      }
-
-      if (aggregation_type === "stats") {
-        return _react["default"].createElement(_RangeFacet.RangeFacet, _extends({
-          facet: facet,
-          filtering: filtering,
-          defaultFacetOpen: defaultFacetOpen,
-          termTransformFxn: termTransformFxn,
-          filters: filters,
-          onFilter: onFilter,
-          mounted: mounted,
-          isStatic: isStatic
-        }, {
-          tooltip: description,
-          title: showTitle
-        }));
-      } // Default case for "terms" buckets/facets
-
 
       if (separateSingleTermFacets && isStatic) {
         // Only one term exists.
@@ -240,10 +210,10 @@ function (_React$PureComponent) {
     }
   }]);
 
-  return Facet;
+  return TermsFacet;
 }(_react["default"].PureComponent);
 
-Facet.propTypes = {
+TermsFacet.propTypes = {
   'facet': _propTypes["default"].shape({
     'field': _propTypes["default"].string.isRequired,
     // Name of nested field property in experiment objects, using dot-notation.
@@ -365,64 +335,6 @@ function performFilteringQuery(props, facet, term, callback) {
     return targetSearchHref;
   }
 }
-/* used in FacetList and FacetTermsList*/
-
-
-function anyTermsSelected() {
-  var terms = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : [];
-  var facet = arguments.length > 1 ? arguments[1] : undefined;
-  var filters = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : [];
-  var activeTermsForField = {};
-  filters.forEach(function (f) {
-    if (f.field !== facet.field) return;
-    activeTermsForField[f.term] = true;
-  });
-
-  for (var i = 0; i < terms.length; i++) {
-    if (activeTermsForField[terms[i].key]) {
-      return true;
-    }
-  }
-
-  return false;
-}
-/* used in FacetList and FacetTermsList */
-
-
-function mergeTerms(facet, filters) {
-  var activeTermsForField = {};
-  filters.forEach(function (f) {
-    if (f.field !== facet.field) return;
-    activeTermsForField[f.term] = true;
-  }); // Filter out terms w/ 0 counts (in case).
-
-  var terms = facet.terms.filter(function (term) {
-    if (term.doc_count > 0) return true;
-    if (activeTermsForField[term.key]) return true;
-    return false;
-  });
-  terms.forEach(function (_ref2) {
-    var key = _ref2.key;
-    delete activeTermsForField[key];
-  }); // Filter out type=Item for now (hardcode)
-
-  if (facet.field === "type") {
-    terms = terms.filter(function (t) {
-      return t !== 'Item' && t && t.key !== 'Item';
-    });
-  } // These are terms which might have been manually defined in URL but are not present in data at all.
-  // Include them so we can unselect them.
-
-
-  var unseenTerms = _underscore["default"].keys(activeTermsForField).map(function (term) {
-    return {
-      key: term,
-      doc_count: 0
-    };
-  });
-
-  return terms.concat(unseenTerms);
-}
 
 var FacetList =
 /*#__PURE__*/
@@ -438,10 +350,6 @@ function (_React$PureComponent2) {
     _this3.state = {
       'mounted': false
     };
-    _this3.memoized = {
-      anyTermsSelected: (0, _memoizeOne["default"])(anyTermsSelected),
-      mergeTerms: (0, _memoizeOne["default"])(mergeTerms)
-    };
     _this3.renderFacets = _this3.renderFacets.bind(_assertThisInitialized(_this3));
     return _this3;
   }
@@ -456,7 +364,6 @@ function (_React$PureComponent2) {
   }, {
     key: "renderFacets",
     value: function renderFacets() {
-      var maxTermsToShow = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 12;
       var _this$props4 = this.props,
           facets = _this$props4.facets,
           href = _this$props4.href,
@@ -468,7 +375,8 @@ function (_React$PureComponent2) {
           windowWidth = _this$props4.windowWidth,
           persistentCount = _this$props4.persistentCount,
           termTransformFxn = _this$props4.termTransformFxn,
-          separateSingleTermFacets = _this$props4.separateSingleTermFacets;
+          separateSingleTermFacets = _this$props4.separateSingleTermFacets,
+          windowHeight = _this$props4.windowHeight;
       var mounted = this.state.mounted; // Ensure each facets has an `order` property and default it to 0 if not.
       // And then sort by `order`.
 
@@ -486,6 +394,7 @@ function (_React$PureComponent2) {
       }), 'order');
 
       var commonProps = {
+        // Passed to all Facets
         onFilter: onFilter,
         href: href,
         getTermStatus: getTermStatus,
@@ -495,7 +404,12 @@ function (_React$PureComponent2) {
         mounted: mounted,
         termTransformFxn: termTransformFxn,
         separateSingleTermFacets: separateSingleTermFacets
-      };
+      }; // We try to initially open some Facets depending on available screen size or props.
+      // We might get rid of this feature at some point as the amount of Facets are likely to increase.
+      // Or we could just set defaultFacetOpen = false if # facets > 10 or something.
+      // Basically seems like should adjust `maxTermsToShow` based on total # of facets...
+
+      var maxTermsToShow = (typeof windowHeight === 'number' && !isNaN(windowHeight) ? Math.floor(windowHeight / 60) : 15) - Math.floor(useFacets.length / 4);
       var facetIndexWherePastXTerms = useFacets.reduce(function (m, facet, index) {
         if (m.end) return m;
         m.facetIndex = index;
@@ -514,73 +428,132 @@ function (_React$PureComponent2) {
         termCount: 0,
         end: false
       }).facetIndex;
-      var rgs = (0, _layout.responsiveGridState)(windowWidth || null);
+      var rgs = (0, _layout.responsiveGridState)(windowWidth || null); // The logic within `Facet` `render`, `componentDidMount`, etc. isn't executed
+      // until is rendered by some other component's render method.
+      // We can sort/manipulate/transform these still according to their `props.` values and such.
 
-      function generateFacet(facet, i) {
-        var isStatic = Facet.isStatic(facet);
-        var defaultFacetOpen = !mounted ? false : !isStatic && !!(rgs !== 'xs' && i < (facetIndexWherePastXTerms || 1) || facet.aggregation_type === "stats" && _underscore["default"].any(filters || [], function (fltr) {
-          return fltr.field === facet.field + ".from" || fltr.field === facet.field + ".to";
-        }) || facet.aggregation_type === "terms" && _underscore["default"].any(filters || [], function (fltr) {
-          return fltr.field === facet.field;
-        }));
-        return _react["default"].createElement(Facet, _extends({}, commonProps, {
-          facet: facet,
-          key: facet.field
-        }, {
-          defaultFacetOpen: defaultFacetOpen,
-          isStatic: isStatic
-        }));
-      }
+      var renderedFacets = useFacets.map(function (facet, i) {
+        var _facet$grouping = facet.grouping,
+            grouping = _facet$grouping === void 0 ? null : _facet$grouping,
+            facetField = facet.field,
+            _facet$aggregation_ty = facet.aggregation_type,
+            aggregation_type = _facet$aggregation_ty === void 0 ? "terms" : _facet$aggregation_ty; // Default Open if mounted and:
 
-      var allFacets = []; // first populated with ungrouped assets, then grouped assets are spliced in
+        var defaultFacetOpen = !mounted ? false : !!(rgs !== 'xs' && i < (facetIndexWherePastXTerms || 1));
 
-      var groupedOnly = []; // only facet groups
+        if (aggregation_type === "stats") {
+          var _getRangeValueFromFil = (0, _RangeFacet.getValueFromFilters)(facet, filters),
+              fromVal = _getRangeValueFromFil.fromVal,
+              toVal = _getRangeValueFromFil.toVal;
 
-      var inGroupIndices = {}; // map group names to index in GroupedOnly for quick lookup
-
-      var spliceIndices = {}; // map group names to index in allFacets where a nested facet should be spliced
-
-      useFacets.forEach(function (facet, i) {
-        if (!facet.grouping) {
-          allFacets.push(generateFacet(facet, i - 1)); // add ungrouped facets straight to allFacets
-        } else {
-          // add or update facet groups and store in groupedOnly
-          var terms = this.memoized.mergeTerms(facet, filters);
-          var areTermsSelected = this.memoized.anyTermsSelected(terms, facet, filters); // keep track of what index in allFacets a particular group should be added at
-
-          if (!spliceIndices.hasOwnProperty(facet.grouping)) {
-            spliceIndices[facet.grouping] = allFacets.length;
-          } // check if there's a facet group in groupedOnly;
-
-
-          if (inGroupIndices.hasOwnProperty(facet.grouping)) {
-            var _i = inGroupIndices[facet.grouping];
-
-            groupedOnly[_i].facets.push(generateFacet(facet, _i)); // if any terms are selected, update group selected status
-
-
-            if (!groupedOnly[_i].areTermsSelected && areTermsSelected) {
-              groupedOnly[_i].areTermsSelected = true;
-            }
-          } else {
-            groupedOnly.push({
-              key: facet.grouping,
-              title: facet.grouping,
-              facets: [generateFacet(facet, i)],
-              areTermsSelected: areTermsSelected
-            });
-            inGroupIndices[facet.grouping] = groupedOnly.length - 1;
-          }
+          var isStatic = facet.min === facet.max;
+          defaultFacetOpen = defaultFacetOpen || !isStatic && _underscore["default"].any(filters || [], function (fltr) {
+            return fltr.field === facetField + ".from" || fltr.field === facetField + ".to";
+          }) || false;
+          return _react["default"].createElement(_RangeFacet.RangeFacet, _extends({}, commonProps, {
+            facet: facet,
+            key: facetField,
+            anyTermsSelected: fromVal !== null || toVal !== null
+          }, {
+            defaultFacetOpen: defaultFacetOpen,
+            isStatic: isStatic,
+            grouping: grouping,
+            fromVal: fromVal,
+            toVal: toVal
+          }));
         }
-      }.bind(this)); // splice back in the nested facets
 
-      groupedOnly.forEach(function (group, i) {
-        allFacets.splice(spliceIndices[group.title] + i, 0, _react["default"].createElement(_FacetOfFacets.FacetOfFacets, _extends({}, commonProps, group, {
-          defaultFacetOpen: false,
-          isStatic: false
-        })));
+        if (aggregation_type === "terms") {
+          var terms = (0, _FacetTermsList.mergeTerms)(facet, filters); // Add in any terms specified in `filters` but not in `facet.terms` - in case someone hand-put that into URL.
+
+          var _anySelected = (0, _FacetTermsList.anyTermsSelected)(terms, facet, filters);
+
+          var _isStatic = TermsFacet.isStatic(facet);
+
+          defaultFacetOpen = defaultFacetOpen || !_isStatic && _underscore["default"].any(filters || [], function (fltr) {
+            return fltr.field === facetField;
+          }) || false;
+          return _react["default"].createElement(TermsFacet, _extends({}, commonProps, {
+            facet: facet,
+            key: facetField,
+            anyTermsSelected: _anySelected
+          }, {
+            defaultFacetOpen: defaultFacetOpen,
+            isStatic: _isStatic,
+            grouping: grouping,
+            terms: terms
+          }));
+        }
+
+        throw new Error("Unknown aggregation_type");
       });
-      return allFacets;
+      var componentsToReturn = []; // first populated with ungrouped facets, then facet groups are spliced in
+
+      var groups = new Map(); // { groupTitle: { index: 0, facets: [facet1, facet2, facet3, ...] } }; Map() to preserve order.
+      // Separate out facets with .grouping into groups.
+
+      renderedFacets.forEach(function (renderedFacet) {
+        var _renderedFacet$props = renderedFacet.props,
+            grouping = _renderedFacet$props.grouping,
+            defaultFacetOpen = _renderedFacet$props.defaultFacetOpen;
+
+        if (!grouping) {
+          // add ungrouped facets straight to componentsToReturn
+          componentsToReturn.push(renderedFacet);
+          return;
+        } // Get existing or create new.
+
+
+        var existingGroup = groups.get(grouping) || {
+          index: componentsToReturn.length,
+          facets: [],
+          defaultGroupOpen: false
+        }; // If any facets are open by default, have group open by default also.
+
+        if (defaultFacetOpen) {
+          existingGroup.defaultGroupOpen = true;
+        }
+
+        existingGroup.facets.push(renderedFacet);
+        groups.set(grouping, existingGroup);
+      });
+
+      var groupsArr = _toConsumableArray(groups); // Check, render, and add groups into `componentsToReturn`
+
+
+      groupsArr.forEach(function (_ref2) {
+        var _ref3 = _slicedToArray(_ref2, 2),
+            groupTitle = _ref3[0],
+            facetGroup = _ref3[1];
+
+        var facetsInGroup = facetGroup.facets,
+            index = facetGroup.index;
+
+        if (facetsInGroup.length === 1) {
+          // Doesn't need to be in group, put back into `componentsToReturn`
+          componentsToReturn.splice(index, 0, facetsInGroup[0]); // Increment remaining group indices to match new length of `componentsToReturn`.
+          // We're not modifying the actual `groupsArr` list itself ever (e.g. removing/adding)
+          // so `fromIdx` / `groupIndex` should always stay stable.
+          // We increment facetGroup.index which is the index in `componentsToReturn`.
+
+          groupsArr.slice(fromIdx).forEach(function (_ref4) {
+            var _ref5 = _slicedToArray(_ref4, 2),
+                subsequentFacetGroup = _ref5[1];
+
+            subsequentFacetGroup.index++;
+          });
+          return;
+        } // `facetGroup` contains `defaultGroupOpen`, `index`, `facets`.
+
+
+        var renderedGroup = _react["default"].createElement(_FacetOfFacets.FacetOfFacets, _extends({}, commonProps, facetGroup, {
+          title: groupTitle,
+          key: groupTitle
+        }));
+
+        componentsToReturn.splice(index, 0, renderedGroup);
+      });
+      return componentsToReturn;
     }
   }, {
     key: "render",
@@ -606,8 +579,7 @@ function (_React$PureComponent2) {
       }
 
       var clearButtonClassName = className && className.indexOf('with-header-bg') > -1 ? "btn-outline-white" : "btn-outline-default";
-      var maxTermsToShow = typeof windowHeight === 'number' && !isNaN(windowHeight) ? Math.floor(windowHeight / 60) : 12;
-      var allFacetElements = this.renderFacets(maxTermsToShow);
+      var allFacetElements = this.renderFacets();
       var staticFacetElements = [];
       var selectableFacetElements = [];
 

--- a/scss/facet-list.scss
+++ b/scss/facet-list.scss
@@ -250,11 +250,11 @@ $facetlist-facet-font-size: 0.925rem !default;
                     opacity: 0.5;
                 }
             }
-            &.open:not(.closing) {
-                h5.facet-title .closed-terms-count {
-                    top : 9px;
-                }
-            }
+            // &.open:not(.closing) {
+            //     h5.facet-title .closed-terms-count {
+            //         top : 9px;
+            //     }
+            // }
             &.closed, &.closing {
                 padding-bottom: 0px;
                 background-color: #fcfcfc;

--- a/scss/facet-list.scss
+++ b/scss/facet-list.scss
@@ -112,6 +112,21 @@ $facetlist-facet-font-size: 0.925rem !default;
         padding-left : 10px;
         padding-right : 10px;
 
+        > .facet-group-list-container {
+            padding-left: 20px;
+            position: relative;
+            &:before {
+                content: "";
+                position: absolute;
+                left: 3px;
+                top: 19px; // Facet title min height is 40px; Try to vertically center-ish it.
+                bottom: 19px;
+                width: 3px;
+                border: 1px solid #ddd;
+                border-right: none;
+            }
+        }
+
         &.closed,
         &:not(.range-facet) {
             overflow: hidden;

--- a/src/components/browse/components/FacetList/FacetOfFacets.js
+++ b/src/components/browse/components/FacetList/FacetOfFacets.js
@@ -2,11 +2,9 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import memoize from 'memoize-one';
 
 import { Collapse } from './../../../ui/Collapse';
 import { Fade } from './../../../ui/Fade';
-import { anyTermsSelected as anyTermsSelectedPerFacet, mergeTerms }  from './index';
 
 /**
  * Used to render individual facet fields and their available terms in FacetList.
@@ -20,16 +18,10 @@ export class FacetOfFacets extends React.PureComponent {
         super(props);
         this.handleOpenToggleClick = this.handleOpenToggleClick.bind(this);
         this.handleExpandListToggleClick = this.handleExpandListToggleClick.bind(this);
-        this.checkAllTerms = this.checkAllTerms.bind(this);
         this.state = {
             'facetOpen'     : typeof props.defaultFacetOpen === 'boolean' ? props.defaultFacetOpen : true,
             'facetClosing'  : false,
             'expanded'      : false
-        };
-        this.memoized = {
-            checkAllTerms: memoize(this.checkAllTerms),
-            anyTermsSelectedPerFacet: memoize(anyTermsSelectedPerFacet),
-            mergeTerms: memoize(mergeTerms)
         };
     }
 
@@ -61,28 +53,10 @@ export class FacetOfFacets extends React.PureComponent {
         });
     }
 
-    checkAllTerms() {
-        const { facets = [], filters = [] } = this.props;
-        let anySelected = false;
-        // console.log("log1: running CheckAllTerms on facetList: ", facets);
-        facets.forEach((facet) => {
-            // console.log("log1: examining this facet for selected terms: ", facet.props.facet);
-            // console.log("log1: seeking match with these filters", filters);
-            const terms = this.memoized.mergeTerms(facet.props.facet, filters);
-            // console.log("log1: merged terms, ", terms);
-            const anyTermsSelectedThisFacet = this.memoized.anyTermsSelectedPerFacet(terms, facet.props.facet, filters);
-            if (anyTermsSelectedThisFacet === true) {
-                anySelected = true;
-            }
-        });
-        return anySelected;
-    }
 
     render() {
-        const { title, facets, tooltip } = this.props;
+        const { title, facets, tooltip, areTermsSelected } = this.props;
         const { facetOpen, facetClosing } = this.state;
-
-        const anyTermsSelected = this.memoized.checkAllTerms();
 
         return (
             <div className={"facet" + (facetOpen ? ' open' : ' closed') + (facetClosing ? ' closing' : '')} data-field={title}>
@@ -92,9 +66,9 @@ export class FacetOfFacets extends React.PureComponent {
                     </span>
                     <span className="inline-block col px-0" data-tip={tooltip} data-place="right">{ title }</span>
                     <Fade in={facetClosing || !facetOpen}>
-                        <span className={"closed-terms-count col-auto px-0" + (anyTermsSelected ? " some-selected" : "")}
-                            data-tip={`Nested filters (${facets.length}) ${ anyTermsSelected ? " with at least 1 selected." : ""}`}>
-                            <i className={"icon fas icon-layer-group" } style={{ opacity: anyTermsSelected ? 0.75 : 0.25 }}/>
+                        <span className={"closed-terms-count col-auto px-0" + (areTermsSelected ? " some-selected" : "")}
+                            data-tip={`Nested filters (${facets.length}) ${ areTermsSelected ? " with at least 1 selected." : ""}`}>
+                            <i className={"icon fas icon-layer-group" } style={{ opacity: areTermsSelected ? 0.75 : 0.25 }}/>
                         </span>
                     </Fade>
                 </h5>

--- a/src/components/browse/components/FacetList/FacetOfFacets.js
+++ b/src/components/browse/components/FacetList/FacetOfFacets.js
@@ -81,21 +81,20 @@ export class FacetOfFacets extends React.PureComponent {
         );
     }
 }
-// FacetOfFacets.propTypes = {
-//     'facet'                 : PropTypes.shape({
-//         'field'                 : PropTypes.string.isRequired,    // Name of nested field property in experiment objects, using dot-notation.
-//         'title'                 : PropTypes.string,               // Human-readable Facet Term
-//         'total'                 : PropTypes.number,               // Total experiments (or terms??) w/ field
-//         'terms'                 : PropTypes.array.isRequired,     // Possible terms,
-//         'description'           : PropTypes.string,
-//         'aggregation_type'      : PropTypes.oneOf(["stats", "terms"])
-//     }),
-//     'defaultFacetOpen'      : PropTypes.bool,
-//     'onFilter'              : PropTypes.func,           // Executed on term click
-//     'extraClassname'        : PropTypes.string,
-//     'schemas'               : PropTypes.object,
-//     'getTermStatus'         : PropTypes.func.isRequired,
-//     'href'                  : PropTypes.string.isRequired,
-//     'filters'               : PropTypes.arrayOf(PropTypes.object).isRequired,
-//     'mounted'               : PropTypes.bool
-// };
+FacetOfFacets.propTypes = {
+    'areTermsSelected'          : PropTypes.bool,
+    'defaultFacetOpen'          : PropTypes.bool,
+    'facets'                    : PropTypes.arrayOf(PropTypes.element),
+    'filters'                   : PropTypes.arrayOf(PropTypes.object).isRequired,
+    'getTermStatus'             : PropTypes.func.isRequired,
+    'href'                      : PropTypes.string.isRequired, // @todo: should this be required?
+    'isStatic'                  : PropTypes.bool,
+    'itemTypeForSchemas'        : PropTypes.string,
+    'mounted'                   : PropTypes.bool,
+    'onFilter'                  : PropTypes.func,           // Executed on term click
+    'schemas'                   : PropTypes.object,
+    'separateSingleTermFacets'  : PropTypes.bool,
+    'termTransformFxn'          : PropTypes.func,
+    'title'                     : PropTypes.string,
+    'extraClassname'            : PropTypes.string
+};

--- a/src/components/browse/components/FacetList/FacetOfFacets.js
+++ b/src/components/browse/components/FacetList/FacetOfFacets.js
@@ -2,27 +2,67 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-
+import memoize from 'memoize-one';
+import ReactTooltip from 'react-tooltip';
 import { Collapse } from './../../../ui/Collapse';
 import { Fade } from './../../../ui/Fade';
 
 /**
  * Used to render individual facet fields and their available terms in FacetList.
- *
- * @memberof module:facetlist
- * @class Facet
- * @type {Component}
  */
 export class FacetOfFacets extends React.PureComponent {
+
+
+    static anyFacetsHaveSelection(renderedFacets){
+        for (let facetIdx = 0; facetIdx < renderedFacets.length; facetIdx++){
+            const renderedFacet = renderedFacets[facetIdx]; // We have rendered facets as `props.facets`
+            const { anyTermsSelected: anySelected } = renderedFacet.props;
+            if (anySelected) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     constructor(props){
         super(props);
         this.handleOpenToggleClick = this.handleOpenToggleClick.bind(this);
         this.handleExpandListToggleClick = this.handleExpandListToggleClick.bind(this);
+
+        this.memoized = {
+            anyFacetsHaveSelection: memoize(FacetOfFacets.anyFacetsHaveSelection)
+        };
+
+        // Most of this logic (facetOpen/facetClosing at least) is same between this and FacetTermsList.
+        // Maybe we could pull it out into reusable controller component. Maybe. Very low priority.
         this.state = {
-            'facetOpen'     : typeof props.defaultFacetOpen === 'boolean' ? props.defaultFacetOpen : true,
+            'facetOpen'     : typeof props.defaultGroupOpen === 'boolean' ? props.defaultGroupOpen : true,
             'facetClosing'  : false,
             'expanded'      : false
         };
+    }
+
+    componentDidUpdate(pastProps, pastState){
+        const { facets: renderedFacets, mounted, defaultGroupOpen, isStatic } = this.props;
+        const { mounted: pastMounted, defaultGroupOpen: pastDefaultOpen, isStatic: pastStatic } = pastProps;
+
+        this.setState(({ facetOpen: currFacetOpen }) => {
+            if (!pastMounted && mounted && typeof defaultGroupOpen === 'boolean' && defaultGroupOpen !== pastDefaultOpen) {
+                return { 'facetOpen' : true };
+            }
+            if (defaultGroupOpen === true && !pastDefaultOpen && !currFacetOpen){
+                return { 'facetOpen' : true };
+            }
+            if (currFacetOpen && isStatic && !pastStatic && !this.memoized.anyFacetsHaveSelection(renderedFacets)){
+                return { 'facetOpen' : false };
+            }
+            return null;
+        }, ()=>{
+            const { facetOpen } = this.state;
+            if (pastState.facetOpen !== facetOpen){
+                ReactTooltip.rebuild();
+            }
+        });
     }
 
     handleOpenToggleClick(e) {
@@ -55,8 +95,15 @@ export class FacetOfFacets extends React.PureComponent {
 
 
     render() {
-        const { title, facets, tooltip, areTermsSelected } = this.props;
+        const { title, facets: renderedFacets, filters, tooltip, defaultGroupOpen } = this.props;
         const { facetOpen, facetClosing } = this.state;
+
+        const anySelections = this.memoized.anyFacetsHaveSelection(renderedFacets);
+
+        // Ensure all facets within group are not "static single terms".
+        const extendedFacets = React.Children.map(renderedFacets, function(renderedFacet){
+            return React.cloneElement(renderedFacet, { isStatic: false });
+        });
 
         return (
             <div className={"facet" + (facetOpen ? ' open' : ' closed') + (facetClosing ? ' closing' : '')} data-field={title}>
@@ -66,15 +113,15 @@ export class FacetOfFacets extends React.PureComponent {
                     </span>
                     <span className="inline-block col px-0" data-tip={tooltip} data-place="right">{ title }</span>
                     <Fade in={facetClosing || !facetOpen}>
-                        <span className={"closed-terms-count col-auto px-0" + (areTermsSelected ? " some-selected" : "")}
-                            data-tip={`Nested filters (${facets.length}) ${ areTermsSelected ? " with at least 1 selected." : ""}`}>
-                            <i className={"icon fas icon-layer-group" } style={{ opacity: areTermsSelected ? 0.75 : 0.25 }}/>
+                        <span className={"closed-terms-count col-auto px-0" + (anySelections ? " some-selected" : "")}
+                            data-tip={`Nested filters (${extendedFacets.length}) ${ anySelections ? " with at least 1 selected." : ""}`}>
+                            <i className={"icon fas icon-layer-group" } style={{ opacity: anySelections ? 0.75 : 0.25 }}/>
                         </span>
                     </Fade>
                 </h5>
                 <Collapse in={facetOpen && !facetClosing}>
                     <div className="ml-2">
-                        { facets }
+                        { extendedFacets }
                     </div>
                 </Collapse>
             </div>
@@ -82,12 +129,9 @@ export class FacetOfFacets extends React.PureComponent {
     }
 }
 FacetOfFacets.propTypes = {
-    'areTermsSelected'          : PropTypes.bool,
-    'defaultFacetOpen'          : PropTypes.bool,
+    'defaultGroupOpen'          : PropTypes.bool,
     'facets'                    : PropTypes.arrayOf(PropTypes.element),
-    'filters'                   : PropTypes.arrayOf(PropTypes.object).isRequired,
-    'getTermStatus'             : PropTypes.func.isRequired,
-    'href'                      : PropTypes.string.isRequired, // @todo: should this be required?
+    'filters'                    : PropTypes.arrayOf(PropTypes.object).isRequired,
     'isStatic'                  : PropTypes.bool,
     'itemTypeForSchemas'        : PropTypes.string,
     'mounted'                   : PropTypes.bool,

--- a/src/components/browse/components/FacetList/FacetOfFacets.js
+++ b/src/components/browse/components/FacetList/FacetOfFacets.js
@@ -1,0 +1,115 @@
+'use strict';
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import _ from 'underscore';
+import memoize from 'memoize-one';
+
+import { Facet } from './index';
+
+/**
+ * Used to render individual facet fields and their available terms in FacetList.
+ *
+ * @memberof module:facetlist
+ * @class Facet
+ * @type {Component}
+ */
+export class FacetOfFacets extends React.PureComponent {
+    render() {
+        const { facetField } = this.props;
+        return (<h1>{facetField}</h1>);
+    }
+
+    // static isStatic(facet){
+    //     const { terms = null, total = 0, aggregation_type = "terms", min = null, max = null } = facet;
+    //     return (
+    //         aggregation_type === "terms" &&
+    //         Array.isArray(terms) &&
+    //         terms.length === 1 &&
+    //         total <= _.reduce(terms, function(m, t){ return m + (t.doc_count || 0); }, 0)
+    //     ) || (
+    //         aggregation_type == "stats" &&
+    //         min === max
+    //     );
+    // }
+
+    // constructor(props){
+    //     super(props);
+    //     this.handleStaticClick = this.handleStaticClick.bind(this);
+    //     this.handleTermClick = this.handleTermClick.bind(this);
+    //     this.state = { 'filtering' : false };
+    // }
+
+    // /**
+    //  * For cases when there is only one option for a facet - we render a 'static' row.
+    //  * This may change in response to design.
+    //  * Unlike in `handleTermClick`, we handle own state/UI here.
+    //  *
+    //  * @todo Allow to specify interval for histogram & date_histogram in schema instead of hard-coding 'month' interval.
+    //  */
+    // handleStaticClick(e) {
+    //     const { facet, isStatic } = this.props;
+    //     const term = facet.terms[0]; // Would only have 1
+
+    //     e.preventDefault();
+    //     if (!isStatic) return false;
+
+    //     this.setState({ 'filtering' : true }, () => {
+    //         this.handleTermClick(facet, term, e, () =>
+    //             this.setState({ 'filtering' : false })
+    //         );
+    //     });
+
+    // }
+
+    // /**
+    //  * Each Term component instance provides their own callback, we just route the navigation request.
+    //  *
+    //  * @todo Allow to specify interval for histogram & date_histogram in schema instead of hard-coding 'month' interval.
+    //  */
+    // handleTermClick(facet, term, e, callback) {
+    //     const { onFilter, href } = this.props;
+    //     onFilter(facet, term, callback, false, href);
+    // }
+
+    // render() {
+    //     const {
+    //         facet, getTermStatus, extraClassname, termTransformFxn, separateSingleTermFacets,
+    //         defaultFacetOpen, filters, onFilter, mounted, isStatic
+    //     } = this.props;
+    //     const { filtering } = this.state;
+    //     const { description = null, field, title, terms = [], aggregation_type = "terms" } = facet;
+    //     const showTitle = title || field;
+
+    //     if (aggregation_type === "stats") {
+    //         return <RangeFacet {...{ facet, filtering, defaultFacetOpen, termTransformFxn, filters, onFilter, mounted, isStatic }} tooltip={description} title={showTitle} />;
+    //     }
+
+    //     // Default case for "terms" buckets/facets
+    //     if (separateSingleTermFacets && isStatic){
+    //         // Only one term exists.
+    //         return <StaticSingleTerm {...{ facet, term : terms[0], filtering, showTitle, onClick : this.handleStaticClick, getTermStatus, extraClassname, termTransformFxn }} />;
+    //     } else {
+    //         return <FacetTermsList {...this.props} onTermClick={this.handleTermClick} tooltip={description} title={showTitle} />;
+    //     }
+
+    // }
+}
+// FacetOfFacets.propTypes = {
+//     'facet'                 : PropTypes.shape({
+//         'field'                 : PropTypes.string.isRequired,    // Name of nested field property in experiment objects, using dot-notation.
+//         'title'                 : PropTypes.string,               // Human-readable Facet Term
+//         'total'                 : PropTypes.number,               // Total experiments (or terms??) w/ field
+//         'terms'                 : PropTypes.array.isRequired,     // Possible terms,
+//         'description'           : PropTypes.string,
+//         'aggregation_type'      : PropTypes.oneOf(["stats", "terms"])
+//     }),
+//     'defaultFacetOpen'      : PropTypes.bool,
+//     'onFilter'              : PropTypes.func,           // Executed on term click
+//     'extraClassname'        : PropTypes.string,
+//     'schemas'               : PropTypes.object,
+//     'getTermStatus'         : PropTypes.func.isRequired,
+//     'href'                  : PropTypes.string.isRequired,
+//     'filters'               : PropTypes.arrayOf(PropTypes.object).isRequired,
+//     'mounted'               : PropTypes.bool
+// };

--- a/src/components/browse/components/FacetList/FacetOfFacets.js
+++ b/src/components/browse/components/FacetList/FacetOfFacets.js
@@ -120,7 +120,7 @@ export class FacetOfFacets extends React.PureComponent {
                     </Fade>
                 </h5>
                 <Collapse in={facetOpen && !facetClosing}>
-                    <div className="ml-2">
+                    <div className="facet-group-list-container">
                         { extendedFacets }
                     </div>
                 </Collapse>

--- a/src/components/browse/components/FacetList/FacetOfFacets.js
+++ b/src/components/browse/components/FacetList/FacetOfFacets.js
@@ -106,7 +106,7 @@ export class FacetOfFacets extends React.PureComponent {
         });
 
         return (
-            <div className={"facet" + (facetOpen ? ' open' : ' closed') + (facetClosing ? ' closing' : '')} data-field={title}>
+            <div className={"facet" + (facetOpen ? ' open' : ' closed') + (facetClosing ? ' closing' : '')} data-group={title}>
                 <h5 className="facet-title" onClick={this.handleOpenToggleClick}>
                     <span className="expand-toggle col-auto px-0">
                         <i className={"icon icon-fw fas " + (facetOpen && !facetClosing ? "icon-minus" : "icon-plus")}/>
@@ -114,7 +114,7 @@ export class FacetOfFacets extends React.PureComponent {
                     <span className="inline-block col px-0" data-tip={tooltip} data-place="right">{ title }</span>
                     <Fade in={facetClosing || !facetOpen}>
                         <span className={"closed-terms-count col-auto px-0" + (anySelections ? " some-selected" : "")}
-                            data-tip={`Nested filters (${extendedFacets.length}) ${ anySelections ? " with at least 1 selected." : ""}`}>
+                            data-tip={`Group of filters (${extendedFacets.length}) ${ anySelections ? " with at least 1 having a selection." : ""}`}>
                             <i className={"icon fas icon-layer-group" } style={{ opacity: anySelections ? 0.75 : 0.25 }}/>
                         </span>
                     </Fade>

--- a/src/components/browse/components/FacetList/FacetOfFacets.js
+++ b/src/components/browse/components/FacetList/FacetOfFacets.js
@@ -2,11 +2,9 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import _ from 'underscore';
-import memoize from 'memoize-one';
 
-import { Facet } from './index';
 import { Collapse } from './../../../ui/Collapse';
+import { Fade } from './../../../ui/Fade';
 
 /**
  * Used to render individual facet fields and their available terms in FacetList.
@@ -25,28 +23,6 @@ export class FacetOfFacets extends React.PureComponent {
             'facetClosing'  : false,
             'expanded'      : false
         };
-    }
-
-    componentDidUpdate(pastProps, pastState){
-        const { mounted, defaultFacetOpen, isStatic } = this.props;
-
-        // this.setState(({ facetOpen: currFacetOpen }) => {
-        //     if (!pastProps.mounted && mounted && typeof defaultFacetOpen === 'boolean' && defaultFacetOpen !== pastProps.defaultFacetOpen) {
-        //         return { 'facetOpen' : true };
-        //     }
-        //     if (defaultFacetOpen === true && !pastProps.defaultFacetOpen && !currFacetOpen){
-        //         return { 'facetOpen' : true };
-        //     }
-        //     if (currFacetOpen && isStatic && !pastProps.isStatic){
-        //         return { 'facetOpen' : false };
-        //     }
-        //     return null;
-        // }, ()=>{
-        //     const { facetOpen } = this.state;
-        //     if (pastState.facetOpen !== facetOpen){
-        //         ReactTooltip.rebuild();
-        //     }
-        // });
     }
 
     handleOpenToggleClick(e) {
@@ -81,8 +57,6 @@ export class FacetOfFacets extends React.PureComponent {
         const { title, facets: facetList, tooltip } = this.props;
         const { facetOpen, facetClosing } = this.state;
 
-        console.log("log1: facetList[0]", facetList[0]);
-        console.log("log1: mapped", facetList.map((facet) => facet.title));
         return (
             <div className={"facet" + (facetOpen ? ' open' : ' closed') + (facetClosing ? ' closing' : '')} data-field={title}>
                 <h5 className="facet-title" onClick={this.handleOpenToggleClick}>
@@ -90,96 +64,22 @@ export class FacetOfFacets extends React.PureComponent {
                         <i className={"icon icon-fw fas " + (facetOpen && !facetClosing ? "icon-minus" : "icon-plus")}/>
                     </span>
                     <span className="inline-block col px-0" data-tip={tooltip} data-place="right">{ title }</span>
-                    {/* { indicator } */}
+                    <Fade in={facetClosing || !facetOpen}>
+                        <span className={"closed-terms-count col-auto px-0"}
+                            data-tip={`Nested filters (${facetList.length})`}>
+                            <i className={"icon fas icon-layer-group"}
+                                style={{ opacity: 0.25 }}/>
+                        </span>
+                    </Fade>
                 </h5>
                 <Collapse in={facetOpen && !facetClosing}>
-                    <div className="ml-1">
+                    <div className="ml-2">
                         { facetList }
-                        {/* facetList.map((facet) => <li key={facet.field}>{facet.title}</li>) */}
                     </div>
-                    {/* <span className="mr-1">{facetList.map((facet) => facet.title)}</span> */}
-                    {/* { facetList.map
-                        (facet) => <h1 key={facet.field}>{facet.title}</h1>)
-                    } */}
                 </Collapse>
             </div>
         );
     }
-
-    // static isStatic(facet){
-    //     const { terms = null, total = 0, aggregation_type = "terms", min = null, max = null } = facet;
-    //     return (
-    //         aggregation_type === "terms" &&
-    //         Array.isArray(terms) &&
-    //         terms.length === 1 &&
-    //         total <= _.reduce(terms, function(m, t){ return m + (t.doc_count || 0); }, 0)
-    //     ) || (
-    //         aggregation_type == "stats" &&
-    //         min === max
-    //     );
-    // }
-
-    // constructor(props){
-    //     super(props);
-    //     this.handleStaticClick = this.handleStaticClick.bind(this);
-    //     this.handleTermClick = this.handleTermClick.bind(this);
-    //     this.state = { 'filtering' : false };
-    // }
-
-    // /**
-    //  * For cases when there is only one option for a facet - we render a 'static' row.
-    //  * This may change in response to design.
-    //  * Unlike in `handleTermClick`, we handle own state/UI here.
-    //  *
-    //  * @todo Allow to specify interval for histogram & date_histogram in schema instead of hard-coding 'month' interval.
-    //  */
-    // handleStaticClick(e) {
-    //     const { facet, isStatic } = this.props;
-    //     const term = facet.terms[0]; // Would only have 1
-
-    //     e.preventDefault();
-    //     if (!isStatic) return false;
-
-    //     this.setState({ 'filtering' : true }, () => {
-    //         this.handleTermClick(facet, term, e, () =>
-    //             this.setState({ 'filtering' : false })
-    //         );
-    //     });
-
-    // }
-
-    // /**
-    //  * Each Term component instance provides their own callback, we just route the navigation request.
-    //  *
-    //  * @todo Allow to specify interval for histogram & date_histogram in schema instead of hard-coding 'month' interval.
-    //  */
-    // handleTermClick(facet, term, e, callback) {
-    //     const { onFilter, href } = this.props;
-    //     onFilter(facet, term, callback, false, href);
-    // }
-
-    // render() {
-    //     const {
-    //         facet, getTermStatus, extraClassname, termTransformFxn, separateSingleTermFacets,
-    //         defaultFacetOpen, filters, onFilter, mounted, isStatic
-    //     } = this.props;
-    //     const { filtering } = this.state;
-    //     const { description = null, field, title, terms = [], aggregation_type = "terms" } = facet;
-    //     const showTitle = title || field;
-
-    //     if (aggregation_type === "stats") {
-    //         return <RangeFacet {...{ facet, filtering, defaultFacetOpen, termTransformFxn, filters, onFilter, mounted, isStatic }} tooltip={description} title={showTitle} />;
-    //     }
-
-    //     // Default case for "terms" buckets/facets
-    //     if (separateSingleTermFacets && isStatic){
-    //         // Only one term exists.
-    //         return <StaticSingleTerm {...{ facet, term : terms[0], filtering, showTitle, onClick : this.handleStaticClick, getTermStatus, extraClassname, termTransformFxn }} />;
-    //     } else {
-    //         return <FacetTermsList {...this.props} onTermClick={this.handleTermClick} tooltip={description} title={showTitle} />;
-    //     }
-
-    // }
 }
 // FacetOfFacets.propTypes = {
 //     'facet'                 : PropTypes.shape({

--- a/src/components/browse/components/FacetList/FacetOfFacets.js
+++ b/src/components/browse/components/FacetList/FacetOfFacets.js
@@ -6,6 +6,7 @@ import _ from 'underscore';
 import memoize from 'memoize-one';
 
 import { Facet } from './index';
+import { Collapse } from './../../../ui/Collapse';
 
 /**
  * Used to render individual facet fields and their available terms in FacetList.
@@ -15,9 +16,94 @@ import { Facet } from './index';
  * @type {Component}
  */
 export class FacetOfFacets extends React.PureComponent {
+    constructor(props){
+        super(props);
+        this.handleOpenToggleClick = this.handleOpenToggleClick.bind(this);
+        this.handleExpandListToggleClick = this.handleExpandListToggleClick.bind(this);
+        this.state = {
+            'facetOpen'     : typeof props.defaultFacetOpen === 'boolean' ? props.defaultFacetOpen : true,
+            'facetClosing'  : false,
+            'expanded'      : false
+        };
+    }
+
+    componentDidUpdate(pastProps, pastState){
+        const { mounted, defaultFacetOpen, isStatic } = this.props;
+
+        // this.setState(({ facetOpen: currFacetOpen }) => {
+        //     if (!pastProps.mounted && mounted && typeof defaultFacetOpen === 'boolean' && defaultFacetOpen !== pastProps.defaultFacetOpen) {
+        //         return { 'facetOpen' : true };
+        //     }
+        //     if (defaultFacetOpen === true && !pastProps.defaultFacetOpen && !currFacetOpen){
+        //         return { 'facetOpen' : true };
+        //     }
+        //     if (currFacetOpen && isStatic && !pastProps.isStatic){
+        //         return { 'facetOpen' : false };
+        //     }
+        //     return null;
+        // }, ()=>{
+        //     const { facetOpen } = this.state;
+        //     if (pastState.facetOpen !== facetOpen){
+        //         ReactTooltip.rebuild();
+        //     }
+        // });
+    }
+
+    handleOpenToggleClick(e) {
+        e.preventDefault();
+        this.setState(function({ facetOpen }){
+            const willBeOpen = !facetOpen;
+            if (willBeOpen) {
+                return { 'facetOpen': true };
+            } else {
+                return { 'facetClosing': true };
+            }
+        }, ()=>{
+            setTimeout(()=>{
+                this.setState(function({ facetOpen, facetClosing }){
+                    if (facetClosing){
+                        return { 'facetOpen' : false, 'facetClosing' : false };
+                    }
+                    return null;
+                });
+            }, 350);
+        });
+    }
+
+    handleExpandListToggleClick(e){
+        e.preventDefault();
+        this.setState(function({ expanded }){
+            return { 'expanded' : !expanded };
+        });
+    }
+
     render() {
-        const { facetField } = this.props;
-        return (<h1>{facetField}</h1>);
+        const { title, facets: facetList, tooltip } = this.props;
+        const { facetOpen, facetClosing } = this.state;
+
+        console.log("log1: facetList[0]", facetList[0]);
+        console.log("log1: mapped", facetList.map((facet) => facet.title));
+        return (
+            <div className={"facet" + (facetOpen ? ' open' : ' closed') + (facetClosing ? ' closing' : '')} data-field={title}>
+                <h5 className="facet-title" onClick={this.handleOpenToggleClick}>
+                    <span className="expand-toggle col-auto px-0">
+                        <i className={"icon icon-fw fas " + (facetOpen && !facetClosing ? "icon-minus" : "icon-plus")}/>
+                    </span>
+                    <span className="inline-block col px-0" data-tip={tooltip} data-place="right">{ title }</span>
+                    {/* { indicator } */}
+                </h5>
+                <Collapse in={facetOpen && !facetClosing}>
+                    <div className="ml-1">
+                        { facetList }
+                        {/* facetList.map((facet) => <li key={facet.field}>{facet.title}</li>) */}
+                    </div>
+                    {/* <span className="mr-1">{facetList.map((facet) => facet.title)}</span> */}
+                    {/* { facetList.map
+                        (facet) => <h1 key={facet.field}>{facet.title}</h1>)
+                    } */}
+                </Collapse>
+            </div>
+        );
     }
 
     // static isStatic(facet){

--- a/src/components/browse/components/FacetList/FacetTermsList.js
+++ b/src/components/browse/components/FacetList/FacetTermsList.js
@@ -232,6 +232,7 @@ export class FacetTermsList extends React.PureComponent {
         const termsLen = terms.length;
         let indicator;
 
+        // @todo: much of this code (including mergeTerms and anyTermsSelected above) were moved to index; consider moving these too
         if (isStatic || termsLen === 1){
             indicator = ( // Small indicator to help represent how many terms there are available for this Facet.
                 <Fade in={facetClosing || !facetOpen}>

--- a/src/components/browse/components/FacetList/FacetTermsList.js
+++ b/src/components/browse/components/FacetList/FacetTermsList.js
@@ -9,6 +9,7 @@ import ReactTooltip from 'react-tooltip';
 import { Collapse } from './../../../ui/Collapse';
 import { Fade } from './../../../ui/Fade';
 import { PartialList } from './../../../ui/PartialList';
+import { anyTermsSelected, mergeTerms } from './index';
 
 
 
@@ -113,54 +114,6 @@ Term.propTypes = {
 
 
 export class FacetTermsList extends React.PureComponent {
-
-    static anyTermsSelected(terms = [], facet, filters = []){
-        const activeTermsForField = {};
-        filters.forEach(function(f){
-            if (f.field !== facet.field) return;
-            activeTermsForField[f.term] = true;
-        });
-
-        for (let i = 0; i < terms.length; i++){
-            if (activeTermsForField[terms[i].key]) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    static mergeTerms(facet, filters){
-        const activeTermsForField = {};
-        filters.forEach(function(f){
-            if (f.field !== facet.field) return;
-            activeTermsForField[f.term] = true;
-        });
-
-        // Filter out terms w/ 0 counts (in case).
-        let terms = facet.terms.filter(function(term){
-            if (term.doc_count > 0) return true;
-            if (activeTermsForField[term.key]) return true;
-            return false;
-        });
-
-        terms.forEach(function({ key }){
-            delete activeTermsForField[key];
-        });
-
-        // Filter out type=Item for now (hardcode)
-        if (facet.field === "type"){
-            terms = terms.filter(function(t){ return t !== 'Item' && t && t.key !== 'Item'; });
-        }
-
-        // These are terms which might have been manually defined in URL but are not present in data at all.
-        // Include them so we can unselect them.
-        const unseenTerms = _.keys(activeTermsForField).map(function(term){
-            return { key: term, doc_count: 0 };
-        });
-
-        return terms.concat(unseenTerms);
-    }
-
     constructor(props){
         super(props);
         this.handleOpenToggleClick = this.handleOpenToggleClick.bind(this);
@@ -172,8 +125,8 @@ export class FacetTermsList extends React.PureComponent {
             'expanded'      : false
         };
         this.memoized = {
-            anyTermsSelected: memoize(FacetTermsList.anyTermsSelected),
-            mergeTerms: memoize(FacetTermsList.mergeTerms)
+            anyTermsSelected: memoize(anyTermsSelected),
+            mergeTerms: memoize(mergeTerms)
         };
     }
 

--- a/src/components/browse/components/FacetList/FacetTermsList.js
+++ b/src/components/browse/components/FacetList/FacetTermsList.js
@@ -9,7 +9,56 @@ import ReactTooltip from 'react-tooltip';
 import { Collapse } from './../../../ui/Collapse';
 import { Fade } from './../../../ui/Fade';
 import { PartialList } from './../../../ui/PartialList';
-import { anyTermsSelected, mergeTerms } from './index';
+
+
+/* used in FacetList and FacetTermsList */
+export function anyTermsSelected(terms = [], facet, filters = []){
+    const activeTermsForField = {};
+    filters.forEach(function(f){
+        if (f.field !== facet.field) return;
+        activeTermsForField[f.term] = true;
+    });
+
+    for (let i = 0; i < terms.length; i++){
+        if (activeTermsForField[terms[i].key]) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/* used in FacetList and FacetTermsList */
+export function mergeTerms(facet, filters){
+    const activeTermsForField = {};
+    filters.forEach(function(f){
+        if (f.field !== facet.field) return;
+        activeTermsForField[f.term] = true;
+    });
+
+    // Filter out terms w/ 0 counts (in case).
+    let terms = facet.terms.filter(function(term){
+        if (term.doc_count > 0) return true;
+        if (activeTermsForField[term.key]) return true;
+        return false;
+    });
+
+    terms.forEach(function({ key }){
+        delete activeTermsForField[key];
+    });
+
+    // Filter out type=Item for now (hardcode)
+    if (facet.field === "type"){
+        terms = terms.filter(function(t){ return t !== 'Item' && t && t.key !== 'Item'; });
+    }
+
+    // These are terms which might have been manually defined in URL but are not present in data at all.
+    // Include them so we can unselect them.
+    const unseenTerms = _.keys(activeTermsForField).map(function(term){
+        return { key: term, doc_count: 0 };
+    });
+
+    return terms.concat(unseenTerms);
+}
 
 
 
@@ -124,23 +173,20 @@ export class FacetTermsList extends React.PureComponent {
             'facetClosing'  : false,
             'expanded'      : false
         };
-        this.memoized = {
-            anyTermsSelected: memoize(anyTermsSelected),
-            mergeTerms: memoize(mergeTerms)
-        };
     }
 
     componentDidUpdate(pastProps, pastState){
-        const { mounted, defaultFacetOpen, isStatic, facet, filters } = this.props;
+        const { anyTermsSelected: anySelected, mounted, defaultFacetOpen, isStatic } = this.props;
+        const { mounted: pastMounted, defaultFacetOpen: pastDefaultOpen, isStatic: pastStatic } = pastProps;
 
         this.setState(({ facetOpen: currFacetOpen }) => {
-            if (!pastProps.mounted && mounted && typeof defaultFacetOpen === 'boolean' && defaultFacetOpen !== pastProps.defaultFacetOpen) {
+            if (!pastMounted && mounted && typeof defaultFacetOpen === 'boolean' && defaultFacetOpen !== pastDefaultOpen) {
                 return { 'facetOpen' : true };
             }
-            if (defaultFacetOpen === true && !pastProps.defaultFacetOpen && !currFacetOpen){
+            if (defaultFacetOpen === true && !pastDefaultOpen && !currFacetOpen){
                 return { 'facetOpen' : true };
             }
-            if (currFacetOpen && isStatic && !pastProps.isStatic && !this.memoized.anyTermsSelected(this.memoized.mergeTerms(facet, filters), facet, filters)){
+            if (currFacetOpen && isStatic && !pastStatic && !anySelected){
                 return { 'facetOpen' : false };
             }
             return null;
@@ -225,10 +271,8 @@ export class FacetTermsList extends React.PureComponent {
     }
 
     render(){
-        const { facet, filters, tooltip, title, isStatic } = this.props;
+        const { facet, terms, tooltip, title, isStatic, anyTermsSelected: anySelected } = this.props;
         const { facetOpen, facetClosing } = this.state;
-        const terms = this.memoized.mergeTerms(facet, filters);
-        const anyTermsSelected = this.memoized.anyTermsSelected(terms, facet, filters);
         const termsLen = terms.length;
         let indicator;
 
@@ -236,20 +280,20 @@ export class FacetTermsList extends React.PureComponent {
         if (isStatic || termsLen === 1){
             indicator = ( // Small indicator to help represent how many terms there are available for this Facet.
                 <Fade in={facetClosing || !facetOpen}>
-                    <span className={"closed-terms-count col-auto px-0" + (anyTermsSelected ? " some-selected" : "")}
-                        data-tip={"No useful options (1 total)" + (anyTermsSelected ? "; is selected" : "")}
-                        data-any-selected={anyTermsSelected}>
-                        <i className={"icon fas icon-" + (anyTermsSelected ? "circle" : "minus-circle")}
-                            style={{ opacity: anyTermsSelected ? 0.75 : 0.25 }}/>
+                    <span className={"closed-terms-count col-auto px-0" + (anySelected ? " some-selected" : "")}
+                        data-tip={"No useful options (1 total)" + (anySelected ? "; is selected" : "")}
+                        data-any-selected={anySelected}>
+                        <i className={"icon fas icon-" + (anySelected ? "circle" : "minus-circle")}
+                            style={{ opacity: anySelected ? 0.75 : 0.25 }}/>
                     </span>
                 </Fade>
             );
         } else {
             indicator = ( // Small indicator to help represent how many terms there are available for this Facet.
                 <Fade in={facetClosing || !facetOpen}>
-                    <span className={"closed-terms-count col-auto px-0" + (anyTermsSelected ? " some-selected" : "")}
-                        data-tip={termsLen + " options" + (anyTermsSelected ? " with at least one selected" : "")}
-                        data-any-selected={anyTermsSelected}>
+                    <span className={"closed-terms-count col-auto px-0" + (anySelected ? " some-selected" : "")}
+                        data-tip={termsLen + " options" + (anySelected ? " with at least one selected" : "")}
+                        data-any-selected={anySelected}>
                         { _.range(0, Math.min(Math.ceil(termsLen / 3), 8)).map((c)=>
                             <i className="icon icon-ellipsis-v fas" key={c}
                                 style={{ opacity : ((c + 1) / 5) * (0.67) + 0.33 }} />

--- a/src/components/browse/components/FacetList/RangeFacet.js
+++ b/src/components/browse/components/FacetList/RangeFacet.js
@@ -12,6 +12,23 @@ import { patchedConsoleInstance as console } from './../../../util/patched-conso
 
 import { Collapse } from './../../../ui/Collapse';
 
+
+export function getValueFromFilters(facet, filters = []){
+    const { field } = facet;
+    const toFilter = _.findWhere(filters, { field: field + ".to" });
+    const fromFilter = _.findWhere(filters, { field: field + ".from" });
+    let fromVal = null;
+    let toVal = null;
+    if (fromFilter) {
+        fromVal = RangeFacet.parseNumber(facet, fromFilter.term);
+    }
+    if (toFilter) {
+        toVal = RangeFacet.parseNumber(facet, toFilter.term);
+    }
+    return { fromVal, toVal };
+}
+
+
 export class RangeFacet extends React.PureComponent {
 
     static parseNumber(facet, value){
@@ -85,21 +102,6 @@ export class RangeFacet extends React.PureComponent {
         };
     }
 
-    static getValueFromFilters(facet, filters = []){
-        const { field } = facet;
-        const toFilter = _.findWhere(filters, { field: field + ".to" });
-        const fromFilter = _.findWhere(filters, { field: field + ".from" });
-        let fromVal = null;
-        let toVal = null;
-        if (fromFilter) {
-            fromVal = RangeFacet.parseNumber(facet, fromFilter.term);
-        }
-        if (toFilter) {
-            toVal = RangeFacet.parseNumber(facet, toFilter.term);
-        }
-        return { fromVal, toVal };
-    }
-
     constructor(props){
         super(props);
         this.handleOpenToggleClick = this.handleOpenToggleClick.bind(this);
@@ -111,14 +113,14 @@ export class RangeFacet extends React.PureComponent {
         this.performUpdateTo = this.performUpdateTo.bind(this);
 
         this.memoized = {
-            validIncrements: memoize(RangeFacet.validIncrements),
-            getValueFromFilters: memoize(RangeFacet.getValueFromFilters)
+            validIncrements: memoize(RangeFacet.validIncrements)
         };
 
         this.state = {
             facetOpen : props.defaultFacetOpen || false,
             facetClosing: false,
-            ...this.memoized.getValueFromFilters(props.facet, props.filters)
+            fromVal: props.fromVal,
+            toVal: props.toVal
         };
     }
 
@@ -231,11 +233,11 @@ export class RangeFacet extends React.PureComponent {
     }
 
     render(){
-        const { facet, title, tooltip, termTransformFxn, filters, isStatic } = this.props;
-        const { field, min, max } = facet;
+        const { facet, title: propTitle, termTransformFxn, isStatic, fromVal: savedFromVal, toVal: savedToVal } = this.props;
+        const { field, min, max, title: facetTitle = null, description: tooltip = null } = facet;
         const { facetOpen, facetClosing, fromVal, toVal } = this.state;
         const { fromIncrements, toIncrements } = this.memoized.validIncrements(facet);
-        const { fromVal: savedFromVal, toVal: savedToVal } = this.memoized.getValueFromFilters(facet, filters);
+        const title = propTitle || facetTitle || field;
 
         return (
             <div className={"facet range-facet" + (facetOpen ? ' open' : ' closed') + (facetClosing ? ' closing' : '')} data-field={facet.field}>

--- a/src/components/browse/components/FacetList/TermsFacet.js
+++ b/src/components/browse/components/FacetList/TermsFacet.js
@@ -1,0 +1,112 @@
+'use strict';
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import _ from 'underscore';
+
+import { FacetTermsList } from './FacetTermsList';
+import { StaticSingleTerm } from './StaticSingleTerm';
+
+/**
+ * Component to render out the FacetList for the Browse and ExperimentSet views.
+ * It can work with AJAX-ed in back-end data, as is used for the Browse page, or
+ * with client-side data from back-end-provided Experiments, as is used for the ExperimentSet view.
+ *
+ * Some of this code is not super clean and eventually could use some refactoring.
+ *
+ * @module {Component} facetlist
+ */
+
+
+
+/**
+ * Used to render individual facet fields and their available terms in FacetList.
+ */
+export class TermsFacet extends React.PureComponent {
+
+    static isStatic(facet){
+        const { terms = null, total = 0 } = facet;
+        return (
+            Array.isArray(terms) &&
+            terms.length === 1 &&
+            total <= _.reduce(terms, function(m, t){ return m + (t.doc_count || 0); }, 0)
+        );
+    }
+
+    constructor(props){
+        super(props);
+        this.handleStaticClick = this.handleStaticClick.bind(this);
+        this.handleTermClick = this.handleTermClick.bind(this);
+
+        this.state = { 'filtering' : false };
+    }
+
+    /**
+     * For cases when there is only one option for a facet - we render a 'static' row.
+     * This may change in response to design.
+     * Unlike in `handleTermClick`, we handle own state/UI here.
+     *
+     * @todo Allow to specify interval for histogram & date_histogram in schema instead of hard-coding 'month' interval.
+     */
+    handleStaticClick(e) {
+        const { facet, isStatic } = this.props;
+        const term = facet.terms[0]; // Would only have 1
+
+        e.preventDefault();
+        if (!isStatic) return false;
+
+        this.setState({ 'filtering' : true }, () => {
+            this.handleTermClick(facet, term, e, () =>
+                this.setState({ 'filtering' : false })
+            );
+        });
+
+    }
+
+    /**
+     * Each Term component instance provides their own callback, we just route the navigation request.
+     *
+     * @todo Allow to specify interval for histogram & date_histogram in schema instead of hard-coding 'month' interval.
+     */
+    handleTermClick(facet, term, e, callback) {
+        const { onFilter, href } = this.props;
+        onFilter(facet, term, callback, false, href);
+    }
+
+    render() {
+        const {
+            facet, terms, getTermStatus, extraClassname, termTransformFxn, separateSingleTermFacets,
+            isStatic
+        } = this.props;
+        const { filtering } = this.state;
+        const { field, title, description = null } = facet || {};
+
+        const showTitle = title || field;
+
+        if (separateSingleTermFacets && isStatic){
+            // Only one term exists.
+            return <StaticSingleTerm {...{ facet, term : terms[0], filtering, showTitle, onClick : this.handleStaticClick, getTermStatus, extraClassname, termTransformFxn }} />;
+        } else {
+            return <FacetTermsList {...this.props} onTermClick={this.handleTermClick} tooltip={description} title={showTitle} />;
+        }
+
+    }
+}
+TermsFacet.propTypes = {
+    'facet'                 : PropTypes.shape({
+        'field'                 : PropTypes.string.isRequired,    // Name of nested field property in experiment objects, using dot-notation.
+        'title'                 : PropTypes.string,               // Human-readable Facet Term
+        'total'                 : PropTypes.number,               // Total experiments (or terms??) w/ field
+        'terms'                 : PropTypes.array.isRequired,     // Possible terms,
+        'description'           : PropTypes.string,
+        'aggregation_type'      : PropTypes.oneOf(["stats", "terms"])
+    }),
+    'defaultFacetOpen'      : PropTypes.bool,
+    'onFilter'              : PropTypes.func,           // Executed on term click
+    'extraClassname'        : PropTypes.string,
+    'schemas'               : PropTypes.object,
+    'getTermStatus'         : PropTypes.func.isRequired,
+    'href'                  : PropTypes.string.isRequired,
+    'filters'               : PropTypes.arrayOf(PropTypes.object).isRequired,
+    'mounted'               : PropTypes.bool
+};

--- a/src/components/browse/components/FacetList/index.js
+++ b/src/components/browse/components/FacetList/index.js
@@ -240,29 +240,6 @@ export class FacetList extends React.PureComponent {
         this.setState({ 'mounted' : true });
     }
 
-    // groupFacets() {
-    //     const { facets } = this.props;
-    //     const grouped = []; // { field: green, }
-    //     const groupIndices = {}; // green : 0 where in grouped
-
-    //     facets.forEach((facet)=> {
-    //         if (facet.grouping) {
-    //             // check if there's a facet group in grouped;
-    //             if (groupIndices.hasOwnProperty(facet.grouping)) {
-    //                 const i = groupIndices[facet.grouping];
-    //                 grouped[i].facetList.push(facet);
-    //             } else  {
-    //                 grouped.push({ field: facet.grouping, facetList: [facet] });
-    //                 groupIndices[facet.grouping] = grouped.length - 1;
-    //             }
-    //         } else {
-    //             grouped.push({ field: facet.field, facet: facet });
-    //         }
-    //     });
-
-    //     return grouped;
-    // }
-
     renderFacets(maxTermsToShow = 12){
         const {
             facets, href, onFilter, schemas, getTermStatus, filters,
@@ -270,7 +247,6 @@ export class FacetList extends React.PureComponent {
         } = this.props;
         const { mounted } = this.state;
 
-        console.log("log1: ", facets);
         // Ensure each facets has an `order` property and default it to 0 if not.
         // And then sort by `order`.
         const useFacets = _.sortBy(
@@ -285,11 +261,6 @@ export class FacetList extends React.PureComponent {
             ),
             'order'
         );
-
-        // console.log("log1: equal?" , facets === useFacets);
-        // console.log("log1: this.groupFacets() ", this.groupFacets());,
-        console.log("log1: usefacets: ", useFacets);
-
 
         const commonProps = {
             onFilter, href, getTermStatus, filters, schemas, itemTypeForSchemas,
@@ -309,7 +280,6 @@ export class FacetList extends React.PureComponent {
             if (m.termCount > maxTermsToShow) m.end = true;
             return m;
         }, { facetIndex : 0, termCount: 0, end : false }).facetIndex;
-
 
         const rgs = responsiveGridState(windowWidth || null);
 
@@ -332,8 +302,6 @@ export class FacetList extends React.PureComponent {
         const inGroupIndices = {}; // green : 0 where in groupedOnly
         const genFacetIndices = {};
 
-
-
         useFacets.forEach(function(facet, i){
             // if the facet isn't groupedOnly, add to render as-is
             if (!facet.grouping) {
@@ -345,25 +313,21 @@ export class FacetList extends React.PureComponent {
                 // check if there's a facet group in groupedOnly;
                 if (inGroupIndices.hasOwnProperty(facet.grouping)) {
                     const i = inGroupIndices[facet.grouping];
-                    groupedOnly[i].facets.push(generateFacet(facet, i - 1));
+                    groupedOnly[i].facets.push(generateFacet(facet, i));
                 } else  {
                     groupedOnly.push({
                         key: facet.grouping,
                         title: facet.grouping,
-                        facets: [generateFacet(facet, i-1)]
+                        facets: [generateFacet(facet, i)]
                     });
                     inGroupIndices[facet.grouping] = groupedOnly.length - 1;
                 }
             }
         });
 
-
-
         // splice back in the nested facets
         groupedOnly.forEach(function(group, i) {
-
-            //facetsWithGroupings.splice(genFacetIndices[group.field] + i, 0, <Facet {...commonProps} {...group} key={group.field} defaultFacetOpen={false} isStatic={false} />);
-            facetsWithGroupings.splice(genFacetIndices[group.field] + i, 0, <FacetOfFacets {...commonProps} {...group} defaultFacetOpen={false} isStatic={false} />);
+            facetsWithGroupings.splice(genFacetIndices[group.title] + i, 0, <FacetOfFacets {...commonProps} {...group} defaultFacetOpen={false} isStatic={false} />);
         });
 
         return facetsWithGroupings;

--- a/src/components/browse/components/FacetList/index.js
+++ b/src/components/browse/components/FacetList/index.js
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import url from 'url';
 import queryString from 'query-string';
 import _ from 'underscore';
-import memoize from 'memoize-one';
 
 import { patchedConsoleInstance as console } from './../../../util/patched-console';
 import { getStatusAndUnselectHrefIfSelectedOrOmittedFromResponseFilters, buildSearchHref, contextFiltersToExpSetFilters } from './../../../util/search-filters';
@@ -13,9 +12,9 @@ import { navigate } from './../../../util/navigate';
 import * as analytics from './../../../util/analytics';
 import { responsiveGridState } from './../../../util/layout';
 
+import { TermsFacet } from './TermsFacet';
 import { RangeFacet, getValueFromFilters as getRangeValueFromFilters } from './RangeFacet';
 import { FacetTermsList, mergeTerms, anyTermsSelected } from './FacetTermsList';
-import { StaticSingleTerm } from './StaticSingleTerm';
 import { FacetOfFacets } from './FacetOfFacets';
 
 /**
@@ -27,102 +26,6 @@ import { FacetOfFacets } from './FacetOfFacets';
  *
  * @module {Component} facetlist
  */
-
-
-
-/**
- * Used to render individual facet fields and their available terms in FacetList.
- */
-class TermsFacet extends React.PureComponent {
-
-    static isStatic(facet){
-        const { terms = null, total = 0 } = facet;
-        return (
-            Array.isArray(terms) &&
-            terms.length === 1 &&
-            total <= _.reduce(terms, function(m, t){ return m + (t.doc_count || 0); }, 0)
-        );
-    }
-
-    constructor(props){
-        super(props);
-        this.handleStaticClick = this.handleStaticClick.bind(this);
-        this.handleTermClick = this.handleTermClick.bind(this);
-
-        this.state = {
-            'filtering' : false
-        };
-    }
-
-    /**
-     * For cases when there is only one option for a facet - we render a 'static' row.
-     * This may change in response to design.
-     * Unlike in `handleTermClick`, we handle own state/UI here.
-     *
-     * @todo Allow to specify interval for histogram & date_histogram in schema instead of hard-coding 'month' interval.
-     */
-    handleStaticClick(e) {
-        const { facet, isStatic } = this.props;
-        const term = facet.terms[0]; // Would only have 1
-
-        e.preventDefault();
-        if (!isStatic) return false;
-
-        this.setState({ 'filtering' : true }, () => {
-            this.handleTermClick(facet, term, e, () =>
-                this.setState({ 'filtering' : false })
-            );
-        });
-
-    }
-
-    /**
-     * Each Term component instance provides their own callback, we just route the navigation request.
-     *
-     * @todo Allow to specify interval for histogram & date_histogram in schema instead of hard-coding 'month' interval.
-     */
-    handleTermClick(facet, term, e, callback) {
-        const { onFilter, href } = this.props;
-        onFilter(facet, term, callback, false, href);
-    }
-
-    render() {
-        const {
-            facet, terms, getTermStatus, extraClassname, termTransformFxn, separateSingleTermFacets,
-            isStatic
-        } = this.props;
-        const { filtering } = this.state;
-        const { field, title, description = null } = facet || {};
-
-        const showTitle = title || field;
-
-        if (separateSingleTermFacets && isStatic){
-            // Only one term exists.
-            return <StaticSingleTerm {...{ facet, term : terms[0], filtering, showTitle, onClick : this.handleStaticClick, getTermStatus, extraClassname, termTransformFxn }} />;
-        } else {
-            return <FacetTermsList {...this.props} onTermClick={this.handleTermClick} tooltip={description} title={showTitle} />;
-        }
-
-    }
-}
-TermsFacet.propTypes = {
-    'facet'                 : PropTypes.shape({
-        'field'                 : PropTypes.string.isRequired,    // Name of nested field property in experiment objects, using dot-notation.
-        'title'                 : PropTypes.string,               // Human-readable Facet Term
-        'total'                 : PropTypes.number,               // Total experiments (or terms??) w/ field
-        'terms'                 : PropTypes.array.isRequired,     // Possible terms,
-        'description'           : PropTypes.string,
-        'aggregation_type'      : PropTypes.oneOf(["stats", "terms"])
-    }),
-    'defaultFacetOpen'      : PropTypes.bool,
-    'onFilter'              : PropTypes.func,           // Executed on term click
-    'extraClassname'        : PropTypes.string,
-    'schemas'               : PropTypes.object,
-    'getTermStatus'         : PropTypes.func.isRequired,
-    'href'                  : PropTypes.string.isRequired,
-    'filters'               : PropTypes.arrayOf(PropTypes.object).isRequired,
-    'mounted'               : PropTypes.bool
-};
 
 
 
@@ -215,10 +118,10 @@ export class FacetList extends React.PureComponent {
 
     constructor(props){
         super(props);
+        this.renderFacets = this.renderFacets.bind(this);
         this.state = {
             'mounted' : false
         };
-        this.renderFacets = this.renderFacets.bind(this);
     }
 
     componentDidMount(){
@@ -366,7 +269,7 @@ export class FacetList extends React.PureComponent {
     }
 
     render() {
-        const { debug, facets, className, title, showClearFiltersButton, onClearFilters, windowHeight, separateSingleTermFacets } = this.props;
+        const { debug, facets, className, title, showClearFiltersButton, onClearFilters, separateSingleTermFacets } = this.props;
         if (debug) console.log('render facetlist');
 
         if (!facets || !Array.isArray(facets) || facets.length === 0) {

--- a/src/components/browse/components/FacetList/index.js
+++ b/src/components/browse/components/FacetList/index.js
@@ -230,6 +230,29 @@ export class FacetList extends React.PureComponent {
         this.setState({ 'mounted' : true });
     }
 
+    groupFacets() {
+        const { facets } = this.props;
+        const grouped = []; // { field: green, }
+        const groupIndices = {}; // green : 0 where in grouped
+
+        facets.forEach((facet)=> {
+            if (facet.grouping) {
+                // check if there's a facet group in grouped;
+                if (groupIndices.hasOwnProperty(facet.grouping)) {
+                    const i = groupIndices[facet.grouping];
+                    grouped[i].facetList.push(facet);
+                } else  {
+                    grouped.push({ field: facet.grouping, facetList: [facet] });
+                    groupIndices[facet.grouping] = grouped.length - 1;
+                }
+            } else {
+                grouped.push({ field: facet.field, facet: facet });
+            }
+        });
+
+        return grouped;
+    }
+
     renderFacets(maxTermsToShow = 12){
         const {
             facets, href, onFilter, schemas, getTermStatus, filters,
@@ -237,6 +260,7 @@ export class FacetList extends React.PureComponent {
         } = this.props;
         const { mounted } = this.state;
 
+        console.log("log1: ", facets);
         // Ensure each facets has an `order` property and default it to 0 if not.
         // And then sort by `order`.
         const useFacets = _.sortBy(
@@ -251,6 +275,10 @@ export class FacetList extends React.PureComponent {
             ),
             'order'
         );
+
+        console.log("log1: equal?" , facets === useFacets);
+        console.log("log1: this.groupFacets() ", this.groupFacets());
+        console.log("log1: usefacets: ", useFacets);
 
         const commonProps = {
             onFilter, href, getTermStatus, filters, schemas, itemTypeForSchemas,
@@ -270,6 +298,8 @@ export class FacetList extends React.PureComponent {
             if (m.termCount > maxTermsToShow) m.end = true;
             return m;
         }, { facetIndex : 0, termCount: 0, end : false }).facetIndex;
+
+        console.log("log1: facetIndexWherePastXTerms", facetIndexWherePastXTerms);
 
         const rgs = responsiveGridState(windowWidth || null);
 


### PR DESCRIPTION
![ad97a069c9f6fc3a8b42545c00a7ef33](https://user-images.githubusercontent.com/16036838/68424406-e994d980-0171-11ea-9e8e-71295986f9dd.gif)

Not sure if we should wait to merge this in or not; have the final schema decisions for grouping been officially made? Definitely needs testing on 4DN either way. And need to pull in changes from master (I'm having trouble getting new master on shared-portal-components working on my local).

Also, please take a look what I did with `mergeTerms()` and `anyTermsSelected()` in `index.js`. I pulled those methods out of `FacetTermsList` to make the indicator color and selected terms tooltips work in `FacetOfFacets`. Not sure if I should rework `FacetTermsList` to work the same way or not.