### PR TITLE
Fixes for cohort submissatajax

### DIFF
--- a/es/components/forms/components/LinkToDropdown.js
+++ b/es/components/forms/components/LinkToDropdown.js
@@ -149,6 +149,11 @@ function (_React$PureComponent) {
   }, {
     key: "render",
     value: function render() {
+      var _this$state = this.state,
+          error = _this$state.error,
+          optionResults = _this$state.optionResults,
+          loading = _this$state.loading,
+          typedSearchQuery = _this$state.typedSearchQuery;
       var _this$props = this.props,
           _this$props$variant = _this$props.variant,
           variant = _this$props$variant === void 0 ? "outline-dark" : _this$props$variant,
@@ -157,13 +162,9 @@ function (_React$PureComponent) {
           _this$props$selectedI = _this$props.selectedID,
           selectedID = _this$props$selectedI === void 0 ? null : _this$props$selectedI,
           _this$props$className = _this$props.className,
-          propClsName = _this$props$className === void 0 ? null : _this$props$className;
-      var _this$state = this.state,
-          error = _this$state.error,
-          optionResults = _this$state.optionResults,
-          loading = _this$state.loading,
-          typedSearchQuery = _this$state.typedSearchQuery;
-      var searchAsYouType = optionResults && optionResults.length > 8;
+          propClsName = _this$props$className === void 0 ? null : _this$props$className,
+          _this$props$searchAsY = _this$props.searchAsYouType,
+          searchAsYouType = _this$props$searchAsY === void 0 ? optionResults && optionResults.length > 8 : _this$props$searchAsY;
       var title;
       var disabled = false;
       var filteredOptions = optionResults;
@@ -189,7 +190,7 @@ function (_React$PureComponent) {
             if (cachedResults) {
               filteredOptions = cachedResults;
             } else {
-              var regexTest = new RegExp(typedSearchQuery);
+              var regexTest = new RegExp(typedSearchQuery, "i");
               filteredOptions = optionResults.filter(function (selectableItem) {
                 var display_title = selectableItem.display_title,
                     itemID = selectableItem['@id'];
@@ -286,6 +287,7 @@ _defineProperty(LinkToDropdown, "defaultProps", {
   'searchURL': "/search/?type=Project",
   'selectedID': null,
   'selectedTitle': null,
+  'searchAsYouType': null,
 
   /**
    * Example function to use.

--- a/es/components/forms/components/LinkToDropdown.js
+++ b/es/components/forms/components/LinkToDropdown.js
@@ -136,7 +136,7 @@ function (_React$PureComponent) {
         throw new Error("Couldn't find ID in resultlist - " + itemID);
       }
 
-      onSelect(itemID, selectedItem);
+      onSelect(selectedItem, itemID);
     }
   }, {
     key: "handleSearchTextChange",
@@ -295,7 +295,7 @@ _defineProperty(LinkToDropdown, "defaultProps", {
    * @param {*} itemID - The "@id" of selected item.
    * @param {*} itemJson - JSON/context of selected item. Will only contain limited subset of fields, e.g. type and title.
    */
-  'onSelect': function onSelect(itemID, itemJson) {
+  'onSelect': function onSelect(itemJson, itemID) {
     _util.console.info("Selected!", itemID, itemJson);
   }
 });

--- a/es/components/forms/components/SearchAsYouTypeAjax.js
+++ b/es/components/forms/components/SearchAsYouTypeAjax.js
@@ -269,9 +269,10 @@ function (_React$PureComponent) {
         }));
       } else {
         if (results.length === 0 && !error) {
+          var queryLen = currentTextValue.length;
           optionsHeader = _react["default"].createElement(_react["default"].Fragment, null, _react["default"].createElement("em", {
             className: "d-block text-center px-4 py-3"
-          }, "No results found"), optionsHeader);
+          }, queryLen == 1 ? "Minimum search length is 2 characters" : "No results found"), optionsHeader);
         } else if (error) {
           optionsHeader = _react["default"].createElement(_react["default"].Fragment, null, _react["default"].createElement("em", {
             className: "d-block text-center px-4 py-3"

--- a/es/components/forms/components/SearchAsYouTypeAjax.js
+++ b/es/components/forms/components/SearchAsYouTypeAjax.js
@@ -282,9 +282,7 @@ function (_React$PureComponent) {
       var intKey = parseInt(value); // if in the middle of editing a custom linked object for this field
 
       var hideButton = value && !isNaN(value) && !keyComplete[intKey];
-      return _react["default"].createElement("div", {
-        className: "d-flex flex-wrap"
-      }, hideButton ? null : _react["default"].createElement(_SearchSelectionMenu.SearchSelectionMenu, _extends({}, passProps, {
+      return hideButton ? null : _react["default"].createElement(_SearchSelectionMenu.SearchSelectionMenu, _extends({}, passProps, {
         optionsHeader: optionsHeader,
         currentTextValue: currentTextValue
       }, {
@@ -294,9 +292,7 @@ function (_React$PureComponent) {
         onToggleOpen: this.onToggleOpen,
         onTextInputChange: this.onTextInputChange,
         onDropdownSelect: this.onDropdownSelect
-      })), _react["default"].createElement(LinkedObj, _extends({
-        key: "linked-item"
-      }, passProps)));
+      }));
     }
   }]);
 
@@ -312,7 +308,8 @@ SearchAsYouTypeAjax.propTypes = {
       return new Error("Invalid prop '".concat(propName, "' supplied to ").concat(componentName, ". Validation failed."));
     }
   },
-  fieldsToRequest: _propTypes["default"].arrayOf(_propTypes["default"].string)
+  fieldsToRequest: _propTypes["default"].arrayOf(_propTypes["default"].string),
+  titleRenderFunction: _propTypes["default"].func
 };
 SearchAsYouTypeAjax.defaultProps = {
   "optionRenderFunction": function optionRenderFunction(result) {
@@ -349,7 +346,8 @@ function SubmissionViewSearchAsYouTypeAjax(props) {
       _props$idToTitleMap = props.idToTitleMap,
       idToTitleMap = _props$idToTitleMap === void 0 ? null : _props$idToTitleMap; // Add some logic based on schema.Linkto props if itemType not already available
 
-  // console.log("idToTitleMap: ", idToTitleMap);
+  var baseHref = "/search/?type=" + linkTo; // console.log("idToTitleMap: ", idToTitleMap);
+
   var optionRenderFunction = (optionCustomizationsByType[itemType] && optionCustomizationsByType[itemType].render ? optionCustomizationsByType[itemType].render : null) || SearchAsYouTypeAjax.defaultProps.optionRenderFunction;
   var fieldsToRequest = (optionCustomizationsByType[itemType] && optionCustomizationsByType[itemType].fieldsToRequest ? optionCustomizationsByType[itemType].fieldsToRequest : null) || SearchAsYouTypeAjax.defaultProps.fieldsToRequest;
   var onChange = (0, _react.useMemo)(function () {
@@ -363,15 +361,21 @@ function SubmissionViewSearchAsYouTypeAjax(props) {
       return idToTitleMap[resultAtID] || resultAtID;
     };
   }, [idToTitleMap]);
-  return _react["default"].createElement(SearchAsYouTypeAjax, _extends({
+  return _react["default"].createElement("div", {
+    className: "d-flex flex-wrap"
+  }, _react["default"].createElement(SearchAsYouTypeAjax, _extends({
     value: value,
     onChange: onChange,
-    baseHref: "/search/?type=" + linkTo,
+    baseHref: baseHref,
     optionRenderFunction: optionRenderFunction,
     fieldsToRequest: fieldsToRequest,
     titleRenderFunction: titleRenderFunction,
     selectComplete: selectComplete
-  }, props));
+  }, props)), _react["default"].createElement(LinkedObj, _extends({
+    key: "linked-item"
+  }, props, {
+    baseHref: baseHref
+  })));
 }
 
 function sexToIcon(sex, showTip) {

--- a/es/components/forms/components/SearchAsYouTypeAjax.js
+++ b/es/components/forms/components/SearchAsYouTypeAjax.js
@@ -227,7 +227,7 @@ function (_React$PureComponent) {
         // if title hasn't been registered, use the old value
         onChange(result, value);
       } else {
-        onChange(result, currentTextValue);
+        onChange(result, result['@id']);
       }
     }
   }, {

--- a/es/components/forms/components/SearchAsYouTypeAjax.js
+++ b/es/components/forms/components/SearchAsYouTypeAjax.js
@@ -224,9 +224,11 @@ function (_React$PureComponent) {
       var currentTextValue = this.state.currentTextValue;
 
       if (!titleRenderFunction(currentTextValue)) {
-        // if title hasn't been registered, use the old value
+        console.log("title hasn't been registered"); // if title hasn't been registered, use the old value
+
         onChange(result, value);
       } else {
+        console.log("calling onDropdownSelect", result);
         onChange(result, result['@id']);
       }
     }
@@ -287,7 +289,6 @@ function (_React$PureComponent) {
         currentTextValue: currentTextValue
       }, {
         alignRight: true,
-        showTips: true,
         options: results,
         onToggleOpen: this.onToggleOpen,
         onTextInputChange: this.onTextInputChange,
@@ -332,9 +333,12 @@ SearchAsYouTypeAjax.defaultProps = {
   "fieldsToRequest": ["@id", "display_title", "description"] // additional fields aside from @id, display_title, and description; all already included
 
 };
+/**
+ * A HOC for wrapping SearchAsYouTypeAjax with SubmissionView specific bits, like
+ * the LinkedObj component which renders the "Create New" & "Advanced Search" buttons.
+ */
 
 function SubmissionViewSearchAsYouTypeAjax(props) {
-  // Another higher-order-component
   var selectComplete = props.selectComplete,
       nestedField = props.nestedField,
       value = props.value,
@@ -347,15 +351,20 @@ function SubmissionViewSearchAsYouTypeAjax(props) {
       idToTitleMap = _props$idToTitleMap === void 0 ? null : _props$idToTitleMap; // Add some logic based on schema.Linkto props if itemType not already available
 
   var baseHref = "/search/?type=" + linkTo; // console.log("idToTitleMap: ", idToTitleMap);
+  // Retrieves Item types from SubmissionView props and uses that to pass SAYTAJAX
+  // item-specific options for rendering dropdown items with more/different info than default
 
-  var optionRenderFunction = (optionCustomizationsByType[itemType] && optionCustomizationsByType[itemType].render ? optionCustomizationsByType[itemType].render : null) || SearchAsYouTypeAjax.defaultProps.optionRenderFunction;
+  var optionRenderFunction = (optionCustomizationsByType[itemType] && optionCustomizationsByType[itemType].render ? optionCustomizationsByType[itemType].render : null) || SearchAsYouTypeAjax.defaultProps.optionRenderFunction; // Retrieves the appropriate fields based on item type
+
   var fieldsToRequest = (optionCustomizationsByType[itemType] && optionCustomizationsByType[itemType].fieldsToRequest ? optionCustomizationsByType[itemType].fieldsToRequest : null) || SearchAsYouTypeAjax.defaultProps.fieldsToRequest;
   var onChange = (0, _react.useMemo)(function () {
     return function (resultItem, valueToReplace) {
       console.log("calling SubmissionViewSearchAsYouType onchange", arrayIdx);
       return selectComplete(resultItem['@id'], nestedField, itemType, arrayIdx, resultItem.display_title, valueToReplace);
     };
-  }, [selectComplete, nestedField, itemType, arrayIdx]);
+  }, [selectComplete, nestedField, itemType, arrayIdx]); // Uses idToTitleMap (similar to SubmissionView.keyDisplay) to keep track of & render display_titles
+  // for previously seen objects
+
   var titleRenderFunction = (0, _react.useMemo)(function () {
     return function (resultAtID) {
       return idToTitleMap[resultAtID] || resultAtID;
@@ -364,6 +373,8 @@ function SubmissionViewSearchAsYouTypeAjax(props) {
   return _react["default"].createElement("div", {
     className: "d-flex flex-wrap"
   }, _react["default"].createElement(SearchAsYouTypeAjax, _extends({
+    showTips: true
+  }, {
     value: value,
     onChange: onChange,
     baseHref: baseHref,

--- a/es/components/forms/components/SearchSelectionMenu.js
+++ b/es/components/forms/components/SearchSelectionMenu.js
@@ -141,6 +141,8 @@ function (_React$PureComponent) {
           optionsHeader = _this$props2.optionsHeader,
           optionsFooter = _this$props2.optionsFooter,
           className = _this$props2.className,
+          _this$props2$variant = _this$props2.variant,
+          variant = _this$props2$variant === void 0 ? "outline-secondary" : _this$props2$variant,
           _this$props2$showTips = _this$props2.showTips,
           showTips = _this$props2$showTips === void 0 ? false : _this$props2$showTips;
       var _this$state = this.state,
@@ -157,10 +159,11 @@ function (_React$PureComponent) {
         onToggle: this.onToggleOpen,
         show: dropOpen,
         className: cls
-      }, _react["default"].createElement(_reactBootstrap.Dropdown.Toggle, {
-        variant: "outline-secondary",
+      }, _react["default"].createElement(_reactBootstrap.Dropdown.Toggle, _extends({
+        variant: variant
+      }, {
         "data-tip": showTips ? value : null
-      }, showValue), _react["default"].createElement(_reactBootstrap.Dropdown.Menu, _extends({
+      }), showValue), _react["default"].createElement(_reactBootstrap.Dropdown.Menu, _extends({
         key: refreshKey,
         as: SearchSelectionMenuBody
       }, {

--- a/src/components/forms/components/LinkToDropdown.js
+++ b/src/components/forms/components/LinkToDropdown.js
@@ -20,7 +20,7 @@ export class LinkToDropdown extends React.PureComponent {
          * @param {*} itemID - The "@id" of selected item.
          * @param {*} itemJson - JSON/context of selected item. Will only contain limited subset of fields, e.g. type and title.
          */
-        'onSelect' : function(itemID, itemJson){
+        'onSelect' : function(itemJson, itemID){
             console.info("Selected!", itemID, itemJson);
         }
     };
@@ -97,7 +97,7 @@ export class LinkToDropdown extends React.PureComponent {
             throw new Error("Couldn't find ID in resultlist - " + itemID);
         }
 
-        onSelect(itemID, selectedItem);
+        onSelect(selectedItem, itemID);
     }
 
     handleSearchTextChange(evt){

--- a/src/components/forms/components/LinkToDropdown.js
+++ b/src/components/forms/components/LinkToDropdown.js
@@ -11,6 +11,7 @@ export class LinkToDropdown extends React.PureComponent {
         'searchURL': "/search/?type=Project",
         'selectedID': null,
         'selectedTitle': null,
+        'searchAsYouType': null,
 
         /**
          * Example function to use.
@@ -106,15 +107,14 @@ export class LinkToDropdown extends React.PureComponent {
     }
 
     render(){
+        const { error, optionResults, loading, typedSearchQuery } = this.state;
         const {
             variant = "outline-dark",
             selectedTitle = null,
             selectedID = null,
-            className: propClsName = null
+            className: propClsName = null,
+            searchAsYouType = (optionResults && optionResults.length > 8)
         } = this.props;
-        const { error, optionResults, loading, typedSearchQuery } = this.state;
-
-        const searchAsYouType = optionResults && optionResults.length > 8;
 
         let title;
         let disabled = false;
@@ -136,7 +136,7 @@ export class LinkToDropdown extends React.PureComponent {
                     if (cachedResults){
                         filteredOptions = cachedResults;
                     } else {
-                        const regexTest = new RegExp(typedSearchQuery);
+                        const regexTest = new RegExp(typedSearchQuery, "i");
                         filteredOptions = optionResults.filter(function(selectableItem){
                             const { display_title, '@id' : itemID } = selectableItem;
                             return regexTest.test(display_title) || regexTest.test(itemID);

--- a/src/components/forms/components/SearchAsYouTypeAjax.js
+++ b/src/components/forms/components/SearchAsYouTypeAjax.js
@@ -118,7 +118,7 @@ export class SearchAsYouTypeAjax extends React.PureComponent {
             // if title hasn't been registered, use the old value
             onChange(result, value);
         } else {
-            onChange(result, currentTextValue);
+            onChange(result, result['@id']);
         }
     }
 

--- a/src/components/forms/components/SearchAsYouTypeAjax.js
+++ b/src/components/forms/components/SearchAsYouTypeAjax.js
@@ -169,22 +169,16 @@ export class SearchAsYouTypeAjax extends React.PureComponent {
         const intKey = parseInt(value); // if in the middle of editing a custom linked object for this field
         const hideButton = value && !isNaN(value) && !keyComplete[intKey];
 
-        return (
-            <div className="d-flex flex-wrap">
-                {
-                    hideButton ? null : (
-                        <SearchSelectionMenu {...passProps} {...{ optionsHeader, currentTextValue }}
-                            alignRight={true}
-                            showTips={true}
-                            options={results}
-                            onToggleOpen={this.onToggleOpen}
-                            onTextInputChange={this.onTextInputChange}
-                            onDropdownSelect={this.onDropdownSelect}
-                        />
-                    )
-                }
-                <LinkedObj key="linked-item" {...passProps} />
-            </div>
+        return ( hideButton ? null : (
+            <SearchSelectionMenu {...passProps} {...{ optionsHeader, currentTextValue }}
+                alignRight={true}
+                showTips={true}
+                options={results}
+                onToggleOpen={this.onToggleOpen}
+                onTextInputChange={this.onTextInputChange}
+                onDropdownSelect={this.onDropdownSelect}
+            />
+        )
         );
     }
 }
@@ -197,7 +191,8 @@ SearchAsYouTypeAjax.propTypes = {
             return new Error(`Invalid prop '${propName}' supplied to ${componentName}. Validation failed.`);
         }
     },
-    fieldsToRequest: PropTypes.arrayOf(PropTypes.string)
+    fieldsToRequest: PropTypes.arrayOf(PropTypes.string),
+    titleRenderFunction: PropTypes.func
 };
 SearchAsYouTypeAjax.defaultProps = {
     "optionRenderFunction" : function(result){
@@ -256,8 +251,13 @@ export function SubmissionViewSearchAsYouTypeAjax(props){ // Another higher-orde
         };
     }, [ idToTitleMap ]);
 
-    return <SearchAsYouTypeAjax {...{ value, onChange, baseHref, optionRenderFunction,
-        fieldsToRequest, titleRenderFunction, selectComplete }} {...props} />;
+    return (
+        <div className="d-flex flex-wrap">
+            <SearchAsYouTypeAjax {...{ value, onChange, baseHref, optionRenderFunction,
+                fieldsToRequest, titleRenderFunction, selectComplete }} {...props} />
+            <LinkedObj key="linked-item" {...props} {...{ baseHref }} />
+        </div>
+    );
 }
 
 

--- a/src/components/forms/components/SearchAsYouTypeAjax.js
+++ b/src/components/forms/components/SearchAsYouTypeAjax.js
@@ -148,10 +148,11 @@ export class SearchAsYouTypeAjax extends React.PureComponent {
             );
         } else {
             if (results.length === 0 && !error) {
+                const queryLen = currentTextValue.length;
                 optionsHeader = (
                     <React.Fragment>
                         <em className="d-block text-center px-4 py-3">
-                            { "No results found" }
+                            { (queryLen == 1) ? "Minimum search length is 2 characters" : "No results found" }
                         </em>
                         { optionsHeader }
                     </React.Fragment>

--- a/src/components/forms/components/SearchSelectionMenu.js
+++ b/src/components/forms/components/SearchSelectionMenu.js
@@ -84,6 +84,7 @@ export class SearchSelectionMenu extends React.PureComponent {
             optionsHeader,
             optionsFooter,
             className,
+            variant = "outline-secondary",
             showTips = false
         } = this.props;
         const { dropOpen, refreshKey } = this.state;
@@ -91,7 +92,7 @@ export class SearchSelectionMenu extends React.PureComponent {
         const showValue = (value && titleRenderFunction(value)) || <span className="text-300">No value</span>;
         return (
             <Dropdown flip onToggle={this.onToggleOpen} show={dropOpen} className={cls}>
-                <Dropdown.Toggle variant="outline-secondary" data-tip={showTips ? value : null}>{ showValue }</Dropdown.Toggle>
+                <Dropdown.Toggle {...{ variant }} data-tip={showTips ? value : null}>{ showValue }</Dropdown.Toggle>
                 <Dropdown.Menu key={refreshKey} as={SearchSelectionMenuBody} {...{ onTextInputChange, optionsHeader, optionsFooter, currentTextValue }}
                     flip show={dropOpen} onTextInputChange={onTextInputChange} toggleOpen={this.onToggleOpen} ref={this.dropdown} onKeyDown={this.onKeyDown}>
                     {


### PR DESCRIPTION
**Testing Notes**
- Must be tested with [this branch](https://github.com/dbmi-bgm/cgap-portal/pull/91) on CGAP; otherwise cohort submission page will crash.

**Changelog**:
- Small changes to `<LinkToDropdown>` to make that component's search as you type setting easier to work with on cohort submission page.
    - Added a toggle prop (boolean - `searchAsYouType`) to define whether or not search as you type is used in the dropdown. Defaults to what the statically fined check used to be.
    - Made regex query case-insensitive for better matching.
    - Swapped order of arguments in `<LinkToDropdown>` `onSelect()` methods to force compatibility with `<SearchAsYouTypeAjax>` `onChange()` in the case that it becomes necessary to swap them out in future.
        - Chose to swap here, since it seemed to be connected to fewer other components than the same method in `<SubmissionView>`.
        - **Downstream changes in CGAP**: See [PR for CGAP](https://github.com/dbmi-bgm/cgap-portal/pull/91). Need a second eye to check 4DN and CGAP to see if the same `onSelect()` is used anywhere more argument swapping is needed.
    - **Downstream changes in CGAP**: Used this component for the search as you type on the `<CohortSubmissionView>`. Most of the following updates to `<SearchAsYouTypeAjax>` were made to make it easier to port it to this cohort submission page should we want the functionality from that specific component instead.

- Updates to `<SearchAsYouTypeAjax>` to improve modularity and fix bugs
    - Moved `<LinkedObj>` component (contains "Advanced Search" and "Create New" linked obj buttons) from `<SearchAsYouTypeAjax>` to `<SubmissionViewSearchAsYouTypeAjax>` wrapper component for improved modularity.
    - Moved `showTips` static definition to `<SubmissionViewSearchAsYouTypeAjax>` so that in non-SubmissionView contexts you can actually decide whether you want the button to have an `@id` tooltip or not via the prop.
    - Pass `result['@id']` (instead of `state.currentTextValue`) into `<SearchAsYouTypeAjax>` `onChange()` when title has not yet been registered in `IdToTitleMap`. 
        - This fixes a bug that arose when using `<SearchAsYouTypeAjax>` outside of `<SubmissionView>`, causing the component to attempt to submit the `currentTextValue` when selecting an item from the dropdown menu. 
        - This worked in the sense that it didn't cause a crash/exception, but would quickly render the component useless until you typed in an actual `@id`. Genuinely have no idea how it was ever working as it was in `<SubmissionView>`; so if you can figure that out, let me know.
    - Added `variant` prop to make passing different bootstrap button styles down to the component easier when using in different views. 
        - Side note: Also discovered that you can basically concatenate any other classes you want to apply to the Bootstrap button to `variant`; may be useful in future. Might also be bad practice, though, so... ¯|_(ツ)_/¯)
    - Added ["minimum search length is 2 characters" notification](https://gyazo.com/38e81317db75750310411d5bd9253e64) to `optionsHeader` in the case that no results are generated because current query is only 1 character long.

- More comments