### PR TITLE
Fix of Enum Fields in Submission View Page

### DIFF
--- a/es/components/forms/components/submission-fields.js
+++ b/es/components/forms/components/submission-fields.js
@@ -322,8 +322,24 @@ function (_React$PureComponent) {
           nestedField = _this$props2.nestedField,
           fieldType = _this$props2.fieldType,
           linkType = _this$props2.linkType,
-          arrayIdx = _this$props2.arrayIdx;
-      modifyNewContext(nestedField, eventKey, fieldType, linkType, arrayIdx);
+          arrayIdx = _this$props2.arrayIdx,
+          schema = _this$props2.schema; //eventKey's type is always string, convert it to the proper type defined in schema
+
+      var value = eventKey;
+
+      if (schema && schema.type && typeof schema.type === 'string') {
+        if (schema.type === 'integer') {
+          value = parseInt(eventKey);
+        } else if (schema.type === 'float') {
+          value = parseFloat(eventKey);
+        } else if (schema.type === 'number') {
+          value = Number(eventKey);
+        } else if (schema.type === 'boolean') {
+          value = eventKey === 'true';
+        }
+      }
+
+      modifyNewContext(nestedField, value, fieldType, linkType, arrayIdx);
     }
   }, {
     key: "handleChange",
@@ -1353,7 +1369,9 @@ function (_React$PureComponent3) {
 
         if (fieldType === 'enum') {
           enumValues = fieldSchema["enum"] || fieldSchema.suggested_enum || [];
-        } // format field as <this_field>.<next_field> so top level modification
+        }
+
+        _util.console.log('xxx enumValues: ', enumValues); // format field as <this_field>.<next_field> so top level modification
         // happens correctly
 
 

--- a/es/components/forms/components/submission-fields.js
+++ b/es/components/forms/components/submission-fields.js
@@ -1369,9 +1369,7 @@ function (_React$PureComponent3) {
 
         if (fieldType === 'enum') {
           enumValues = fieldSchema["enum"] || fieldSchema.suggested_enum || [];
-        }
-
-        _util.console.log('xxx enumValues: ', enumValues); // format field as <this_field>.<next_field> so top level modification
+        } // format field as <this_field>.<next_field> so top level modification
         // happens correctly
 
 

--- a/src/components/forms/components/submission-fields.js
+++ b/src/components/forms/components/submission-fields.js
@@ -168,8 +168,25 @@ export class BuildField extends React.PureComponent {
     }
 
     submitEnumVal(eventKey){
-        const { modifyNewContext, nestedField, fieldType, linkType, arrayIdx } = this.props;
-        modifyNewContext(nestedField, eventKey, fieldType, linkType, arrayIdx);
+        const { modifyNewContext, nestedField, fieldType, linkType, arrayIdx, schema } = this.props;
+
+        //eventKey's type is always string, convert it to the proper type defined in schema
+        let value = eventKey;
+        if (schema && schema.type && (typeof schema.type === 'string')) {
+            if (schema.type === 'integer') {
+                value = parseInt(eventKey);
+            } else if (schema.type === 'float') {
+                value = parseFloat(eventKey);
+            } else if (schema.type === 'number') {
+                value = Number(eventKey);
+            } else if (schema.type === 'boolean') {
+                value = (eventKey === 'true');
+            } else {
+                //todo: define other conversion types
+            }
+        }
+
+        modifyNewContext(nestedField, value, fieldType, linkType, arrayIdx);
     }
 
     handleChange(e){
@@ -881,6 +898,7 @@ class ObjectField extends React.PureComponent {
             if (fieldType === 'enum'){
                 enumValues = fieldSchema.enum || fieldSchema.suggested_enum || [];
             }
+            console.log('xxx enumValues: ', enumValues);
             // format field as <this_field>.<next_field> so top level modification
             // happens correctly
             const nestedField = propNestedField + '.' + field;

--- a/src/components/forms/components/submission-fields.js
+++ b/src/components/forms/components/submission-fields.js
@@ -898,7 +898,6 @@ class ObjectField extends React.PureComponent {
             if (fieldType === 'enum'){
                 enumValues = fieldSchema.enum || fieldSchema.suggested_enum || [];
             }
-            console.log('xxx enumValues: ', enumValues);
             // format field as <this_field>.<next_field> so top level modification
             // happens correctly
             const nestedField = propNestedField + '.' + field;


### PR DESCRIPTION
**Problem:**

- If a property is defined as enum in schema
and
- its value type is not string

then submission view fails while validating the submitted enum value, since it is recognized as string. This problem occurred while submitting a page with redirection. Page.json's related property is:
```

"code" : {
     "title" : "Response Code",
     "description" : "Code returned by response.",
     "comment" : "See https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#3xx_Redirection",
     "type" : "integer",
     "default" : 307,
     "enum" : [301, 302, 303, 307]
}
```

**Solution:**

The value is converted to the schema-defined data type before validation/submission. (currently supports integer, float, number and boolean.)