### PR TITLE
FacetList Updates re: UX -

### DIFF
--- a/es/components/browse/components/FacetList/FacetOfFacets.js
+++ b/es/components/browse/components/FacetList/FacetOfFacets.js
@@ -69,109 +69,32 @@ function (_React$PureComponent) {
 
     _this = _possibleConstructorReturn(this, _getPrototypeOf(FacetOfFacets).call(this, props));
     _this.handleOpenToggleClick = _this.handleOpenToggleClick.bind(_assertThisInitialized(_this));
-    _this.handleExpandListToggleClick = _this.handleExpandListToggleClick.bind(_assertThisInitialized(_this));
     _this.memoized = {
       anyFacetsHaveSelection: (0, _memoizeOne["default"])(FacetOfFacets.anyFacetsHaveSelection)
-    }; // Most of this logic (facetOpen/facetClosing at least) is same between this and FacetTermsList.
-    // Maybe we could pull it out into reusable controller component. Maybe. Very low priority.
-
-    _this.state = {
-      'facetOpen': typeof props.defaultGroupOpen === 'boolean' ? props.defaultGroupOpen : true,
-      'facetClosing': false,
-      'expanded': false
     };
     return _this;
   }
 
   _createClass(FacetOfFacets, [{
     key: "componentDidUpdate",
-    value: function componentDidUpdate(pastProps, pastState) {
-      var _this2 = this;
+    value: function componentDidUpdate(pastProps) {
+      var facetOpen = this.props.facetOpen;
+      var prevOpen = pastProps.facetOpen;
 
-      var _this$props = this.props,
-          renderedFacets = _this$props.facets,
-          mounted = _this$props.mounted,
-          defaultGroupOpen = _this$props.defaultGroupOpen,
-          isStatic = _this$props.isStatic;
-      var pastMounted = pastProps.mounted,
-          pastDefaultOpen = pastProps.defaultGroupOpen,
-          pastStatic = pastProps.isStatic;
-      this.setState(function (_ref) {
-        var currFacetOpen = _ref.facetOpen;
-
-        if (!pastMounted && mounted && typeof defaultGroupOpen === 'boolean' && defaultGroupOpen !== pastDefaultOpen) {
-          return {
-            'facetOpen': true
-          };
-        }
-
-        if (defaultGroupOpen === true && !pastDefaultOpen && !currFacetOpen) {
-          return {
-            'facetOpen': true
-          };
-        }
-
-        if (currFacetOpen && isStatic && !pastStatic && !_this2.memoized.anyFacetsHaveSelection(renderedFacets)) {
-          return {
-            'facetOpen': false
-          };
-        }
-
-        return null;
-      }, function () {
-        var facetOpen = _this2.state.facetOpen;
-
-        if (pastState.facetOpen !== facetOpen) {
-          _reactTooltip["default"].rebuild();
-        }
-      });
+      if (prevOpen !== facetOpen) {
+        _reactTooltip["default"].rebuild();
+      }
     }
   }, {
     key: "handleOpenToggleClick",
     value: function handleOpenToggleClick(e) {
-      var _this3 = this;
-
       e.preventDefault();
-      this.setState(function (_ref2) {
-        var facetOpen = _ref2.facetOpen;
-
-        if (!facetOpen) {
-          return {
-            'facetOpen': true
-          };
-        } else {
-          return {
-            'facetClosing': true
-          };
-        }
-      }, function () {
-        setTimeout(function () {
-          _this3.setState(function (_ref3) {
-            var facetOpen = _ref3.facetOpen,
-                facetClosing = _ref3.facetClosing;
-
-            if (facetClosing) {
-              return {
-                'facetOpen': false,
-                'facetClosing': false
-              };
-            }
-
-            return null;
-          });
-        }, 350);
-      });
-    }
-  }, {
-    key: "handleExpandListToggleClick",
-    value: function handleExpandListToggleClick(e) {
-      e.preventDefault();
-      this.setState(function (_ref4) {
-        var expanded = _ref4.expanded;
-        return {
-          'expanded': !expanded
-        };
-      });
+      var _this$props = this.props,
+          onToggleOpen = _this$props.onToggleOpen,
+          groupTitle = _this$props.title,
+          _this$props$facetOpen = _this$props.facetOpen,
+          facetOpen = _this$props$facetOpen === void 0 ? false : _this$props$facetOpen;
+      onToggleOpen("group:" + groupTitle, !facetOpen);
     }
   }, {
     key: "render",
@@ -179,20 +102,23 @@ function (_React$PureComponent) {
       var _this$props2 = this.props,
           title = _this$props2.title,
           renderedFacets = _this$props2.facets,
-          tooltip = _this$props2.tooltip;
-      var _this$state = this.state,
-          facetOpen = _this$state.facetOpen,
-          facetClosing = _this$state.facetClosing;
+          tooltip = _this$props2.tooltip,
+          facetOpen = _this$props2.facetOpen,
+          _this$props2$openFace = _this$props2.openFacets,
+          openFacets = _this$props2$openFace === void 0 ? {} : _this$props2$openFace;
       var anySelections = this.memoized.anyFacetsHaveSelection(renderedFacets); // Ensure all facets within group are not "static single terms".
+      // Pass in facetOpen prop.
 
       var extendedFacets = _react["default"].Children.map(renderedFacets, function (renderedFacet) {
+        var field = renderedFacet.props.facet.field;
         return _react["default"].cloneElement(renderedFacet, {
-          isStatic: false
+          isStatic: false,
+          facetOpen: openFacets[field]
         });
       });
 
       return _react["default"].createElement("div", {
-        className: "facet" + (facetOpen ? ' open' : ' closed') + (facetClosing ? ' closing' : ''),
+        className: "facet" + (facetOpen || anySelections ? ' open' : ' closed'),
         "data-group": title
       }, _react["default"].createElement("h5", {
         className: "facet-title",
@@ -200,14 +126,14 @@ function (_React$PureComponent) {
       }, _react["default"].createElement("span", {
         className: "expand-toggle col-auto px-0"
       }, _react["default"].createElement("i", {
-        className: "icon icon-fw fas " + (facetOpen && !facetClosing ? "icon-minus" : "icon-plus")
+        className: "icon icon-fw icon-" + (anySelections ? "dot-circle far" : facetOpen ? "minus fas" : "plus fas")
       })), _react["default"].createElement("div", {
         className: "col px-0 line-height-1"
       }, _react["default"].createElement("span", {
         "data-tip": tooltip,
         "data-place": "right"
       }, title)), _react["default"].createElement(_Fade.Fade, {
-        "in": facetClosing || !facetOpen
+        "in": !facetOpen && !anySelections
       }, _react["default"].createElement("span", {
         className: "closed-terms-count col-auto px-0" + (anySelections ? " some-selected" : ""),
         "data-place": "right",
@@ -215,7 +141,7 @@ function (_React$PureComponent) {
       }, _react["default"].createElement("i", {
         className: "icon fas icon-layer-group"
       })))), _react["default"].createElement(_Collapse.Collapse, {
-        "in": facetOpen && !facetClosing
+        "in": facetOpen || anySelections
       }, _react["default"].createElement("div", {
         className: "facet-group-list-container"
       }, extendedFacets)));

--- a/es/components/browse/components/FacetList/FacetOfFacets.js
+++ b/es/components/browse/components/FacetList/FacetOfFacets.js
@@ -11,8 +11,6 @@ var _propTypes = _interopRequireDefault(require("prop-types"));
 
 var _memoizeOne = _interopRequireDefault(require("memoize-one"));
 
-var _reactTooltip = _interopRequireDefault(require("react-tooltip"));
-
 var _Collapse = require("./../../../ui/Collapse");
 
 var _Fade = require("./../../../ui/Fade");
@@ -54,6 +52,7 @@ function (_React$PureComponent) {
         var anySelected = renderedFacet.props.anyTermsSelected;
 
         if (anySelected) {
+          console.log(renderedFacet);
           return true;
         }
       }
@@ -76,16 +75,6 @@ function (_React$PureComponent) {
   }
 
   _createClass(FacetOfFacets, [{
-    key: "componentDidUpdate",
-    value: function componentDidUpdate(pastProps) {
-      var facetOpen = this.props.facetOpen;
-      var prevOpen = pastProps.facetOpen;
-
-      if (prevOpen !== facetOpen) {
-        _reactTooltip["default"].rebuild();
-      }
-    }
-  }, {
     key: "handleOpenToggleClick",
     value: function handleOpenToggleClick(e) {
       e.preventDefault();
@@ -101,7 +90,7 @@ function (_React$PureComponent) {
     value: function render() {
       var _this$props2 = this.props,
           title = _this$props2.title,
-          renderedFacets = _this$props2.facets,
+          renderedFacets = _this$props2.children,
           tooltip = _this$props2.tooltip,
           facetOpen = _this$props2.facetOpen,
           _this$props2$openFace = _this$props2.openFacets,

--- a/es/components/browse/components/FacetList/FacetTermsList.js
+++ b/es/components/browse/components/FacetList/FacetTermsList.js
@@ -313,7 +313,6 @@ function (_React$PureComponent2) {
     _this3.handleOpenToggleClick = _this3.handleOpenToggleClick.bind(_assertThisInitialized(_this3));
     _this3.handleExpandListToggleClick = _this3.handleExpandListToggleClick.bind(_assertThisInitialized(_this3));
     _this3.state = {
-      'facetOpen': typeof props.defaultFacetOpen === 'boolean' ? props.defaultFacetOpen : true,
       'expanded': false
     };
     return _this3;
@@ -321,66 +320,31 @@ function (_React$PureComponent2) {
 
   _createClass(FacetTermsList, [{
     key: "componentDidUpdate",
-    value: function componentDidUpdate(pastProps, pastState) {
-      var _this4 = this;
+    value: function componentDidUpdate(pastProps) {
+      var facetOpen = this.props.facetOpen;
+      var prevOpen = pastProps.facetOpen;
 
-      var _this$props3 = this.props,
-          anySelected = _this$props3.anyTermsSelected,
-          mounted = _this$props3.mounted,
-          defaultFacetOpen = _this$props3.defaultFacetOpen,
-          isStatic = _this$props3.isStatic,
-          windowWidth = _this$props3.windowWidth;
-      var pastMounted = pastProps.mounted,
-          pastDefaultOpen = pastProps.defaultFacetOpen,
-          pastStatic = pastProps.isStatic,
-          pastWidth = pastProps.windowWidth;
-      this.setState(function (_ref2) {
-        var currFacetOpen = _ref2.facetOpen;
-
-        if (pastWidth === null && typeof windowWidth === "number" && typeof defaultFacetOpen === 'boolean' && defaultFacetOpen !== pastDefaultOpen) {
-          return {
-            'facetOpen': true
-          };
-        }
-
-        if (defaultFacetOpen === true && !pastDefaultOpen && !currFacetOpen) {
-          return {
-            'facetOpen': true
-          };
-        }
-
-        if (currFacetOpen && isStatic && !pastStatic && !anySelected) {
-          return {
-            'facetOpen': false
-          };
-        }
-
-        return null;
-      }, function () {
-        var facetOpen = _this4.state.facetOpen;
-
-        if (pastState.facetOpen !== facetOpen) {
-          _reactTooltip["default"].rebuild();
-        }
-      });
+      if (prevOpen !== facetOpen) {
+        _reactTooltip["default"].rebuild();
+      }
     }
   }, {
     key: "handleOpenToggleClick",
     value: function handleOpenToggleClick(e) {
       e.preventDefault();
-      this.setState(function (_ref3) {
-        var facetOpen = _ref3.facetOpen;
-        return {
-          'facetOpen': !facetOpen
-        };
-      });
+      var _this$props3 = this.props,
+          onToggleOpen = _this$props3.onToggleOpen,
+          field = _this$props3.facet.field,
+          _this$props3$facetOpe = _this$props3.facetOpen,
+          facetOpen = _this$props3$facetOpe === void 0 ? false : _this$props3$facetOpe;
+      onToggleOpen(field, !facetOpen);
     }
   }, {
     key: "handleExpandListToggleClick",
     value: function handleExpandListToggleClick(e) {
       e.preventDefault();
-      this.setState(function (_ref4) {
-        var expanded = _ref4.expanded;
+      this.setState(function (_ref2) {
+        var expanded = _ref2.expanded;
         return {
           'expanded': !expanded
         };
@@ -400,10 +364,9 @@ function (_React$PureComponent2) {
           persistentCount = _this$props4.persistentCount,
           onTermClick = _this$props4.onTermClick,
           getTermStatus = _this$props4.getTermStatus,
-          termTransformFxn = _this$props4.termTransformFxn;
-      var _this$state = this.state,
-          facetOpen = _this$state.facetOpen,
-          expanded = _this$state.expanded;
+          termTransformFxn = _this$props4.termTransformFxn,
+          facetOpen = _this$props4.facetOpen;
+      var expanded = this.state.expanded;
       var termsLen = terms.length;
       var allTermsSelected = termsSelectedCount === termsLen;
       var indicator; // @todo: much of this code (including mergeTerms and anyTermsSelected above) were moved to index; consider moving these too
@@ -609,21 +572,21 @@ var ListOfTerms = _react["default"].memo(function (props) {
   }
 });
 
-var CountIndicator = _react["default"].memo(function (_ref5) {
-  var _ref5$count = _ref5.count,
-      count = _ref5$count === void 0 ? 1 : _ref5$count,
-      _ref5$countActive = _ref5.countActive,
-      countActive = _ref5$countActive === void 0 ? 0 : _ref5$countActive,
-      _ref5$height = _ref5.height,
-      height = _ref5$height === void 0 ? 16 : _ref5$height,
-      _ref5$width = _ref5.width,
-      width = _ref5$width === void 0 ? 40 : _ref5$width;
+var CountIndicator = _react["default"].memo(function (_ref3) {
+  var _ref3$count = _ref3.count,
+      count = _ref3$count === void 0 ? 1 : _ref3$count,
+      _ref3$countActive = _ref3.countActive,
+      countActive = _ref3$countActive === void 0 ? 0 : _ref3$countActive,
+      _ref3$height = _ref3.height,
+      height = _ref3$height === void 0 ? 16 : _ref3$height,
+      _ref3$width = _ref3.width,
+      width = _ref3$width === void 0 ? 40 : _ref3$width;
   var dotCountToShow = Math.min(count, 21);
   var dotCoords = (0, _utilities.stackDotsInContainer)(dotCountToShow, height, 4, 2, false);
-  var dots = dotCoords.map(function (_ref6, idx) {
-    var _ref7 = _slicedToArray(_ref6, 2),
-        x = _ref7[0],
-        y = _ref7[1];
+  var dots = dotCoords.map(function (_ref4, idx) {
+    var _ref5 = _slicedToArray(_ref4, 2),
+        x = _ref5[0],
+        y = _ref5[1];
 
     var colIdx = Math.floor(idx / 3); // Flip both axes so going bottom right to top left.
 

--- a/es/components/browse/components/FacetList/RangeFacet.js
+++ b/es/components/browse/components/FacetList/RangeFacet.js
@@ -229,13 +229,13 @@ function (_React$PureComponent) {
       var _this2 = this;
 
       var _this$props = this.props,
-          mounted = _this$props.mounted,
+          windowWidth = _this$props.windowWidth,
           defaultFacetOpen = _this$props.defaultFacetOpen,
           isStatic = _this$props.isStatic;
       this.setState(function (_ref2) {
         var currFacetOpen = _ref2.facetOpen;
 
-        if (!pastProps.mounted && mounted && typeof defaultFacetOpen === 'boolean' && defaultFacetOpen !== pastProps.defaultFacetOpen) {
+        if (pastProps.windowWidth === null && typeof windowWidth === "number" && typeof defaultFacetOpen === 'boolean' && defaultFacetOpen !== pastProps.defaultFacetOpen) {
           return {
             'facetOpen': true
           };
@@ -271,9 +271,6 @@ function (_React$PureComponent) {
 
       try {
         var fromVal = RangeFacet.parseAndValidate(facet, value);
-
-        _patchedConsole.patchedConsoleInstance.log("AAAAA", fromVal, value, facet);
-
         this.setState(function (_ref3) {
           var toVal = _ref3.toVal;
 
@@ -407,7 +404,6 @@ function (_React$PureComponent) {
           number_step = facet.number_step;
       var _this$state = this.state,
           facetOpen = _this$state.facetOpen,
-          facetClosing = _this$state.facetClosing,
           fromVal = _this$state.fromVal,
           toVal = _this$state.toVal;
 
@@ -415,8 +411,9 @@ function (_React$PureComponent) {
           fromIncrements = _this$memoized$validI.fromIncrements,
           toIncrements = _this$memoized$validI.toIncrements;
 
+      var isOpen = facetOpen || savedFromVal !== null || savedToVal !== null;
       return _react["default"].createElement("div", {
-        className: "facet range-facet" + (facetOpen ? ' open' : ' closed') + (facetClosing ? ' closing' : ''),
+        className: "facet range-facet" + (isOpen ? ' open' : ' closed'),
         "data-field": facet.field
       }, _react["default"].createElement("h5", {
         className: "facet-title",
@@ -424,14 +421,14 @@ function (_React$PureComponent) {
       }, _react["default"].createElement("span", {
         className: "expand-toggle col-auto px-0"
       }, _react["default"].createElement("i", {
-        className: "icon icon-fw fas " + (facetOpen && !facetClosing ? "icon-minus" : "icon-plus")
+        className: "icon icon-fw icon-" + (savedFromVal !== null || savedToVal !== null ? "chevron-circle-right fas" : isOpen ? "minus fas" : "plus fas")
       })), _react["default"].createElement("div", {
         className: "col px-0 line-height-1"
       }, _react["default"].createElement("span", {
         "data-tip": tooltip,
         "data-place": "right"
       }, propTitle || facetTitle || field)), _react["default"].createElement(_reactBootstrap.Fade, {
-        "in": facetClosing || !facetOpen
+        "in": !isOpen
       }, _react["default"].createElement("span", {
         className: "closed-terms-count col-auto px-0" + (savedFromVal !== null || savedToVal !== null ? " some-selected" : "")
       }, isStatic ? _react["default"].createElement("i", {
@@ -442,7 +439,7 @@ function (_React$PureComponent) {
       }) : _react["default"].createElement("i", {
         className: "icon icon-fw icon-greater-than-equal fas"
       })))), _react["default"].createElement(_Collapse.Collapse, {
-        "in": facetOpen && !facetClosing
+        "in": isOpen
       }, _react["default"].createElement("div", {
         className: "inner-panel"
       }, _react["default"].createElement("div", {

--- a/es/components/browse/components/FacetList/RangeFacet.js
+++ b/es/components/browse/components/FacetList/RangeFacet.js
@@ -215,7 +215,6 @@ function (_React$PureComponent) {
       validIncrements: (0, _memoizeOne["default"])(RangeFacet.validIncrements)
     };
     _this.state = {
-      facetOpen: props.defaultFacetOpen || false,
       facetClosing: false,
       fromVal: props.fromVal,
       toVal: props.toVal
@@ -225,42 +224,13 @@ function (_React$PureComponent) {
 
   _createClass(RangeFacet, [{
     key: "componentDidUpdate",
-    value: function componentDidUpdate(pastProps, pastState) {
-      var _this2 = this;
+    value: function componentDidUpdate(pastProps) {
+      var facetOpen = this.props.facetOpen;
+      var prevOpen = pastProps.facetOpen;
 
-      var _this$props = this.props,
-          windowWidth = _this$props.windowWidth,
-          defaultFacetOpen = _this$props.defaultFacetOpen,
-          isStatic = _this$props.isStatic;
-      this.setState(function (_ref2) {
-        var currFacetOpen = _ref2.facetOpen;
-
-        if (pastProps.windowWidth === null && typeof windowWidth === "number" && typeof defaultFacetOpen === 'boolean' && defaultFacetOpen !== pastProps.defaultFacetOpen) {
-          return {
-            'facetOpen': true
-          };
-        }
-
-        if (defaultFacetOpen === true && !pastProps.defaultFacetOpen && !currFacetOpen) {
-          return {
-            'facetOpen': true
-          };
-        }
-
-        if (currFacetOpen && isStatic && !pastProps.isStatic) {
-          return {
-            'facetOpen': false
-          };
-        }
-
-        return null;
-      }, function () {
-        var facetOpen = _this2.state.facetOpen;
-
-        if (pastState.facetOpen !== facetOpen) {
-          _reactTooltip["default"].rebuild();
-        }
-      });
+      if (prevOpen !== facetOpen) {
+        _reactTooltip["default"].rebuild();
+      }
     }
   }, {
     key: "setFrom",
@@ -271,8 +241,8 @@ function (_React$PureComponent) {
 
       try {
         var fromVal = RangeFacet.parseAndValidate(facet, value);
-        this.setState(function (_ref3) {
-          var toVal = _ref3.toVal;
+        this.setState(function (_ref2) {
+          var toVal = _ref2.toVal;
 
           if (fromVal === null || fromVal === min) {
             return {
@@ -309,8 +279,8 @@ function (_React$PureComponent) {
 
       try {
         var toVal = RangeFacet.parseAndValidate(facet, value);
-        this.setState(function (_ref4) {
-          var fromVal = _ref4.fromVal;
+        this.setState(function (_ref3) {
+          var fromVal = _ref3.fromVal;
 
           if (toVal === null || toVal === max) {
             return {
@@ -341,9 +311,9 @@ function (_React$PureComponent) {
   }, {
     key: "performUpdateFrom",
     value: function performUpdateFrom() {
-      var _this$props2 = this.props,
-          onFilter = _this$props2.onFilter,
-          facet = _this$props2.facet;
+      var _this$props = this.props,
+          onFilter = _this$props.onFilter,
+          facet = _this$props.facet;
       var fromVal = this.state.fromVal;
       onFilter(_objectSpread({}, facet, {
         field: facet.field + ".from"
@@ -354,9 +324,9 @@ function (_React$PureComponent) {
   }, {
     key: "performUpdateTo",
     value: function performUpdateTo() {
-      var _this$props3 = this.props,
-          onFilter = _this$props3.onFilter,
-          facet = _this$props3.facet;
+      var _this$props2 = this.props,
+          onFilter = _this$props2.onFilter,
+          facet = _this$props2.facet;
       var toVal = this.state.toVal;
       onFilter(_objectSpread({}, facet, {
         field: facet.field + ".to"
@@ -376,13 +346,14 @@ function (_React$PureComponent) {
     }
   }, {
     key: "handleOpenToggleClick",
-    value: function handleOpenToggleClick() {
-      this.setState(function (_ref5) {
-        var facetOpen = _ref5.facetOpen;
-        return {
-          facetOpen: !facetOpen
-        };
-      });
+    value: function handleOpenToggleClick(e) {
+      e.preventDefault();
+      var _this$props3 = this.props,
+          onToggleOpen = _this$props3.onToggleOpen,
+          field = _this$props3.facet.field,
+          _this$props3$facetOpe = _this$props3.facetOpen,
+          facetOpen = _this$props3$facetOpe === void 0 ? false : _this$props3$facetOpe;
+      onToggleOpen(field, !facetOpen);
     }
   }, {
     key: "render",
@@ -393,17 +364,16 @@ function (_React$PureComponent) {
           termTransformFxn = _this$props4.termTransformFxn,
           isStatic = _this$props4.isStatic,
           savedFromVal = _this$props4.fromVal,
-          savedToVal = _this$props4.toVal;
+          savedToVal = _this$props4.toVal,
+          facetOpen = _this$props4.facetOpen;
       var field = facet.field,
           min = facet.min,
           max = facet.max,
           _facet$title = facet.title,
           facetTitle = _facet$title === void 0 ? null : _facet$title,
           _facet$description = facet.description,
-          tooltip = _facet$description === void 0 ? null : _facet$description,
-          number_step = facet.number_step;
+          tooltip = _facet$description === void 0 ? null : _facet$description;
       var _this$state = this.state,
-          facetOpen = _this$state.facetOpen,
           fromVal = _this$state.fromVal,
           toVal = _this$state.toVal;
 
@@ -507,15 +477,15 @@ function (_React$PureComponent2) {
   _inherits(RangeDropdown, _React$PureComponent2);
 
   function RangeDropdown(props) {
-    var _this3;
+    var _this2;
 
     _classCallCheck(this, RangeDropdown);
 
-    _this3 = _possibleConstructorReturn(this, _getPrototypeOf(RangeDropdown).call(this, props));
-    _this3.onTextInputChange = _this3.onTextInputChange.bind(_assertThisInitialized(_this3));
-    _this3.onDropdownSelect = _this3.onDropdownSelect.bind(_assertThisInitialized(_this3));
-    _this3.onTextInputFormSubmit = _this3.onTextInputFormSubmit.bind(_assertThisInitialized(_this3));
-    return _this3;
+    _this2 = _possibleConstructorReturn(this, _getPrototypeOf(RangeDropdown).call(this, props));
+    _this2.onTextInputChange = _this2.onTextInputChange.bind(_assertThisInitialized(_this2));
+    _this2.onDropdownSelect = _this2.onDropdownSelect.bind(_assertThisInitialized(_this2));
+    _this2.onTextInputFormSubmit = _this2.onTextInputFormSubmit.bind(_assertThisInitialized(_this2));
+    return _this2;
   }
 
   _createClass(RangeDropdown, [{

--- a/es/components/browse/components/FacetList/TermsFacet.js
+++ b/es/components/browse/components/FacetList/TermsFacet.js
@@ -23,15 +23,15 @@ function _extends() { _extends = Object.assign || function (target) { for (var i
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
 function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function (o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
-
-function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
-
-function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
 
@@ -54,19 +54,6 @@ var TermsFacet =
 /*#__PURE__*/
 function (_React$PureComponent) {
   _inherits(TermsFacet, _React$PureComponent);
-
-  _createClass(TermsFacet, null, [{
-    key: "isStatic",
-    value: function isStatic(facet) {
-      var _facet$terms = facet.terms,
-          terms = _facet$terms === void 0 ? null : _facet$terms,
-          _facet$total = facet.total,
-          total = _facet$total === void 0 ? 0 : _facet$total;
-      return Array.isArray(terms) && terms.length === 1 && total <= _underscore["default"].reduce(terms, function (m, t) {
-        return m + (t.doc_count || 0);
-      }, 0);
-    }
-  }]);
 
   function TermsFacet(props) {
     var _this;
@@ -192,5 +179,5 @@ TermsFacet.propTypes = {
   'getTermStatus': _propTypes["default"].func.isRequired,
   'href': _propTypes["default"].string.isRequired,
   'filters': _propTypes["default"].arrayOf(_propTypes["default"].object).isRequired,
-  'mounted': _propTypes["default"].bool
+  'windowWidth': _propTypes["default"].number
 };

--- a/es/components/browse/components/FacetList/index.js
+++ b/es/components/browse/components/FacetList/index.js
@@ -8,6 +8,8 @@ exports.FacetList = void 0;
 
 var _react = _interopRequireDefault(require("react"));
 
+var _memoizeOne = _interopRequireDefault(require("memoize-one"));
+
 var _propTypes = _interopRequireDefault(require("prop-types"));
 
 var _url = _interopRequireDefault(require("url"));
@@ -42,6 +44,8 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "d
 
 function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function (obj) { return typeof obj; }; } else { _typeof = function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
+function _toArray(arr) { return _arrayWithHoles(arr) || _iterableToArray(arr) || _nonIterableRest(); }
+
 function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _nonIterableRest(); }
 
 function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance"); }
@@ -60,17 +64,21 @@ function _arrayWithoutHoles(arr) { if (Array.isArray(arr)) { for (var i = 0, arr
 
 function _extends() { _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
 
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
+
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(source, true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(source).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
+
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-
-function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
-
-function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
 
 function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function (o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
 
@@ -175,93 +183,30 @@ var FacetList =
 function (_React$PureComponent) {
   _inherits(FacetList, _React$PureComponent);
 
-  function FacetList(props) {
-    var _this;
+  _createClass(FacetList, null, [{
+    key: "createFacetComponents",
 
-    _classCallCheck(this, FacetList);
-
-    _this = _possibleConstructorReturn(this, _getPrototypeOf(FacetList).call(this, props));
-    _this.onFilterExtended = _this.onFilterExtended.bind(_assertThisInitialized(_this));
-    _this.getTermStatus = _this.getTermStatus.bind(_assertThisInitialized(_this));
-    _this.renderFacets = _this.renderFacets.bind(_assertThisInitialized(_this));
-    _this.state = {
-      'mounted': false
-    };
-    return _this;
-  }
-
-  _createClass(FacetList, [{
-    key: "componentDidMount",
-    value: function componentDidMount() {
-      this.setState({
-        'mounted': true
-      });
-    }
     /**
-     * Calls props.onFilter after sending analytics.
-     * N.B. When rangeFacet calls onFilter, it creates a `term` with `key` property
-     * as no 'terms' exist when aggregation_type === stats.
+     * We use a function instead of functional/memoized components because we want literal list of JSX components.
+     * These JSX components might later be segmented or something.
      */
+    value: function createFacetComponents(props) {
+      var href = props.href,
+          filters = props.filters,
+          schemas = props.schemas,
+          itemTypeForSchemas = props.itemTypeForSchemas,
+          termTransformFxn = props.termTransformFxn,
+          onFilter = props.onFilter,
+          getTermStatus = props.getTermStatus,
+          facets = props.facets,
+          windowWidth = props.windowWidth,
+          windowHeight = props.windowHeight,
+          _props$persistentCoun = props.persistentCount,
+          persistentCount = _props$persistentCoun === void 0 ? _FacetTermsList.FacetTermsList.defaultProps.persistentCount : _props$persistentCoun,
+          _props$separateSingle = props.separateSingleTermFacets,
+          separateSingleTermFacets = _props$separateSingle === void 0 ? false : _props$separateSingle;
 
-  }, {
-    key: "onFilterExtended",
-    value: function onFilterExtended(facet, term) {
-      var _this$props = this.props,
-          onFilter = _this$props.onFilter,
-          contextFilters = _this$props.filters;
-      var field = facet.field;
-      var termKey = term.key;
-      var statusAndHref = (0, _searchFilters.getStatusAndUnselectHrefIfSelectedOrOmittedFromResponseFilters)(term, facet, contextFilters);
-      var isUnselecting = !!statusAndHref.href;
-      analytics.event('FacetList', isUnselecting ? 'Unset Filter' : 'Set Filter', {
-        field: field,
-        'term': termKey,
-        'eventLabel': analytics.eventLabelFromChartNode({
-          field: field,
-          'term': termKey
-        }),
-        'currentFilters': analytics.getStringifiedCurrentFilters((0, _searchFilters.contextFiltersToExpSetFilters)(contextFilters || null)) // 'Existing' filters, or filters at time of action, go here.
-
-      });
-      return onFilter.apply(void 0, arguments);
-    }
-  }, {
-    key: "getTermStatus",
-    value: function getTermStatus(term, facet) {
-      var contextFilters = this.props.filters;
-      return (0, _searchFilters.getTermFacetStatus)(term, facet, contextFilters);
-    }
-  }, {
-    key: "renderFacets",
-    value: function renderFacets() {
-      var _this$props2 = this.props,
-          facets = _this$props2.facets,
-          href = _this$props2.href,
-          schemas = _this$props2.schemas,
-          filters = _this$props2.filters,
-          itemTypeForSchemas = _this$props2.itemTypeForSchemas,
-          windowWidth = _this$props2.windowWidth,
-          windowHeight = _this$props2.windowHeight,
-          termTransformFxn = _this$props2.termTransformFxn,
-          _this$props2$persiste = _this$props2.persistentCount,
-          persistentCount = _this$props2$persiste === void 0 ? _FacetTermsList.FacetTermsList.defaultProps.persistentCount : _this$props2$persiste,
-          _this$props2$separate = _this$props2.separateSingleTermFacets,
-          separateSingleTermFacets = _this$props2$separate === void 0 ? false : _this$props2$separate;
-      var mounted = this.state.mounted; // Ensure each facets has an `order` property and default it to 0 if not.
-      // And then sort by `order`.
-
-      var useFacets = _underscore["default"].sortBy(_underscore["default"].map(_underscore["default"].uniq(facets, false, function (f) {
-        return f.field;
-      }), // Ensure facets are unique, field-wise.
-      function (f) {
-        if (typeof f.order !== 'number') {
-          return _underscore["default"].extend({
-            'order': 0
-          }, f);
-        }
-
-        return f;
-      }), 'order');
+      _patchedConsole.patchedConsoleInstance.log("CREATING COMPS");
 
       var commonProps = {
         // Passed to all Facets
@@ -269,35 +214,55 @@ function (_React$PureComponent) {
         filters: filters,
         schemas: schemas,
         itemTypeForSchemas: itemTypeForSchemas,
-        mounted: mounted,
         termTransformFxn: termTransformFxn,
         separateSingleTermFacets: separateSingleTermFacets,
-        onFilter: this.onFilterExtended,
-        getTermStatus: this.getTermStatus
-      }; // We try to initially open some Facets depending on available screen size or props.
+        onFilter: onFilter,
+        getTermStatus: getTermStatus,
+        windowWidth: windowWidth
+      }; // Ensure each facets has an `order` property and default it to 0 if not.
+      // Also 'merge in terms' for each facet (i.e. add in active filtered terms with 0 results)
+      // And then sort by `order`.
+
+      var useFacets = _underscore["default"].sortBy(_underscore["default"].map(_underscore["default"].uniq(facets, false, function (f) {
+        return f.field;
+      }), // Ensure facets are unique, field-wise.
+      function (f) {
+        var newFacet = _objectSpread({}, f, {
+          order: f.order || 0
+        });
+
+        if (f.aggregation_type === "terms") {
+          newFacet.terms = (0, _FacetTermsList.mergeTerms)(f, filters);
+        }
+
+        return newFacet;
+      }), 'order');
+
+      var facetLen = useFacets.length; // We try to initially open some Facets depending on available screen size or props.
       // We might get rid of this feature at some point as the amount of Facets are likely to increase.
       // Or we could just set defaultFacetOpen = false if # facets > 10 or something.
       // Basically seems like should adjust `maxTermsToShow` based on total # of facets...
 
       var maxTermsToShow = (typeof windowHeight === 'number' && !isNaN(windowHeight) ? Math.floor(windowHeight / 60) : 15) - Math.floor(useFacets.length / 4);
-      var facetIndexWherePastXTerms = useFacets.reduce(function (m, facet, index) {
-        if (m.end) return m;
-        m.facetIndex = index;
+      var facetIndexWherePastXTerms;
+      var currTermCount = 0;
 
-        if (facet.aggregation_type === "stats") {
-          m.termCount = m.termCount + 2;
+      for (facetIndexWherePastXTerms = 0; facetIndexWherePastXTerms < facetLen; facetIndexWherePastXTerms++) {
+        if (useFacets[facetIndexWherePastXTerms].aggregation_type === "stats") {
+          // Range Facet (shows 2 'terms' or fields)
+          currTermCount += 2;
         } else {
-          // Take into account 'view more' button
-          m.termCount = m.termCount + Math.min(facet.terms.length, persistentCount);
+          // Terms; Take into account 'view more' button
+          // Slightly deprecated as doesn;t take into account 'mergeTerms'.
+          // Maybe could move mergeTerms stuff up into here.
+          currTermCount += Math.min(useFacets[facetIndexWherePastXTerms].terms.length, persistentCount);
         }
 
-        if (m.termCount > maxTermsToShow) m.end = true;
-        return m;
-      }, {
-        facetIndex: 0,
-        termCount: 0,
-        end: false
-      }).facetIndex;
+        if (currTermCount > maxTermsToShow) {
+          break;
+        }
+      }
+
       var rgs = (0, _layout.responsiveGridState)(windowWidth || null); // The logic within `Facet` `render`, `componentDidMount`, etc. isn't executed
       // until is rendered by some other component's render method.
       // We can sort/manipulate/transform these still according to their `props.` values and such.
@@ -307,19 +272,19 @@ function (_React$PureComponent) {
             grouping = _facet$grouping === void 0 ? null : _facet$grouping,
             facetField = facet.field,
             _facet$aggregation_ty2 = facet.aggregation_type,
-            aggregation_type = _facet$aggregation_ty2 === void 0 ? "terms" : _facet$aggregation_ty2; // Default Open if mounted and:
+            aggregation_type = _facet$aggregation_ty2 === void 0 ? "terms" : _facet$aggregation_ty2; // Default Open if ~~mounted~~ windowWidth not null (aka we mounted) and:
 
-        var defaultFacetOpen = !mounted ? false : !!(rgs !== 'xs' && i < (facetIndexWherePastXTerms || 1));
+        var defaultFacetOpen = typeof windowWidth !== "number" ? false : !!(rgs !== 'xs' && i < (facetIndexWherePastXTerms || 1));
 
         if (aggregation_type === "stats") {
           var _getRangeValueFromFil = (0, _RangeFacet.getValueFromFilters)(facet, filters),
               fromVal = _getRangeValueFromFil.fromVal,
               toVal = _getRangeValueFromFil.toVal;
 
-          var isStatic = facet.min === facet.max;
-          defaultFacetOpen = defaultFacetOpen || !isStatic && _underscore["default"].any(filters || [], function (fltr) {
-            return fltr.field === facetField + ".from" || fltr.field === facetField + ".to";
-          }) || false;
+          var isStatic = facet.min === facet.max; // defaultFacetOpen = defaultFacetOpen || (!isStatic && _.any(filters || [], function(fltr){
+          //     return (fltr.field === facetField + ".from") || (fltr.field === facetField + ".to");
+          // })) || false;
+
           return _react["default"].createElement(_RangeFacet.RangeFacet, _extends({}, commonProps, {
             facet: facet,
             key: facetField,
@@ -334,24 +299,24 @@ function (_React$PureComponent) {
         }
 
         if (aggregation_type === "terms") {
-          var terms = (0, _FacetTermsList.mergeTerms)(facet, filters); // Add in any terms specified in `filters` but not in `facet.terms` - in case someone hand-put that into URL.
+          //const terms = mergeTerms(facet, filters); // Add in any terms specified in `filters` but not in `facet.terms` - in case someone hand-put that into URL.
+          var termsSelectedCount = (0, _FacetTermsList.countTermsSelected)(facet.terms, facet, filters);
 
-          var termsSelectedCount = (0, _FacetTermsList.countTermsSelected)(terms, facet, filters);
+          var _anySelected = termsSelectedCount !== 0;
 
-          var _isStatic = _TermsFacet.TermsFacet.isStatic(facet);
+          var _isStatic = !_anySelected && facet.terms.length === 1; // TermsFacet.isStatic(facet);
+          //defaultFacetOpen = defaultFacetOpen || anySelected;
 
-          defaultFacetOpen = defaultFacetOpen || !_isStatic && _underscore["default"].any(filters || [], function (fltr) {
-            return fltr.field === facetField;
-          }) || false;
+
           return _react["default"].createElement(_TermsFacet.TermsFacet, _extends({}, commonProps, {
+            terms: facet.terms,
             facet: facet,
             key: facetField,
-            anyTermsSelected: termsSelectedCount !== 0
+            anyTermsSelected: _anySelected
           }, {
             defaultFacetOpen: defaultFacetOpen,
             isStatic: _isStatic,
             grouping: grouping,
-            terms: terms,
             termsSelectedCount: termsSelectedCount
           }));
         }
@@ -427,21 +392,137 @@ function (_React$PureComponent) {
       return componentsToReturn;
     }
   }, {
+    key: "segmentOutCommonProperties",
+    value: function segmentOutCommonProperties(facetComponents, separateSingleTermFacets) {
+      var staticFacetElements = [];
+      var selectableFacetElements = [];
+
+      if (separateSingleTermFacets) {
+        facetComponents.forEach(function (renderedFacet) {
+          if (renderedFacet.props.isStatic) {
+            staticFacetElements.push(renderedFacet);
+          } else {
+            selectableFacetElements.push(renderedFacet);
+          }
+        });
+      } else {
+        selectableFacetElements = facetComponents;
+      }
+
+      return {
+        selectableFacetElements: selectableFacetElements,
+        staticFacetElements: staticFacetElements
+      };
+    }
+  }]);
+
+  function FacetList(props) {
+    var _this;
+
+    _classCallCheck(this, FacetList);
+
+    _this = _possibleConstructorReturn(this, _getPrototypeOf(FacetList).call(this, props));
+    _this.onFilterExtended = _this.onFilterExtended.bind(_assertThisInitialized(_this));
+    _this.getTermStatus = _this.getTermStatus.bind(_assertThisInitialized(_this));
+    _this.renderFacets = _this.renderFacets.bind(_assertThisInitialized(_this));
+    _this.memoized = {
+      segmentOutCommonProperties: (0, _memoizeOne["default"])(FacetList.segmentOutCommonProperties),
+      createFacetComponents: (0, _memoizeOne["default"])(FacetList.createFacetComponents, function (paramSetA, paramSetB) {
+        var _paramSetA = _toArray(paramSetA),
+            propsA = _paramSetA[0],
+            argsA = _paramSetA.slice(1);
+
+        var _paramSetB = _toArray(paramSetB),
+            propsB = _paramSetB[0],
+            argsB = _paramSetB.slice(1);
+
+        var i;
+
+        for (i = 0; i < argsA.length; i++) {
+          if (argsA[i] !== argsB[i]) {
+            //console.log("CHANGED1", argsA[i], argsB[i])
+            return false;
+          }
+        }
+
+        var keys = Object.keys(propsA);
+        var keysLen = keys.length;
+
+        for (i = 0; i < keysLen; i++) {
+          if (propsA[keys[i]] !== propsB[keys[i]]) {
+            //console.log("CHANGED2", keys[i], propsA[keys[i]], propsB[keys[i]])
+            return false;
+          }
+        }
+
+        return true;
+      })
+    };
+    return _this;
+  }
+  /**
+   * Calls props.onFilter after sending analytics.
+   * N.B. When rangeFacet calls onFilter, it creates a `term` with `key` property
+   * as no 'terms' exist when aggregation_type === stats.
+   */
+
+
+  _createClass(FacetList, [{
+    key: "onFilterExtended",
+    value: function onFilterExtended(facet, term) {
+      var _this$props = this.props,
+          onFilter = _this$props.onFilter,
+          contextFilters = _this$props.filters;
+      var field = facet.field;
+      var termKey = term.key;
+      var statusAndHref = (0, _searchFilters.getStatusAndUnselectHrefIfSelectedOrOmittedFromResponseFilters)(term, facet, contextFilters);
+      var isUnselecting = !!statusAndHref.href;
+      analytics.event('FacetList', isUnselecting ? 'Unset Filter' : 'Set Filter', {
+        field: field,
+        'term': termKey,
+        'eventLabel': analytics.eventLabelFromChartNode({
+          field: field,
+          'term': termKey
+        }),
+        'currentFilters': analytics.getStringifiedCurrentFilters((0, _searchFilters.contextFiltersToExpSetFilters)(contextFilters || null)) // 'Existing' filters, or filters at time of action, go here.
+
+      });
+      return onFilter.apply(void 0, arguments);
+    }
+  }, {
+    key: "getTermStatus",
+    value: function getTermStatus(term, facet) {
+      var contextFilters = this.props.filters;
+      return (0, _searchFilters.getTermFacetStatus)(term, facet, contextFilters);
+    }
+    /** Internally calls memoized function to return list of rendered facet JSX components. */
+
+  }, {
+    key: "renderFacets",
+    value: function renderFacets() {
+      var propsUsed = _objectSpread({}, _underscore["default"].pick(this.props, "facets", "href", "schemas", "filters", "itemTypeForSchemas", "windowWidth", "windowHeight", "termTransformFxn", "persistentCount", "separateSingleTermFacets"), {
+        onFilter: this.onFilterExtended,
+        getTermStatus: this.getTermStatus
+      });
+
+      return this.memoized.createFacetComponents(propsUsed);
+    }
+  }, {
     key: "render",
     value: function render() {
-      var _this$props3 = this.props,
-          _this$props3$facets = _this$props3.facets,
-          facets = _this$props3$facets === void 0 ? null : _this$props3$facets,
-          className = _this$props3.className,
-          _this$props3$title = _this$props3.title,
-          title = _this$props3$title === void 0 ? "Properties" : _this$props3$title,
-          onClearFilters = _this$props3.onClearFilters,
-          _this$props3$showClea = _this$props3.showClearFiltersButton,
-          showClearFiltersButton = _this$props3$showClea === void 0 ? false : _this$props3$showClea,
-          _this$props3$separate = _this$props3.separateSingleTermFacets,
-          separateSingleTermFacets = _this$props3$separate === void 0 ? false : _this$props3$separate,
-          _this$props3$maxBodyH = _this$props3.maxBodyHeight,
-          maxHeight = _this$props3$maxBodyH === void 0 ? null : _this$props3$maxBodyH;
+      var _this$props2 = this.props,
+          _this$props2$facets = _this$props2.facets,
+          facets = _this$props2$facets === void 0 ? null : _this$props2$facets,
+          className = _this$props2.className,
+          _this$props2$title = _this$props2.title,
+          title = _this$props2$title === void 0 ? "Properties" : _this$props2$title,
+          onClearFilters = _this$props2.onClearFilters,
+          _this$props2$showClea = _this$props2.showClearFiltersButton,
+          showClearFiltersButton = _this$props2$showClea === void 0 ? false : _this$props2$showClea,
+          _this$props2$separate = _this$props2.separateSingleTermFacets,
+          separateSingleTermFacets = _this$props2$separate === void 0 ? false : _this$props2$separate,
+          _this$props2$maxBodyH = _this$props2.maxBodyHeight,
+          maxHeight = _this$props2$maxBodyH === void 0 ? null : _this$props2$maxBodyH;
 
       if (!facets || !Array.isArray(facets) || facets.length === 0) {
         return _react["default"].createElement("div", {
@@ -460,20 +541,10 @@ function (_React$PureComponent) {
           maxHeight: maxHeight
         } : null
       };
-      var staticFacetElements = [];
-      var selectableFacetElements = [];
 
-      if (separateSingleTermFacets) {
-        allFacetElements.forEach(function (renderedFacet) {
-          if (renderedFacet.props.isStatic) {
-            staticFacetElements.push(renderedFacet);
-          } else {
-            selectableFacetElements.push(renderedFacet);
-          }
-        });
-      } else {
-        selectableFacetElements = allFacetElements;
-      }
+      var _this$memoized$segmen = this.memoized.segmentOutCommonProperties(allFacetElements, separateSingleTermFacets),
+          staticFacetElements = _this$memoized$segmen.staticFacetElements,
+          selectableFacetElements = _this$memoized$segmen.selectableFacetElements;
 
       return _react["default"].createElement("div", {
         className: "facets-container facets" + (className ? ' ' + className : '')

--- a/es/components/browse/components/table-commons.js
+++ b/es/components/browse/components/table-commons.js
@@ -249,7 +249,7 @@ var basicColumnExtensionMap = {
 exports.basicColumnExtensionMap = basicColumnExtensionMap;
 
 function sanitizeOutputValue(value) {
-  if (typeof value !== 'string' && !_react["default"].isValidElement(value)) {
+  if (typeof value !== 'string' && typeof value !== 'number' && !_react["default"].isValidElement(value)) {
     if (value && _typeof(value) === 'object') {
       if (typeof value.display_title !== 'undefined') {
         var atId = _object.itemUtil.atId(value);
@@ -262,7 +262,9 @@ function sanitizeOutputValue(value) {
           return value.display_title;
         }
       }
-    } else if (!value) value = null;
+    } else if (!value) {
+      value = null;
+    }
   }
 
   if (value === "None") value = null;
@@ -611,7 +613,7 @@ function (_React$Component) {
       }
 
       var value = (0, _object.getNestedProperty)(result, columnDefinition.field, true);
-      if (!value) value = null;
+      if (typeof value === "undefined") value = null;
 
       if (Array.isArray(value)) {
         // getNestedProperty may return a multidimensional array, # of dimennsions depending on how many child arrays were encountered in original result obj.

--- a/es/components/ui/PartialList.js
+++ b/es/components/ui/PartialList.js
@@ -31,15 +31,10 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function (o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
-function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-
 /**
  * Bootstrap 'Row' component which may be used in PartialList's props.collapsible or props.persistent.
  * Renders two row columns: one for props.label and one for props.value or props.children.
  *
- * @memberof module:item-pages/components.PartialList
- * @namespace
- * @type {Component}
  * @prop {Component|Element|string} label - Label to use in left column.
  * @prop {Component|Element|string} value - Value to use in right column.
  * @prop {string} className - Classname to add to '.row.list-item'.
@@ -101,19 +96,31 @@ Row.defaultProps = {
 
 var PartialList =
 /*#__PURE__*/
-function (_React$Component) {
-  _inherits(PartialList, _React$Component);
+function (_React$PureComponent) {
+  _inherits(PartialList, _React$PureComponent);
 
   _createClass(PartialList, null, [{
     key: "getDerivedStateFromProps",
-    value: function getDerivedStateFromProps(props) {
-      if (typeof props.open === 'boolean') {
+    value: function getDerivedStateFromProps(props, state) {
+      var lastOpen = props.open;
+
+      if (lastOpen) {
         return {
-          "open": props.open
+          closing: false,
+          lastOpen: lastOpen
         };
       }
 
-      return null;
+      if (!lastOpen && state.lastOpen) {
+        return {
+          closing: true,
+          lastOpen: lastOpen
+        };
+      }
+
+      return {
+        lastOpen: lastOpen
+      };
     }
   }]);
 
@@ -124,48 +131,70 @@ function (_React$Component) {
 
     _this = _possibleConstructorReturn(this, _getPrototypeOf(PartialList).call(this, props));
     _this.state = {
-      'open': false
+      closing: false,
+      lastOpen: props.open
     };
+    _this.timeout = null;
     return _this;
   }
-  /** TODO implement handleToggle fxn and pass to child */
-
 
   _createClass(PartialList, [{
+    key: "componentDidUpdate",
+    value: function componentDidUpdate(pastProps) {
+      var _this2 = this;
+
+      var _this$props = this.props,
+          open = _this$props.open,
+          _this$props$timeout = _this$props.timeout,
+          timeout = _this$props$timeout === void 0 ? 400 : _this$props$timeout;
+      var pastOpen = pastProps.open;
+
+      if (!open && pastOpen) {
+        clearTimeout(this.timeout);
+        this.timeout = setTimeout(function () {
+          _this2.setState({
+            closing: false
+          });
+        }, timeout);
+      }
+    }
+  }, {
     key: "render",
     value: function render() {
-      var _this$props = this.props,
-          className = _this$props.className,
-          containerClassName = _this$props.containerClassName,
-          containerType = _this$props.containerType,
-          collapsible = _this$props.collapsible,
-          persistent = _this$props.persistent,
-          children = _this$props.children;
-      var open = this.state.open;
+      var _this$props2 = this.props,
+          _this$props2$classNam = _this$props2.className,
+          className = _this$props2$classNam === void 0 ? null : _this$props2$classNam,
+          _this$props2$containe = _this$props2.containerClassName,
+          containerClassName = _this$props2$containe === void 0 ? "" : _this$props2$containe,
+          _this$props2$containe2 = _this$props2.containerPersistentClassName,
+          containerPersistentClassName = _this$props2$containe2 === void 0 ? "" : _this$props2$containe2,
+          _this$props2$containe3 = _this$props2.containerCollapseClassName,
+          containerCollapseClassName = _this$props2$containe3 === void 0 ? "" : _this$props2$containe3,
+          _this$props2$containe4 = _this$props2.containerType,
+          containerType = _this$props2$containe4 === void 0 ? "div" : _this$props2$containe4,
+          collapsible = _this$props2.collapsible,
+          _this$props2$persiste = _this$props2.persistent,
+          persistent = _this$props2$persiste === void 0 ? [] : _this$props2$persiste,
+          children = _this$props2.children,
+          _this$props2$open = _this$props2.open,
+          open = _this$props2$open === void 0 ? false : _this$props2$open;
+      var _this$state$closing = this.state.closing,
+          closing = _this$state$closing === void 0 ? false : _this$state$closing;
       return _react["default"].createElement("div", {
-        className: "expandable-list " + (className || '')
-      }, _react["default"].createElement(containerType, {
-        'className': containerClassName
-      }, persistent || children), collapsible.length > 0 ? _react["default"].createElement(_Collapse.Collapse, {
+        className: "expandable-list " + (open ? "open" : "closed") + (className ? " " + className : "")
+      }, persistent || children ? _react["default"].createElement(containerType, {
+        'className': "persistent " + (containerPersistentClassName || containerClassName)
+      }, persistent || children) : null, collapsible ? _react["default"].createElement(_Collapse.Collapse, {
         "in": open
-      }, _react["default"].createElement("div", null, _react["default"].createElement(containerType, {
-        'className': containerClassName
-      }, collapsible))) : null);
+      }, _react["default"].createElement(containerType, {
+        'className': containerCollapseClassName || containerClassName,
+        'key': "c"
+      }, open || closing ? collapsible : null)) : null);
     }
   }]);
 
   return PartialList;
-}(_react["default"].Component);
+}(_react["default"].PureComponent);
 
 exports.PartialList = PartialList;
-
-_defineProperty(PartialList, "Row", Row);
-
-PartialList.defaultProps = {
-  'className': null,
-  'containerClassName': null,
-  'containerType': 'div',
-  'persistent': [],
-  'collapsible': [],
-  'open': null
-};
+PartialList.Row = Row;

--- a/scss/facet-list.scss
+++ b/scss/facet-list.scss
@@ -29,6 +29,7 @@ $facetlist-term-block-height: default !default;
         border-top-left-radius: inherit;
         border-top-right-radius: inherit;
         color: #111;
+
         .facets-title-column {
             top : -1px;
             display: flex;
@@ -214,6 +215,7 @@ $facetlist-term-block-height: default !default;
         h5.facet-title {
             margin: 0 0 3px;
             font-weight: 500;
+            text-shadow: 0 0 0;
             line-height: inherit;
             height: 40px;
             @include font-size($facetlist-facet-font-size);
@@ -236,8 +238,12 @@ $facetlist-term-block-height: default !default;
             transition: padding-bottom .35s ease, background-color .35s ease;
             background-color: transparent;
             h5.facet-title {
-                margin : -1px 0 0;
+                
+                margin : 0;
+                border-top: 1px solid transparent;
+                //border-bottom: 1px solid transparent;
                 border-bottom: 1px solid #f8f8f8;
+                
                 cursor: pointer;
                 display: flex;
                 align-items: center;
@@ -274,6 +280,7 @@ $facetlist-term-block-height: default !default;
                             transition: fill .2s ease-out;
                         }
                     }
+
                     &.some-selected {
                         color: $facetlist-selected-term-color;
                         //transform: scale3d(1.025, 1.025, 1.025);// translateX(2px);
@@ -302,7 +309,7 @@ $facetlist-term-block-height: default !default;
                     .closed-terms-count {
 
                         &.show {
-                            transform: scale3d(1.25, 1.25, 1);// translateX(-5px);
+                            transform: scale3d(1.075, 1.075, 1);// translateX(-5px);
                             &.some-selected {
                                 svg.svg-count-indicator circle {
                                     &:not(.active) {
@@ -317,10 +324,10 @@ $facetlist-term-block-height: default !default;
                             transform: translateX(-3px);
                         }
 
-                        &:hover svg.svg-count-indicator,
-                        &:hover i.icon {
-                            transform: translateX(-6px);
-                        }
+                        // &:hover svg.svg-count-indicator,
+                        // &:hover i.icon {
+                        //     transform: translateX(-6px);
+                        // }
 
                     }
 
@@ -440,20 +447,21 @@ $facetlist-term-block-height: default !default;
         .facet-list {
             margin: 0;
             list-style: none;
+            padding-top: 0px;
+            padding-bottom: 0px;
+            transition: padding-bottom .35s ease-out, padding-top .35s ease-out;
+
+            &[data-open="true"],
+            &[data-any-active="true"]{
+                padding-top: 8px;
+                padding-bottom: 8px;
+            }
 
             li {
                 margin-bottom: 1px;
                 position: relative;
                 @include font-size($facetlist-term-font-size);
                 line-height: 1rem;
-
-                &:first-child {
-                    padding-top: 8px;
-                }
-
-                &:last-child {
-                    padding-bottom: 8px;
-                }
 
                 > a {
                     border-radius: 3px;
@@ -510,6 +518,15 @@ $facetlist-term-block-height: default !default;
 
                 }
 
+                &.selected:last-child:after ,
+                &.omitted:last-child:after {
+                    content: " ";
+                    border-bottom: 1px solid #ccc;
+                    margin-top: 5px;
+                    margin-bottom: 5px;
+                    display: block;
+                }
+
                 &.selected > a {
                     text-decoration: none;
                     color: #f8f8f8;
@@ -535,15 +552,8 @@ $facetlist-term-block-height: default !default;
                 }
             }
 
-            > .expandable-list {
-                li:last-child {
-                    padding-bottom: 0;
-                }
-                > .collapse, > .collapsing {
-                    li:first-child {
-                        padding-top: 0;
-                    }
-                }
+            .expandable-list {
+                margin-bottom: 0;
             }
 
             .view-more-button {
@@ -552,8 +562,6 @@ $facetlist-term-block-height: default !default;
                 border: 1px solid #888;
                 padding: 2px 6px 1px;
                 line-height: 20px;
-                margin-top: 0;
-                margin-bottom: 12px;
                 border-radius: 2px;
                 &:hover {
                     border-color: #000;
@@ -567,6 +575,19 @@ $facetlist-term-block-height: default !default;
             }
 
             
+        }
+
+        &.closed .facet-list {
+            li {
+                &.selected:last-child:after ,
+                &.omitted:last-child:after {
+                    //display: none;
+                    border-width: 0px;
+                    border-color: transparent;
+                    margin: 0px;
+                    transition: margin .35s .1s ease-out, border-width 0s .45s ease-out, border-color .35s ease-out;
+                }
+            }
         }
 
         /* .facet */

--- a/scss/facet-list.scss
+++ b/scss/facet-list.scss
@@ -42,6 +42,17 @@ $facetlist-term-block-height: default !default;
                 display: inline;
             }
         }
+
+        .btn-group.properties-controls {
+            > button {
+                padding-top: 0.2rem;
+                padding-bottom: 0.1rem;
+                padding-left: 0.35rem;
+                padding-right: 0.35rem;
+            }
+        }
+
+        /*
         .clear-filters-control {
             text-align: right;
             font-size: 0.9rem;
@@ -71,6 +82,7 @@ $facetlist-term-block-height: default !default;
                 z-index: -10;
             }
         }
+        */
         
     }
 
@@ -89,6 +101,7 @@ $facetlist-term-block-height: default !default;
             margin-left: -1px;
             margin-right: -1px;
             margin-top: -1px;
+            align-items: center;
         }
     }
 
@@ -553,6 +566,14 @@ $facetlist-term-block-height: default !default;
                             text-shadow: 0px 0px 0px #fff;
                         }
                     }
+                }
+            }
+
+            &[data-all-active="true"] {
+                li.selected:last-child:after,
+                li.omitted:last-child:after {
+                    content: none;
+                    display: none;
                 }
             }
 

--- a/scss/facet-list.scss
+++ b/scss/facet-list.scss
@@ -215,7 +215,6 @@ $facetlist-term-block-height: default !default;
         h5.facet-title {
             margin: 0 0 3px;
             font-weight: 500;
-            text-shadow: 0 0 0;
             line-height: inherit;
             height: 40px;
             @include font-size($facetlist-facet-font-size);
@@ -229,8 +228,13 @@ $facetlist-term-block-height: default !default;
                 }
             }
 
+            > i.icon-plus {
+                text-shadow: 0 0 0;
+            }
+
             > span {
                 line-height: 1;
+                text-shadow: 0 0 0;
             }
         }
 

--- a/src/components/browse/components/FacetList/FacetOfFacets.js
+++ b/src/components/browse/components/FacetList/FacetOfFacets.js
@@ -27,100 +27,53 @@ export class FacetOfFacets extends React.PureComponent {
     constructor(props){
         super(props);
         this.handleOpenToggleClick = this.handleOpenToggleClick.bind(this);
-        this.handleExpandListToggleClick = this.handleExpandListToggleClick.bind(this);
-
         this.memoized = {
             anyFacetsHaveSelection: memoize(FacetOfFacets.anyFacetsHaveSelection)
         };
-
-        // Most of this logic (facetOpen/facetClosing at least) is same between this and FacetTermsList.
-        // Maybe we could pull it out into reusable controller component. Maybe. Very low priority.
-        this.state = {
-            'facetOpen'     : typeof props.defaultGroupOpen === 'boolean' ? props.defaultGroupOpen : true,
-            'facetClosing'  : false,
-            'expanded'      : false
-        };
     }
 
-    componentDidUpdate(pastProps, pastState){
-        const { facets: renderedFacets, mounted, defaultGroupOpen, isStatic } = this.props;
-        const { mounted: pastMounted, defaultGroupOpen: pastDefaultOpen, isStatic: pastStatic } = pastProps;
-
-        this.setState(({ facetOpen: currFacetOpen }) => {
-            if (!pastMounted && mounted && typeof defaultGroupOpen === 'boolean' && defaultGroupOpen !== pastDefaultOpen) {
-                return { 'facetOpen' : true };
-            }
-            if (defaultGroupOpen === true && !pastDefaultOpen && !currFacetOpen){
-                return { 'facetOpen' : true };
-            }
-            if (currFacetOpen && isStatic && !pastStatic && !this.memoized.anyFacetsHaveSelection(renderedFacets)){
-                return { 'facetOpen' : false };
-            }
-            return null;
-        }, ()=>{
-            const { facetOpen } = this.state;
-            if (pastState.facetOpen !== facetOpen){
-                ReactTooltip.rebuild();
-            }
-        });
+    componentDidUpdate(pastProps){
+        const { facetOpen } = this.props;
+        const { facetOpen: prevOpen } = pastProps;
+        if (prevOpen !== facetOpen) {
+            ReactTooltip.rebuild();
+        }
     }
 
     handleOpenToggleClick(e) {
         e.preventDefault();
-        this.setState(function({ facetOpen }){
-            const willBeOpen = !facetOpen;
-            if (willBeOpen) {
-                return { 'facetOpen': true };
-            } else {
-                return { 'facetClosing': true };
-            }
-        }, ()=>{
-            setTimeout(()=>{
-                this.setState(function({ facetOpen, facetClosing }){
-                    if (facetClosing){
-                        return { 'facetOpen' : false, 'facetClosing' : false };
-                    }
-                    return null;
-                });
-            }, 350);
-        });
+        const { onToggleOpen, title: groupTitle, facetOpen = false } = this.props;
+        onToggleOpen("group:" + groupTitle, !facetOpen);
     }
-
-    handleExpandListToggleClick(e){
-        e.preventDefault();
-        this.setState(function({ expanded }){
-            return { 'expanded' : !expanded };
-        });
-    }
-
 
     render() {
-        const { title, facets: renderedFacets, tooltip } = this.props;
-        const { facetOpen, facetClosing } = this.state;
+        const { title, facets: renderedFacets, tooltip, facetOpen, openFacets = {} } = this.props;
         const anySelections = this.memoized.anyFacetsHaveSelection(renderedFacets);
 
         // Ensure all facets within group are not "static single terms".
+        // Pass in facetOpen prop.
         const extendedFacets = React.Children.map(renderedFacets, function(renderedFacet){
-            return React.cloneElement(renderedFacet, { isStatic: false });
+            const { facet : { field } } = renderedFacet.props;
+            return React.cloneElement(renderedFacet, { isStatic: false, facetOpen: openFacets[field] });
         });
 
         return (
-            <div className={"facet" + (facetOpen ? ' open' : ' closed') + (facetClosing ? ' closing' : '')} data-group={title}>
+            <div className={"facet" + (facetOpen || anySelections ? ' open' : ' closed')} data-group={title}>
                 <h5 className="facet-title" onClick={this.handleOpenToggleClick}>
                     <span className="expand-toggle col-auto px-0">
-                        <i className={"icon icon-fw fas " + (facetOpen && !facetClosing ? "icon-minus" : "icon-plus")}/>
+                        <i className={"icon icon-fw icon-" + (anySelections ? "dot-circle far" : (facetOpen ? "minus fas" : "plus fas"))}/>
                     </span>
                     <div className="col px-0 line-height-1">
                         <span data-tip={tooltip} data-place="right">{ title }</span>
                     </div>
-                    <Fade in={facetClosing || !facetOpen}>
+                    <Fade in={!facetOpen && !anySelections}>
                         <span className={"closed-terms-count col-auto px-0" + (anySelections ? " some-selected" : "")} data-place="right"
                             data-tip={`Group of ${extendedFacets.length} facets ${ anySelections ? " with at least 1 having a selection." : ""}`}>
                             <i className="icon fas icon-layer-group" />
                         </span>
                     </Fade>
                 </h5>
-                <Collapse in={facetOpen && !facetClosing}>
+                <Collapse in={facetOpen || anySelections}>
                     <div className="facet-group-list-container">
                         { extendedFacets }
                     </div>

--- a/src/components/browse/components/FacetList/FacetOfFacets.js
+++ b/src/components/browse/components/FacetList/FacetOfFacets.js
@@ -3,7 +3,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import memoize from 'memoize-one';
-import ReactTooltip from 'react-tooltip';
 import { Collapse } from './../../../ui/Collapse';
 import { Fade } from './../../../ui/Fade';
 
@@ -18,6 +17,8 @@ export class FacetOfFacets extends React.PureComponent {
             const renderedFacet = renderedFacets[facetIdx]; // We have rendered facets as `props.facets`
             const { anyTermsSelected: anySelected } = renderedFacet.props;
             if (anySelected) {
+
+                console.log(renderedFacet);
                 return true;
             }
         }
@@ -32,14 +33,6 @@ export class FacetOfFacets extends React.PureComponent {
         };
     }
 
-    componentDidUpdate(pastProps){
-        const { facetOpen } = this.props;
-        const { facetOpen: prevOpen } = pastProps;
-        if (prevOpen !== facetOpen) {
-            ReactTooltip.rebuild();
-        }
-    }
-
     handleOpenToggleClick(e) {
         e.preventDefault();
         const { onToggleOpen, title: groupTitle, facetOpen = false } = this.props;
@@ -47,7 +40,7 @@ export class FacetOfFacets extends React.PureComponent {
     }
 
     render() {
-        const { title, facets: renderedFacets, tooltip, facetOpen, openFacets = {} } = this.props;
+        const { title, children: renderedFacets, tooltip, facetOpen, openFacets = {} } = this.props;
         const anySelections = this.memoized.anyFacetsHaveSelection(renderedFacets);
 
         // Ensure all facets within group are not "static single terms".

--- a/src/components/browse/components/FacetList/FacetTermsList.js
+++ b/src/components/browse/components/FacetList/FacetTermsList.js
@@ -202,40 +202,21 @@ export class FacetTermsList extends React.PureComponent {
         super(props);
         this.handleOpenToggleClick = this.handleOpenToggleClick.bind(this);
         this.handleExpandListToggleClick = this.handleExpandListToggleClick.bind(this);
-        this.state = {
-            'facetOpen'     : typeof props.defaultFacetOpen === 'boolean' ? props.defaultFacetOpen : true,
-            'expanded'      : false
-        };
+        this.state = { 'expanded' : false };
     }
 
-    componentDidUpdate(pastProps, pastState){
-        const { anyTermsSelected: anySelected, mounted, defaultFacetOpen, isStatic, windowWidth } = this.props;
-        const { mounted: pastMounted, defaultFacetOpen: pastDefaultOpen, isStatic: pastStatic, windowWidth: pastWidth } = pastProps;
-
-        this.setState(({ facetOpen: currFacetOpen }) => {
-            if (pastWidth === null && typeof windowWidth === "number" && typeof defaultFacetOpen === 'boolean' && defaultFacetOpen !== pastDefaultOpen) {
-                return { 'facetOpen' : true };
-            }
-            if (defaultFacetOpen === true && !pastDefaultOpen && !currFacetOpen){
-                return { 'facetOpen' : true };
-            }
-            if (currFacetOpen && isStatic && !pastStatic && !anySelected){
-                return { 'facetOpen' : false };
-            }
-            return null;
-        }, ()=>{
-            const { facetOpen } = this.state;
-            if (pastState.facetOpen !== facetOpen){
-                ReactTooltip.rebuild();
-            }
-        });
+    componentDidUpdate(pastProps){
+        const { facetOpen } = this.props;
+        const { facetOpen: prevOpen } = pastProps;
+        if (prevOpen !== facetOpen) {
+            ReactTooltip.rebuild();
+        }
     }
 
     handleOpenToggleClick(e) {
         e.preventDefault();
-        this.setState(function({ facetOpen }){
-            return { 'facetOpen' : !facetOpen };
-        });
+        const { onToggleOpen, facet: { field }, facetOpen = false } = this.props;
+        onToggleOpen(field, !facetOpen);
     }
 
     handleExpandListToggleClick(e){
@@ -257,9 +238,10 @@ export class FacetTermsList extends React.PureComponent {
             persistentCount,
             onTermClick,
             getTermStatus,
-            termTransformFxn
+            termTransformFxn,
+            facetOpen
         } = this.props;
-        const { facetOpen, expanded } = this.state;
+        const { expanded } = this.state;
         const termsLen = terms.length;
         const allTermsSelected = termsSelectedCount === termsLen;
         let indicator;

--- a/src/components/browse/components/FacetList/FacetTermsList.js
+++ b/src/components/browse/components/FacetList/FacetTermsList.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import _ from 'underscore';
 import memoize from 'memoize-one';
@@ -85,6 +85,18 @@ export function mergeTerms(facet, filters){
     return terms.concat(unseenTerms);
 }
 
+function segmentTermComponentsByStatus(termComponents){
+    const groups = {};
+    termComponents.forEach(function(t){
+        const { props: { status } } = t;
+        if (!Array.isArray(groups[status])) {
+            groups[status] = [];
+        }
+        groups[status].push(t);
+    });
+    return groups;
+}
+
 
 
 /**
@@ -139,9 +151,8 @@ export class Term extends React.PureComponent {
     */
 
     render() {
-        const { term, facet, getTermStatus, termTransformFxn } = this.props;
+        const { term, facet, status, termTransformFxn } = this.props;
         const { filtering } = this.state;
-        const status = getTermStatus(term, facet);
         const selected = (status !== 'none');
         const count = (term && term.doc_count) || 0;
         let title = termTransformFxn(facet.field, term.key) || term.key;
@@ -149,9 +160,7 @@ export class Term extends React.PureComponent {
 
         if (filtering) {
             icon = <i className="icon fas icon-circle-notch icon-spin icon-fw" />;
-        } else if (status === 'selected') {
-            icon = <i className="icon icon-times-circle icon-fw fas" />;
-        } else if (status === 'omitted') {
+        } else if (status === 'selected' || status === 'omitted') {
             icon = <i className="icon icon-minus-circle icon-fw fas" />;
         } else {
             icon = <i className="icon icon-circle icon-fw unselected far" />;
@@ -188,24 +197,23 @@ Term.propTypes = {
 
 
 export class FacetTermsList extends React.PureComponent {
+
     constructor(props){
         super(props);
         this.handleOpenToggleClick = this.handleOpenToggleClick.bind(this);
         this.handleExpandListToggleClick = this.handleExpandListToggleClick.bind(this);
-        this.renderTerms = this.renderTerms.bind(this);
         this.state = {
             'facetOpen'     : typeof props.defaultFacetOpen === 'boolean' ? props.defaultFacetOpen : true,
-            'facetClosing'  : false,
             'expanded'      : false
         };
     }
 
     componentDidUpdate(pastProps, pastState){
-        const { anyTermsSelected: anySelected, mounted, defaultFacetOpen, isStatic } = this.props;
-        const { mounted: pastMounted, defaultFacetOpen: pastDefaultOpen, isStatic: pastStatic } = pastProps;
+        const { anyTermsSelected: anySelected, mounted, defaultFacetOpen, isStatic, windowWidth } = this.props;
+        const { mounted: pastMounted, defaultFacetOpen: pastDefaultOpen, isStatic: pastStatic, windowWidth: pastWidth } = pastProps;
 
         this.setState(({ facetOpen: currFacetOpen }) => {
-            if (!pastMounted && mounted && typeof defaultFacetOpen === 'boolean' && defaultFacetOpen !== pastDefaultOpen) {
+            if (pastWidth === null && typeof windowWidth === "number" && typeof defaultFacetOpen === 'boolean' && defaultFacetOpen !== pastDefaultOpen) {
                 return { 'facetOpen' : true };
             }
             if (defaultFacetOpen === true && !pastDefaultOpen && !currFacetOpen){
@@ -226,21 +234,7 @@ export class FacetTermsList extends React.PureComponent {
     handleOpenToggleClick(e) {
         e.preventDefault();
         this.setState(function({ facetOpen }){
-            const willBeOpen = !facetOpen;
-            if (willBeOpen) {
-                return { 'facetOpen': true };
-            } else {
-                return { 'facetClosing': true };
-            }
-        }, ()=>{
-            setTimeout(()=>{
-                this.setState(function({ facetOpen, facetClosing }){
-                    if (facetClosing){
-                        return { 'facetOpen' : false, 'facetClosing' : false };
-                    }
-                    return null;
-                });
-            }, 350);
+            return { 'facetOpen' : !facetOpen };
         });
     }
 
@@ -251,60 +245,29 @@ export class FacetTermsList extends React.PureComponent {
         });
     }
 
-
-    renderTerms(terms){
-        const { facet, persistentCount, onTermClick } = this.props;
-        const { expanded } = this.state;
-        const makeTermComponent = (term) => (
-            <Term {...this.props} onClick={onTermClick} key={term.key} term={term} total={facet.total} />
-        );
-
-        if (terms.length > persistentCount){
-            const persistentTerms     = terms.slice(0, persistentCount);
-            const collapsibleTerms    = terms.slice(persistentCount);
-            const remainingTermsCount = !expanded ? _.reduce(collapsibleTerms, function(m, term){
-                return m + (term.doc_count || 0);
-            }, 0) : null;
-            let expandButtonTitle;
-
-            if (expanded){
-                expandButtonTitle = (
-                    <span>
-                        <i className="icon icon-fw icon-minus fas"/> Collapse
-                    </span>
-                );
-            } else {
-                expandButtonTitle = (
-                    <span>
-                        <i className="icon icon-fw icon-plus fas"/> View {terms.length - persistentCount} More
-                        <span className="pull-right">{ remainingTermsCount }</span>
-                    </span>
-                );
-            }
-
-            return (
-                <div className="facet-list">
-                    <PartialList open={expanded} persistent={ _.map(persistentTerms,  makeTermComponent)} collapsible={_.map(collapsibleTerms, makeTermComponent)} />
-                    <div className="view-more-button" onClick={this.handleExpandListToggleClick}>{ expandButtonTitle }</div>
-                </div>
-            );
-        } else {
-            return (
-                <div className="facet-list">{ _.map(terms, makeTermComponent) }</div>
-            );
-        }
-    }
-
     render(){
-        const { facet, terms, tooltip, title, isStatic, anyTermsSelected: anySelected, termsSelectedCount } = this.props;
-        const { facetOpen, facetClosing } = this.state;
+        const {
+            facet,
+            terms,
+            tooltip,
+            title,
+            isStatic,
+            anyTermsSelected: anySelected,
+            termsSelectedCount,
+            persistentCount,
+            onTermClick,
+            getTermStatus,
+            termTransformFxn
+        } = this.props;
+        const { facetOpen, expanded } = this.state;
         const termsLen = terms.length;
+        const allTermsSelected = termsSelectedCount === termsLen;
         let indicator;
 
         // @todo: much of this code (including mergeTerms and anyTermsSelected above) were moved to index; consider moving these too
         if (isStatic || termsLen === 1){
             indicator = ( // Small indicator to help represent how many terms there are available for this Facet.
-                <Fade in={facetClosing || !facetOpen}>
+                <Fade in={!facetOpen}>
                     <span className={"closed-terms-count col-auto px-0" + (anySelected ? " some-selected" : "")}
                         data-tip={"No useful options (1 total)" + (anySelected ? "; is selected" : "")}
                         data-place="right" data-any-selected={anySelected}>
@@ -314,7 +277,7 @@ export class FacetTermsList extends React.PureComponent {
             );
         } else {
             indicator = ( // Small indicator to help represent how many terms there are available for this Facet.
-                <Fade in={facetClosing || !facetOpen}>
+                <Fade in={!facetOpen}>
                     <span className={"closed-terms-count col-auto px-0" + (anySelected ? " some-selected" : "")}
                         data-tip={`${termsLen} options with ${termsSelectedCount} selected`}
                         data-place="right" data-any-selected={anySelected}>
@@ -326,17 +289,17 @@ export class FacetTermsList extends React.PureComponent {
 
         // List of terms
         return (
-            <div className={"facet" + (facetOpen ? ' open' : ' closed') + (facetClosing ? ' closing' : '')} data-field={facet.field}>
+            <div className={"facet" + (facetOpen || allTermsSelected ? ' open' : ' closed')} data-field={facet.field}>
                 <h5 className="facet-title" onClick={this.handleOpenToggleClick}>
                     <span className="expand-toggle col-auto px-0">
-                        <i className={"icon icon-fw fas " + (facetOpen && !facetClosing ? "icon-minus" : "icon-plus")}/>
+                        <i className={"icon icon-fw icon-" + (allTermsSelected ? "dot-circle far" : (facetOpen ? "minus" : "plus") + " fas")}/>
                     </span>
                     <div className="col px-0 line-height-1">
                         <span data-tip={tooltip} data-place="right">{ title }</span>
                     </div>
                     { indicator }
                 </h5>
-                <Collapse in={facetOpen && !facetClosing}>{ this.renderTerms(terms) }</Collapse>
+                <ListOfTerms {...{ facet, facetOpen, terms, persistentCount, onTermClick, expanded, getTermStatus, termTransformFxn }} onToggleExpanded={this.handleExpandListToggleClick} />
             </div>
         );
     }
@@ -345,6 +308,97 @@ FacetTermsList.defaultProps = {
     'persistentCount' : 10
 };
 
+
+const ListOfTerms = React.memo(function ListOfTerms(props){
+    const { facet, facetOpen, facetClosing, terms, persistentCount, onTermClick, expanded, onToggleExpanded, getTermStatus, termTransformFxn } = props;
+
+    /** Create term components and sort by status (selected->omitted->unselected) */
+    const {
+        termComponents, activeTermComponents, unselectedTermComponents,
+        totalLen, selectedLen, omittedLen, unselectedLen,
+        persistentTerms = null,
+        collapsibleTerms = null,
+        collapsibleTermsCount = 0,
+        collapsibleTermsItemCount = 0
+    } = useMemo(function(){
+        const {
+            selected: selectedTermComponents    = [],
+            omitted : omittedTermComponents     = [],
+            none    : unselectedTermComponents  = []
+        } = segmentTermComponentsByStatus(terms.map(function(term){
+            return <Term {...{ facet, term, termTransformFxn }} onClick={onTermClick} key={term.key} status={getTermStatus(term, facet)} />;
+        }));
+        const selectedLen = selectedTermComponents.length;
+        const omittedLen = omittedTermComponents.length;
+        const unselectedLen = unselectedTermComponents.length;
+        const totalLen = selectedLen + omittedLen + unselectedLen;
+        const termComponents = selectedTermComponents.concat(omittedTermComponents).concat(unselectedTermComponents);
+        const activeTermComponents = termComponents.slice(0, selectedLen + omittedLen);
+
+        const retObj = { termComponents, activeTermComponents, unselectedTermComponents, selectedLen, omittedLen, unselectedLen, totalLen };
+
+        if (totalLen <= Math.max(persistentCount, selectedLen + omittedLen)) {
+            return retObj;
+        }
+
+        const unselectedStartIdx = selectedLen + omittedLen;
+        retObj.persistentTerms = []; //termComponents.slice(0, unselectedStartIdx);
+
+        var i;
+        for (i = unselectedStartIdx; i < persistentCount; i++){
+            retObj.persistentTerms.push(termComponents[i]);
+        }
+
+        retObj.collapsibleTerms = termComponents.slice(i);
+        retObj.collapsibleTermsCount = totalLen - i;
+        retObj.collapsibleTermsItemCount = retObj.collapsibleTerms.reduce(function(m, termComponent){
+            return m + (termComponent.props.term.doc_count || 0);
+        }, 0);
+
+        return retObj;
+
+    }, [ terms, persistentCount ]);
+
+
+    if (Array.isArray(collapsibleTerms)){
+
+        let expandButtonTitle;
+
+        if (expanded){
+            expandButtonTitle = (
+                <span>
+                    <i className="icon icon-fw icon-minus fas"/> Collapse
+                </span>
+            );
+        } else {
+            expandButtonTitle = (
+                <span>
+                    <i className="icon icon-fw icon-plus fas"/> View { collapsibleTermsCount } More
+                    <span className="pull-right">{ collapsibleTermsItemCount }</span>
+                </span>
+            );
+        }
+
+        return (
+            <div className="facet-list" key="fl" data-any-active={!!(selectedLen || omittedLen)} data-open={facetOpen}>
+                <PartialList className="mb-0 active-terms-pl" open={facetOpen} persistent={activeTermComponents} collapsible={
+                    <React.Fragment>
+                        <PartialList className="mb-0" open={expanded} persistent={persistentTerms} collapsible={collapsibleTerms} />
+                        <div className="pt-08 pb-0">
+                            <div className="view-more-button" onClick={onToggleExpanded}>{ expandButtonTitle }</div>
+                        </div>
+                    </React.Fragment>
+                } />
+            </div>
+        );
+    } else {
+        return (
+            <div className="facet-list" key="fl" data-any-active={!!(selectedLen || omittedLen)} data-open={facetOpen}>
+                <PartialList className="mb-0 active-terms-pl" open={facetOpen} persistent={activeTermComponents} collapsible={unselectedTermComponents} />
+            </div>
+        );
+    }
+});
 
 
 export const CountIndicator = React.memo(function CountIndicator({ count = 1, countActive = 0, height = 16, width = 40 }){
@@ -355,7 +409,7 @@ export const CountIndicator = React.memo(function CountIndicator({ count = 1, co
         // Flip both axes so going bottom right to top left.
         return (
             <circle cx={width - x + 1} cy={height - y + 1} r={2} key={idx} data-original-index={idx}
-                style={{ opacity: 1 - (colIdx * .125) }} className={(count - idx) <= countActive ? "active" : null} />
+                style={{ opacity: 1 - (colIdx * .125) }} className={(dotCountToShow - idx) <= countActive ? "active" : null} />
         );
     });
     return (

--- a/src/components/browse/components/FacetList/RangeFacet.js
+++ b/src/components/browse/components/FacetList/RangeFacet.js
@@ -145,10 +145,10 @@ export class RangeFacet extends React.PureComponent {
     }
 
     componentDidUpdate(pastProps, pastState){
-        const { mounted, defaultFacetOpen, isStatic } = this.props;
+        const { windowWidth, defaultFacetOpen, isStatic } = this.props;
 
         this.setState(function({ facetOpen: currFacetOpen }){
-            if (!pastProps.mounted && mounted && typeof defaultFacetOpen === 'boolean' && defaultFacetOpen !== pastProps.defaultFacetOpen) {
+            if (pastProps.windowWidth === null && typeof windowWidth === "number" && typeof defaultFacetOpen === 'boolean' && defaultFacetOpen !== pastProps.defaultFacetOpen) {
                 return { 'facetOpen' : true };
             }
             if (defaultFacetOpen === true && !pastProps.defaultFacetOpen && !currFacetOpen){
@@ -171,7 +171,6 @@ export class RangeFacet extends React.PureComponent {
         const { min, max } = facet;
         try {
             let fromVal = RangeFacet.parseAndValidate(facet, value);
-            console.log("AAAAA", fromVal, value, facet);
             this.setState(function({ toVal }){
                 if (fromVal === null || fromVal === min) {
                     return { fromVal: null };
@@ -252,20 +251,22 @@ export class RangeFacet extends React.PureComponent {
     render(){
         const { facet, title: propTitle, termTransformFxn, isStatic, fromVal: savedFromVal, toVal: savedToVal } = this.props;
         const { field, min, max, title: facetTitle = null, description: tooltip = null, number_step } = facet;
-        const { facetOpen, facetClosing, fromVal, toVal } = this.state;
+        const { facetOpen, fromVal, toVal } = this.state;
         const { fromIncrements, toIncrements } = this.memoized.validIncrements(facet);
         const title = propTitle || facetTitle || field;
 
+        const isOpen = facetOpen || savedFromVal !== null || savedToVal !== null;
+
         return (
-            <div className={"facet range-facet" + (facetOpen ? ' open' : ' closed') + (facetClosing ? ' closing' : '')} data-field={facet.field}>
+            <div className={"facet range-facet" + (isOpen ? ' open' : ' closed')} data-field={facet.field}>
                 <h5 className="facet-title" onClick={this.handleOpenToggleClick}>
                     <span className="expand-toggle col-auto px-0">
-                        <i className={"icon icon-fw fas " + (facetOpen && !facetClosing ? "icon-minus" : "icon-plus")}/>
+                        <i className={"icon icon-fw icon-" + (savedFromVal !== null || savedToVal !== null ? "chevron-circle-right fas" : (isOpen ? "minus fas" : "plus fas"))}/>
                     </span>
                     <div className="col px-0 line-height-1">
                         <span data-tip={tooltip} data-place="right">{ title }</span>
                     </div>
-                    <Fade in={facetClosing || !facetOpen}>
+                    <Fade in={!isOpen}>
                         <span className={"closed-terms-count col-auto px-0" + (savedFromVal !== null || savedToVal !== null ? " some-selected" : "")}>
                             { isStatic?
                                 <i className={"icon fas icon-" + (savedFromVal !== null || savedToVal !== null ? "circle" : "minus-circle")}
@@ -274,7 +275,7 @@ export class RangeFacet extends React.PureComponent {
                         </span>
                     </Fade>
                 </h5>
-                <Collapse in={facetOpen && !facetClosing}>
+                <Collapse in={isOpen}>
                     <div className="inner-panel">
                         <div className="row">
                             <label className="col-auto mb-0">

--- a/src/components/browse/components/FacetList/RangeFacet.js
+++ b/src/components/browse/components/FacetList/RangeFacet.js
@@ -137,33 +137,18 @@ export class RangeFacet extends React.PureComponent {
         };
 
         this.state = {
-            facetOpen : props.defaultFacetOpen || false,
             facetClosing: false,
             fromVal: props.fromVal,
             toVal: props.toVal
         };
     }
 
-    componentDidUpdate(pastProps, pastState){
-        const { windowWidth, defaultFacetOpen, isStatic } = this.props;
-
-        this.setState(function({ facetOpen: currFacetOpen }){
-            if (pastProps.windowWidth === null && typeof windowWidth === "number" && typeof defaultFacetOpen === 'boolean' && defaultFacetOpen !== pastProps.defaultFacetOpen) {
-                return { 'facetOpen' : true };
-            }
-            if (defaultFacetOpen === true && !pastProps.defaultFacetOpen && !currFacetOpen){
-                return { 'facetOpen' : true };
-            }
-            if (currFacetOpen && isStatic && !pastProps.isStatic){
-                return { 'facetOpen' : false };
-            }
-            return null;
-        }, ()=>{
-            const { facetOpen } = this.state;
-            if (pastState.facetOpen !== facetOpen){
-                ReactTooltip.rebuild();
-            }
-        });
+    componentDidUpdate(pastProps){
+        const { facetOpen } = this.props;
+        const { facetOpen: prevOpen } = pastProps;
+        if (prevOpen !== facetOpen) {
+            ReactTooltip.rebuild();
+        }
     }
 
     setFrom(value, callback){
@@ -242,16 +227,16 @@ export class RangeFacet extends React.PureComponent {
         this.setTo(null, this.performUpdateTo);
     }
 
-    handleOpenToggleClick(){
-        this.setState(function({ facetOpen }){
-            return { facetOpen: !facetOpen };
-        });
+    handleOpenToggleClick(e) {
+        e.preventDefault();
+        const { onToggleOpen, facet: { field }, facetOpen = false } = this.props;
+        onToggleOpen(field, !facetOpen);
     }
 
     render(){
-        const { facet, title: propTitle, termTransformFxn, isStatic, fromVal: savedFromVal, toVal: savedToVal } = this.props;
-        const { field, min, max, title: facetTitle = null, description: tooltip = null, number_step } = facet;
-        const { facetOpen, fromVal, toVal } = this.state;
+        const { facet, title: propTitle, termTransformFxn, isStatic, fromVal: savedFromVal, toVal: savedToVal, facetOpen } = this.props;
+        const { field, min, max, title: facetTitle = null, description: tooltip = null } = facet;
+        const { fromVal, toVal } = this.state;
         const { fromIncrements, toIncrements } = this.memoized.validIncrements(facet);
         const title = propTitle || facetTitle || field;
 

--- a/src/components/browse/components/FacetList/TermsFacet.js
+++ b/src/components/browse/components/FacetList/TermsFacet.js
@@ -24,15 +24,6 @@ import { StaticSingleTerm } from './StaticSingleTerm';
  */
 export class TermsFacet extends React.PureComponent {
 
-    static isStatic(facet){
-        const { terms = null, total = 0 } = facet;
-        return (
-            Array.isArray(terms) &&
-            terms.length === 1 &&
-            total <= _.reduce(terms, function(m, t){ return m + (t.doc_count || 0); }, 0)
-        );
-    }
-
     constructor(props){
         super(props);
         this.handleStaticClick = this.handleStaticClick.bind(this);
@@ -108,5 +99,5 @@ TermsFacet.propTypes = {
     'getTermStatus'         : PropTypes.func.isRequired,
     'href'                  : PropTypes.string.isRequired,
     'filters'               : PropTypes.arrayOf(PropTypes.object).isRequired,
-    'mounted'               : PropTypes.bool
+    'windowWidth'           : PropTypes.number
 };

--- a/src/components/browse/components/table-commons.js
+++ b/src/components/browse/components/table-commons.js
@@ -147,7 +147,7 @@ export const basicColumnExtensionMap = {
  * @param {any} value - Value to sanitize.
  */
 export function sanitizeOutputValue(value){
-    if (typeof value !== 'string' && !React.isValidElement(value)){
+    if (typeof value !== 'string' && typeof value !== 'number' && !React.isValidElement(value)){
         if (value && typeof value === 'object'){
             if (typeof value.display_title !== 'undefined'){
                 const atId = itemUtil.atId(value);
@@ -157,7 +157,9 @@ export function sanitizeOutputValue(value){
                     return value.display_title;
                 }
             }
-        } else if (!value) value = null;
+        } else if (!value){
+            value = null;
+        }
     }
     if (value === "None") value = null;
     return value;
@@ -435,7 +437,7 @@ export class ResultRowColumnBlockValue extends React.Component {
         }
 
         let value = getNestedProperty(result, columnDefinition.field, true);
-        if (!value) value = null;
+        if (typeof value === "undefined") value = null;
         if (Array.isArray(value)){ // getNestedProperty may return a multidimensional array, # of dimennsions depending on how many child arrays were encountered in original result obj.
             value = filterAndUniq(value.map(function(v){
                 if (Array.isArray(v)){


### PR DESCRIPTION
Selected terms are now always visible, even if facet is collapsed per UX research / design / recommendations from Shannon.

- If all terms are selected, no option to collapse until deselect term(s).
- For simpler transitions, active (selected or omitted) terms are grouped at top of list now.

Also, minor fixes UI/styling edits esp re: new UX changes.
Most notably, for "Common Properties", no terms get moved down there unless no filter set for that field at all anywhere. This gives a more much predictable experience without selected filters (often unexpectedly) jumping down into "common properties".

Selected (and/or Omitted) terms now always show up the same - as highlighted bar(s) - even if facet containing the term is collapsed. Gives a large quick overview of currently-active filters.

### Screenshots

Expanded:
![](https://i.gyazo.com/ae2f2551050091cac60d76b83a57ece1.png)

Collapsed:
![](https://i.gyazo.com/1f3577193ea3be42c76e67ca83593bf9.png)

### Future

May introduce a "collapse all facets" icon/button in header, next to clear all filters. Needs some code refactoring so will wait until get more feedback on these edits.