### PR TITLE
Search Results Table: Multiple Sort Options (per column); CSS+layout updates (more flexbox)

### DIFF
--- a/es/components/browse/SearchView.js
+++ b/es/components/browse/SearchView.js
@@ -148,6 +148,7 @@ function (_React$PureComponent) {
       var childViewProps = _objectSpread({}, passProps, {
         currentAction: currentAction,
         schemas: schemas,
+        windowWidth: windowWidth,
         isOwnPage: true,
         facets: propFacets || contextFacets
       });
@@ -160,9 +161,7 @@ function (_React$PureComponent) {
       }), _react["default"].createElement(_tableCommons.ColumnCombiner, {
         columns: columns,
         columnExtensionMap: columnExtensionMap
-      }, _react["default"].createElement(_CustomColumnController.CustomColumnController, {
-        windowWidth: windowWidth
-      }, _react["default"].createElement(_SortController.SortController, null, _react["default"].createElement(_ControlsAndResults.ControlsAndResults, childViewProps)))));
+      }, _react["default"].createElement(_CustomColumnController.CustomColumnController, null, _react["default"].createElement(_SortController.SortController, null, _react["default"].createElement(_ControlsAndResults.ControlsAndResults, childViewProps)))));
 
       if ((0, _misc.isSelectAction)(currentAction)) {
         // We don't allow "SelectionMode" unless is own page.

--- a/es/components/browse/components/FacetList/FacetTermsList.js
+++ b/es/components/browse/components/FacetList/FacetTermsList.js
@@ -349,7 +349,6 @@ function (_React$PureComponent2) {
       var _this$props4 = this.props,
           facet = _this$props4.facet,
           terms = _this$props4.terms,
-          tooltip = _this$props4.tooltip,
           title = _this$props4.title,
           isStatic = _this$props4.isStatic,
           anySelected = _this$props4.anyTermsSelected,
@@ -359,6 +358,8 @@ function (_React$PureComponent2) {
           getTermStatus = _this$props4.getTermStatus,
           termTransformFxn = _this$props4.termTransformFxn,
           facetOpen = _this$props4.facetOpen;
+      var _facet$description = facet.description,
+          description = _facet$description === void 0 ? null : _facet$description;
       var expanded = this.state.expanded;
       var termsLen = terms.length;
       var allTermsSelected = termsSelectedCount === termsLen;
@@ -406,7 +407,8 @@ function (_React$PureComponent2) {
       })), _react["default"].createElement("div", {
         className: "col px-0 line-height-1"
       }, _react["default"].createElement("span", {
-        "data-tip": tooltip,
+        "data-tip": description,
+        "data-html": true,
         "data-place": "right"
       }, title)), indicator), _react["default"].createElement(ListOfTerms, _extends({
         facet: facet,

--- a/es/components/browse/components/FacetList/TermsFacet.js
+++ b/es/components/browse/components/FacetList/TermsFacet.js
@@ -126,9 +126,7 @@ function (_React$PureComponent) {
 
       var _ref = facet || {},
           field = _ref.field,
-          title = _ref.title,
-          _ref$description = _ref.description,
-          description = _ref$description === void 0 ? null : _ref$description;
+          title = _ref.title;
 
       var showTitle = title || field;
 
@@ -147,7 +145,6 @@ function (_React$PureComponent) {
       } else {
         return _react["default"].createElement(_FacetTermsList.FacetTermsList, _extends({}, this.props, {
           onTermClick: this.handleTermClick,
-          tooltip: description,
           title: showTitle
         }));
       }

--- a/es/components/browse/components/SearchResultTable.js
+++ b/es/components/browse/components/SearchResultTable.js
@@ -398,7 +398,7 @@ function (_React$PureComponent2) {
           columnDefinitions = _this$props6.columnDefinitions,
           selectedFiles = _this$props6.selectedFiles; // Contains required 'result', 'rowNumber', 'href', 'columnWidths', 'mounted', 'windowWidth', 'schemas', 'currentAction', 'detailOpen'
 
-      var commonProps = _underscore["default"].omit(this.props, 'tableContainerWidth', 'tableContainerScrollLeft', 'renderDetailPane', 'id');
+      var commonProps = _underscore["default"].omit(this.props, 'tableContainerWidth', 'tableContainerScrollLeft', 'renderDetailPane', 'id', 'toggleDetailPaneOpen');
 
       return columnDefinitions.map(function (columnDefinition, columnNumber) {
         // todo: rename columnNumber to columnIndex

--- a/es/components/browse/components/SearchResultTable.js
+++ b/es/components/browse/components/SearchResultTable.js
@@ -687,7 +687,7 @@ function (_React$PureComponent3) {
         ,
         loadingSpinnerDelegate: _react["default"].createElement(LoadingSpinner, {
           width: tableContainerWidth,
-          tableContainerScrollLeft: tableContainerScrollLeft
+          scrollLeft: tableContainerScrollLeft
         }),
         infiniteLoadBeginEdgeOffset: canLoadMore ? 200 : undefined,
         preloadAdditionalHeight: _reactInfinite["default"].containerHeightScaleFactor(1.5),
@@ -738,17 +738,19 @@ _defineProperty(LoadMoreAsYouScroll, "defaultProps", {
 });
 
 var LoadingSpinner = _react["default"].memo(function (_ref3) {
-  var width = _ref3.width,
-      tableContainerScrollLeft = _ref3.tableContainerScrollLeft;
+  var maxWidth = _ref3.width,
+      _ref3$scrollLeft = _ref3.scrollLeft,
+      scrollLeft = _ref3$scrollLeft === void 0 ? 0 : _ref3$scrollLeft;
+  var style = {
+    maxWidth: maxWidth,
+    'transform': _utilities.style.translate3d(scrollLeft)
+  };
   return _react["default"].createElement("div", {
-    className: "search-result-row loading text-center",
-    style: {
-      'maxWidth': width,
-      'transform': _utilities.style.translate3d(tableContainerScrollLeft)
-    }
-  }, _react["default"].createElement("i", {
+    className: "search-result-row loading text-center d-flex align-items-center justify-content-center",
+    style: style
+  }, _react["default"].createElement("span", null, _react["default"].createElement("i", {
     className: "icon icon-circle-notch icon-spin fas"
-  }), "\xA0 Loading...");
+  }), "\xA0 Loading..."));
 });
 
 var ShadowBorderLayer =
@@ -1068,6 +1070,18 @@ function (_React$PureComponent4) {
     value: function componentDidMount() {
       var _this9 = this;
 
+      // Maybe todo: play with 'experimental technology' for controlling columing widths (& compare performance),
+      // see https://developer.mozilla.org/en-US/docs/Web/API/DocumentOrShadowRoot/styleSheets
+      // and https://developer.mozilla.org/en-US/docs/Web/API/CSSStylesheet.
+      // Probably do in separate component since seems like hefty-enough logic to separate/modularize.
+      // this.isDynamicStylesheetSupported = typeof document.styleSheets !== "undefined";
+      // if (this.isDynamicStylesheetSupported) {
+      //    insert new <style> element somewhere (new stylesheet?), save reference (prly doesnt do ton.. w/e)
+      //    check that new sheet exists in document.styleSheets, start setting widths per column via CSS rules
+      //    deleting and inserting upon any changes, accordingly. Use componentDidUpdate or useEffect for this,
+      //    re: props.widths (this table's state.widths) changes.
+      //    (This all within new component if supported, else pass widths down to cols as fallback (?) from this component)
+      // }
       // Detect if table width changes (and update dims if true) every 5sec
       // No way to attach resize event listener to an element (only to window)
       // and element might change width independent of window (e.g. open/hide
@@ -1110,18 +1124,11 @@ function (_React$PureComponent4) {
     value: function componentDidUpdate(pastProps, pastState) {
       var _this$state2 = this.state,
           loadedResults = _this$state2.results,
-          mounted = _this$state2.mounted,
-          widths = _this$state2.widths;
+          mounted = _this$state2.mounted;
       var pastLoadedResults = pastState.results,
           pastMounted = pastState.mounted;
-      var _this$props13 = this.props,
-          propResults = _this$props13.results,
-          columnDefinitions = _this$props13.columnDefinitions,
-          windowWidth = _this$props13.windowWidth,
-          isOwnPage = _this$props13.isOwnPage;
-      var pastPropResults = pastProps.results,
-          pastColDefs = pastProps.columnDefinitions,
-          pastWindowWidth = pastProps.windowWidth;
+      var windowWidth = this.props.windowWidth;
+      var pastWindowWidth = pastProps.windowWidth;
 
       if (pastLoadedResults !== loadedResults) {
         _reactTooltip["default"].rebuild();
@@ -1232,13 +1239,13 @@ function (_React$PureComponent4) {
   }, {
     key: "canLoadMore",
     value: function canLoadMore() {
-      var _this$props14 = this.props,
-          _this$props14$context = _this$props14.context;
-      _this$props14$context = _this$props14$context === void 0 ? {} : _this$props14$context;
-      var _this$props14$context2 = _this$props14$context.total,
-          total = _this$props14$context2 === void 0 ? 0 : _this$props14$context2,
-          _this$props14$isConte = _this$props14.isContextLoading,
-          isContextLoading = _this$props14$isConte === void 0 ? false : _this$props14$isConte;
+      var _this$props13 = this.props,
+          _this$props13$context = _this$props13.context;
+      _this$props13$context = _this$props13$context === void 0 ? {} : _this$props13$context;
+      var _this$props13$context2 = _this$props13$context.total,
+          total = _this$props13$context2 === void 0 ? 0 : _this$props13$context2,
+          _this$props13$isConte = _this$props13.isContextLoading,
+          isContextLoading = _this$props13$isConte === void 0 ? false : _this$props13$isConte;
       var _this$state$results = this.state.results,
           results = _this$state$results === void 0 ? [] : _this$state$results;
       return !isContextLoading && LoadMoreAsYouScroll.canLoadMore(total, results);
@@ -1246,23 +1253,23 @@ function (_React$PureComponent4) {
   }, {
     key: "render",
     value: function render() {
-      var _this$props15 = this.props,
-          columnDefinitions = _this$props15.columnDefinitions,
-          windowWidth = _this$props15.windowWidth,
-          context = _this$props15.context,
-          _this$props15$isOwnPa = _this$props15.isOwnPage,
-          isOwnPage = _this$props15$isOwnPa === void 0 ? true : _this$props15$isOwnPa,
-          navigate = _this$props15.navigate,
-          _this$props15$rowHeig = _this$props15.rowHeight,
-          rowHeight = _this$props15$rowHeig === void 0 ? 47 : _this$props15$rowHeig,
-          _this$props15$openRow = _this$props15.openRowHeight,
-          openRowHeight = _this$props15$openRow === void 0 ? 57 : _this$props15$openRow,
-          _this$props15$maxHeig = _this$props15.maxHeight,
-          maxHeight = _this$props15$maxHeig === void 0 ? 500 : _this$props15$maxHeig,
-          _this$props15$isConte = _this$props15.isContextLoading,
-          isContextLoading = _this$props15$isConte === void 0 ? false : _this$props15$isConte,
-          setColumnWidths = _this$props15.setColumnWidths,
-          columnWidths = _this$props15.columnWidths;
+      var _this$props14 = this.props,
+          columnDefinitions = _this$props14.columnDefinitions,
+          windowWidth = _this$props14.windowWidth,
+          context = _this$props14.context,
+          _this$props14$isOwnPa = _this$props14.isOwnPage,
+          isOwnPage = _this$props14$isOwnPa === void 0 ? true : _this$props14$isOwnPa,
+          navigate = _this$props14.navigate,
+          _this$props14$rowHeig = _this$props14.rowHeight,
+          rowHeight = _this$props14$rowHeig === void 0 ? 47 : _this$props14$rowHeig,
+          _this$props14$openRow = _this$props14.openRowHeight,
+          openRowHeight = _this$props14$openRow === void 0 ? 57 : _this$props14$openRow,
+          _this$props14$maxHeig = _this$props14.maxHeight,
+          maxHeight = _this$props14$maxHeig === void 0 ? 500 : _this$props14$maxHeig,
+          _this$props14$isConte = _this$props14.isContextLoading,
+          isContextLoading = _this$props14$isConte === void 0 ? false : _this$props14$isConte,
+          setColumnWidths = _this$props14.setColumnWidths,
+          columnWidths = _this$props14.columnWidths;
       var _this$state3 = this.state,
           results = _this$state3.results,
           tableContainerWidth = _this$state3.tableContainerWidth,
@@ -1425,13 +1432,13 @@ function (_React$PureComponent5) {
   _createClass(SearchResultTable, [{
     key: "render",
     value: function render() {
-      var _this$props16 = this.props,
-          context = _this$props16.context,
-          visibleColumnDefinitions = _this$props16.visibleColumnDefinitions,
-          columnDefinitions = _this$props16.columnDefinitions,
-          _this$props16$isConte = _this$props16.isContextLoading,
-          isContextLoading = _this$props16$isConte === void 0 ? false : _this$props16$isConte,
-          isOwnPage = _this$props16.isOwnPage;
+      var _this$props15 = this.props,
+          context = _this$props15.context,
+          visibleColumnDefinitions = _this$props15.visibleColumnDefinitions,
+          columnDefinitions = _this$props15.columnDefinitions,
+          _this$props15$isConte = _this$props15.isContextLoading,
+          isContextLoading = _this$props15$isConte === void 0 ? false : _this$props15$isConte,
+          isOwnPage = _this$props15.isOwnPage;
 
       if (isContextLoading && !context) {
         // Initial context (pre-sort, filter, etc) loading.

--- a/es/components/browse/components/SearchResultTable.js
+++ b/es/components/browse/components/SearchResultTable.js
@@ -1210,8 +1210,8 @@ function (_React$PureComponent4) {
           nextScrollLeft = 0; // Might occur right after changing column widths or something.
         }
 
-        var headersElem = innerElem.parentElement.childNodes[0].childNodes[0];
-        headersElem.style.left = "-".concat(nextScrollLeft, "px");
+        var columnsWrapperElement = innerElem.parentElement.childNodes[0].childNodes[0].childNodes[0];
+        columnsWrapperElement.style.left = "-".concat(nextScrollLeft, "px");
 
         if (nextScrollLeft !== tableContainerScrollLeft) {
           // Shouldn't occur or matter but presence of this seems to improve smoothness (?)

--- a/es/components/browse/components/SearchResultTable.js
+++ b/es/components/browse/components/SearchResultTable.js
@@ -88,6 +88,7 @@ function _extends() { _extends = Object.assign || function (target) { for (var i
 
 var ResultRowColumnBlock = _react["default"].memo(function (props) {
   var columnDefinition = props.columnDefinition,
+      columnNumber = props.columnNumber,
       mounted = props.mounted,
       columnWidths = props.columnWidths,
       schemas = props.schemas,
@@ -107,7 +108,8 @@ var ResultRowColumnBlock = _react["default"].memo(function (props) {
       style: {
         "width": blockWidth
       },
-      "data-field": columnDefinition.field
+      "data-field": field,
+      "data-column-even": columnNumber % 2 === 0
     }, _react["default"].createElement(_ResultRowColumnBlockValue.ResultRowColumnBlockValue, _extends({}, props, {
       width: blockWidth,
       schemas: schemas
@@ -295,11 +297,11 @@ function (_React$PureComponent2) {
     }
   }, {
     key: "getStyles",
-    value: function getStyles(rowWidth, rowHeight) {
+    value: function getStyles(rowWidth) {
+      arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 47;
+      arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 1;
       return {
-        inner: {
-          minHeight: rowHeight - 1
-        },
+        /* inner: { minHeight: rowHeight - rowBottomPadding }, */
         outer: {
           minWidth: rowWidth
         }
@@ -312,8 +314,7 @@ function (_React$PureComponent2) {
 
     _classCallCheck(this, ResultRow);
 
-    _this2 = _possibleConstructorReturn(this, _getPrototypeOf(ResultRow).call(this, props)); //this.shouldComponentUpdate = this.shouldComponentUpdate.bind(this);
-
+    _this2 = _possibleConstructorReturn(this, _getPrototypeOf(ResultRow).call(this, props));
     _this2.toggleDetailOpen = _underscore["default"].throttle(_this2.toggleDetailOpen.bind(_assertThisInitialized(_this2)), 250);
     _this2.setDetailHeight = _this2.setDetailHeight.bind(_assertThisInitialized(_this2));
     _this2.handleDragStart = _this2.handleDragStart.bind(_assertThisInitialized(_this2));
@@ -395,19 +396,19 @@ function (_React$PureComponent2) {
       // to make more reusable re: e.g. `selectedFiles` (= 4DN-specific).
       var _this$props6 = this.props,
           columnDefinitions = _this$props6.columnDefinitions,
-          selectedFiles = _this$props6.selectedFiles,
-          detailOpen = _this$props6.detailOpen;
+          selectedFiles = _this$props6.selectedFiles; // Contains required 'result', 'rowNumber', 'href', 'columnWidths', 'mounted', 'windowWidth', 'schemas', 'currentAction', 'detailOpen'
+
+      var commonProps = _underscore["default"].omit(this.props, 'tableContainerWidth', 'tableContainerScrollLeft', 'renderDetailPane', 'id');
+
       return columnDefinitions.map(function (columnDefinition, columnNumber) {
         // todo: rename columnNumber to columnIndex
         var field = columnDefinition.field;
 
-        var passedProps = _underscore["default"].extend( // Contains required 'result', 'rowNumber', 'href', 'columnWidths', 'mounted', 'windowWidth', 'schemas', 'currentAction
-        _underscore["default"].omit(_this3.props, 'tableContainerWidth', 'tableContainerScrollLeft', 'renderDetailPane', 'id'), {
+        var passedProps = _objectSpread({}, commonProps, {
           columnDefinition: columnDefinition,
           columnNumber: columnNumber,
-          detailOpen: detailOpen,
-          'toggleDetailOpen': _this3.toggleDetailOpen,
           // Only needed on first column (contains title, checkbox)
+          'toggleDetailOpen': columnNumber === 0 ? _this3.toggleDetailOpen : null,
           'selectedFiles': columnNumber === 0 ? selectedFiles : null
         });
 
@@ -721,12 +722,11 @@ _defineProperty(LoadMoreAsYouScroll, "propTypes", {
   'mounted': _propTypes["default"].bool,
   'onDuplicateResultsFoundCallback': _propTypes["default"].func,
   'navigate': _propTypes["default"].func,
-  'openRowHeight': _propTypes["default"].number
+  'openRowHeight': _propTypes["default"].number.isRequired
 });
 
 _defineProperty(LoadMoreAsYouScroll, "defaultProps", {
   'debouncePointerEvents': 150,
-  'openRowHeight': 57,
   'onDuplicateResultsFoundCallback': function onDuplicateResultsFoundCallback() {
     _Alerts.Alerts.queue({
       'title': 'Results Refreshed',
@@ -1255,6 +1255,8 @@ function (_React$PureComponent4) {
           navigate = _this$props15.navigate,
           _this$props15$rowHeig = _this$props15.rowHeight,
           rowHeight = _this$props15$rowHeig === void 0 ? 47 : _this$props15$rowHeig,
+          _this$props15$openRow = _this$props15.openRowHeight,
+          openRowHeight = _this$props15$openRow === void 0 ? 57 : _this$props15$openRow,
           _this$props15$maxHeig = _this$props15.maxHeight,
           maxHeight = _this$props15$maxHeig === void 0 ? 500 : _this$props15$maxHeig,
           _this$props15$isConte = _this$props15.isContextLoading,
@@ -1299,6 +1301,7 @@ function (_React$PureComponent4) {
       var loadMoreAsYouScrollProps = _objectSpread({}, _underscore["default"].pick(this.props, 'href', 'onDuplicateResultsFoundCallback', 'schemas', 'navigate'), {
         context: context,
         rowHeight: rowHeight,
+        openRowHeight: openRowHeight,
         results: results,
         openDetailPanes: openDetailPanes,
         maxHeight: maxHeight,
@@ -1509,8 +1512,9 @@ _defineProperty(SearchResultTable, "defaultProps", {
   'defaultMinColumnWidth': 55,
   'hiddenColumns': null,
   // This value (the default or if passed in) should be aligned to value in CSS.
-  // Value in CSS is decremented by 1px to account for border height.
+  // Must account for any border or padding at bottom/top of row, as well.
   'rowHeight': 47,
+  'openRowHeight': 57,
   'fullWidthInitOffset': 60,
   'fullWidthContainerSelectorString': '.browse-page-container',
   'currentAction': null,

--- a/es/components/browse/components/SearchResultTable.js
+++ b/es/components/browse/components/SearchResultTable.js
@@ -479,16 +479,7 @@ _defineProperty(ResultRow, "propTypes", {
   'rowNumber': _propTypes["default"].number.isRequired,
   'rowHeight': _propTypes["default"].number,
   'mounted': _propTypes["default"].bool.isRequired,
-  'columnDefinitions': _propTypes["default"].arrayOf(_propTypes["default"].shape({
-    'title': _propTypes["default"].string.isRequired,
-    'field': _propTypes["default"].string.isRequired,
-    'render': _propTypes["default"].func,
-    'widthMap': _propTypes["default"].shape({
-      'lg': _propTypes["default"].number.isRequired,
-      'md': _propTypes["default"].number.isRequired,
-      'sm': _propTypes["default"].number.isRequired
-    })
-  })).isRequired,
+  'columnDefinitions': _HeadersRow.HeadersRow.propTypes.columnDefinitions,
   'columnWidths': _propTypes["default"].objectOf(_propTypes["default"].number),
   'renderDetailPane': _propTypes["default"].func.isRequired,
   'detailOpen': _propTypes["default"].bool.isRequired,

--- a/es/components/browse/components/table-commons/ColumnCombiner.js
+++ b/es/components/browse/components/table-commons/ColumnCombiner.js
@@ -256,11 +256,6 @@ function columnsToColumnDefinitions(columns, columnDefinitionMap) {
       var colDef2 = _underscore["default"].extend({}, colDefOverride, colDef);
 
       colDef = colDef2;
-    } // Add defaults for any required-for-view but not-present properties.
-
-
-    if (colDef.widthMap && colDef.widthMap.sm && typeof colDef.widthMap.xs !== 'number') {
-      colDef.widthMap.xs = colDef.widthMap.sm;
     }
 
     colDef.widthMap = colDef.widthMap || defaultWidthMap;

--- a/es/components/browse/components/table-commons/HeadersRow.js
+++ b/es/components/browse/components/table-commons/HeadersRow.js
@@ -608,6 +608,8 @@ function (_React$PureComponent3) {
           return title || field;
         }).join(", ");
         tooltip = sortedByFieldTitles.length > 0 ? "Sorted by <span class=\"text-600\">".concat(sortedByFieldTitles, "</span>") : null;
+      } else if (hasMultipleSortOptions) {
+        tooltip = "" + sort_fields.length + " sort options";
       }
 
       return _react["default"].createElement("span", {

--- a/es/components/browse/components/table-commons/HeadersRow.js
+++ b/es/components/browse/components/table-commons/HeadersRow.js
@@ -21,6 +21,8 @@ var _WindowClickEventDelegator = require("./../../../util/WindowClickEventDelega
 
 var _layout = require("./../../../util/layout");
 
+var _utilities = require("./../../../viz/utilities");
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
 function _getRequireWildcardCache() { if (typeof WeakMap !== "function") return null; var cache = new WeakMap(); _getRequireWildcardCache = function _getRequireWildcardCache() { return cache; }; return cache; }
@@ -250,18 +252,20 @@ function (_React$PureComponent) {
   }, {
     key: "setColumnWidthsFromState",
     value: function setColumnWidthsFromState() {
-      var _this$props3 = this.props,
-          setColumnWidths = _this$props3.setColumnWidths,
-          columnWidths = _this$props3.columnWidths;
-      var widths = this.state.widths;
+      var _this3 = this;
 
-      if (typeof setColumnWidths !== 'function') {
-        throw new Error('props.setHeaderWidths not a function');
-      }
+      (0, _utilities.requestAnimationFrame)(function () {
+        var _this3$props = _this3.props,
+            setColumnWidths = _this3$props.setColumnWidths,
+            columnWidths = _this3$props.columnWidths;
+        var widths = _this3.state.widths;
 
-      setTimeout(function () {
+        if (typeof setColumnWidths !== 'function') {
+          throw new Error('props.setHeaderWidths not a function');
+        }
+
         setColumnWidths(_objectSpread({}, columnWidths, {}, widths));
-      }, 0);
+      });
     }
   }, {
     key: "onAdjusterDrag",
@@ -270,31 +274,27 @@ function (_React$PureComponent) {
       this.setState(function (_ref3, _ref4) {
         var widths = _ref3.widths;
         var defaultMinColumnWidth = _ref4.defaultMinColumnWidth;
-
-        var nextWidths = _underscore["default"].clone(widths);
-
-        nextWidths[field] = Math.max(columnDefinition.minColumnWidth || defaultMinColumnWidth || 55, r.x);
         return {
-          'widths': nextWidths
+          'widths': _objectSpread({}, widths, _defineProperty({}, field, Math.max(columnDefinition.minColumnWidth || defaultMinColumnWidth || 55, r.x)))
         };
       });
     }
   }, {
     key: "render",
     value: function render() {
-      var _this$props4 = this.props,
-          columnDefinitions = _this$props4.columnDefinitions,
-          renderDetailPane = _this$props4.renderDetailPane,
-          _this$props4$sortColu = _this$props4.sortColumn,
-          sortColumn = _this$props4$sortColu === void 0 ? null : _this$props4$sortColu,
-          _this$props4$sortReve = _this$props4.sortReverse,
-          sortReverse = _this$props4$sortReve === void 0 ? false : _this$props4$sortReve,
-          sortBy = _this$props4.sortBy,
-          columnWidths = _this$props4.columnWidths,
-          setColumnWidths = _this$props4.setColumnWidths,
-          width = _this$props4.width,
-          tableContainerScrollLeft = _this$props4.tableContainerScrollLeft,
-          windowWidth = _this$props4.windowWidth;
+      var _this$props3 = this.props,
+          columnDefinitions = _this$props3.columnDefinitions,
+          renderDetailPane = _this$props3.renderDetailPane,
+          _this$props3$sortColu = _this$props3.sortColumn,
+          sortColumn = _this$props3$sortColu === void 0 ? null : _this$props3$sortColu,
+          _this$props3$sortReve = _this$props3.sortReverse,
+          sortReverse = _this$props3$sortReve === void 0 ? false : _this$props3$sortReve,
+          sortBy = _this$props3.sortBy,
+          columnWidths = _this$props3.columnWidths,
+          setColumnWidths = _this$props3.setColumnWidths,
+          width = _this$props3.width,
+          tableContainerScrollLeft = _this$props3.tableContainerScrollLeft,
+          windowWidth = _this$props3.windowWidth;
       var _this$state2 = this.state,
           showingSortFieldsForColumn = _this$state2.showingSortFieldsForColumn,
           widths = _this$state2.widths,
@@ -404,19 +404,19 @@ function (_React$PureComponent2) {
   _inherits(HeadersRowColumn, _React$PureComponent2);
 
   function HeadersRowColumn(props) {
-    var _this3;
+    var _this4;
 
     _classCallCheck(this, HeadersRowColumn);
 
-    _this3 = _possibleConstructorReturn(this, _getPrototypeOf(HeadersRowColumn).call(this, props));
-    _this3.onDrag = _this3.onDrag.bind(_assertThisInitialized(_this3));
-    _this3.onStop = _this3.onStop.bind(_assertThisInitialized(_this3));
-    _this3.memoized = {
+    _this4 = _possibleConstructorReturn(this, _getPrototypeOf(HeadersRowColumn).call(this, props));
+    _this4.onDrag = _this4.onDrag.bind(_assertThisInitialized(_this4));
+    _this4.onStop = _this4.onStop.bind(_assertThisInitialized(_this4));
+    _this4.memoized = {
       showTooltip: (0, _memoizeOne["default"])(function (colWidth, titleStr) {
         return (colWidth - 40) / 7 < (titleStr || "").length;
       })
     };
-    return _this3;
+    return _this4;
   }
   /** Updates HeadersRow.state.widths {Object<string,numer>} */
 
@@ -424,9 +424,9 @@ function (_React$PureComponent2) {
   _createClass(HeadersRowColumn, [{
     key: "onDrag",
     value: function onDrag(event, res) {
-      var _this$props5 = this.props,
-          columnDefinition = _this$props5.columnDefinition,
-          onAdjusterDrag = _this$props5.onAdjusterDrag;
+      var _this$props4 = this.props,
+          columnDefinition = _this$props4.columnDefinition,
+          onAdjusterDrag = _this$props4.onAdjusterDrag;
       onAdjusterDrag(columnDefinition, event, res);
     }
     /** Updates CustomColumnController.state.columnWidths from HeadersRow.state.widths */
@@ -440,16 +440,16 @@ function (_React$PureComponent2) {
   }, {
     key: "render",
     value: function render() {
-      var _this$props6 = this.props,
-          sortByField = _this$props6.sortByField,
-          width = _this$props6.width,
-          columnDefinition = _this$props6.columnDefinition,
-          onAdjusterDrag = _this$props6.onAdjusterDrag,
-          showingSortOptionsMenu = _this$props6.showingSortOptionsMenu,
-          setShowingSortFieldsFor = _this$props6.setShowingSortFieldsFor,
-          active = _this$props6.active,
-          _this$props6$isLoadin = _this$props6.isLoading,
-          isLoading = _this$props6$isLoadin === void 0 ? false : _this$props6$isLoadin;
+      var _this$props5 = this.props,
+          sortByField = _this$props5.sortByField,
+          width = _this$props5.width,
+          columnDefinition = _this$props5.columnDefinition,
+          onAdjusterDrag = _this$props5.onAdjusterDrag,
+          showingSortOptionsMenu = _this$props5.showingSortOptionsMenu,
+          setShowingSortFieldsFor = _this$props5.setShowingSortFieldsFor,
+          active = _this$props5.active,
+          _this$props5$isLoadin = _this$props5.isLoading,
+          isLoading = _this$props5$isLoadin === void 0 ? false : _this$props5$isLoadin;
       var noSort = columnDefinition.noSort,
           colTitle = columnDefinition.colTitle,
           title = columnDefinition.title,
@@ -522,16 +522,16 @@ function (_React$PureComponent3) {
   }]);
 
   function ColumnSorterIcon(props) {
-    var _this4;
+    var _this5;
 
     _classCallCheck(this, ColumnSorterIcon);
 
-    _this4 = _possibleConstructorReturn(this, _getPrototypeOf(ColumnSorterIcon).call(this, props));
-    _this4.onIconClick = _this4.onIconClick.bind(_assertThisInitialized(_this4));
-    _this4.memoized = {
+    _this5 = _possibleConstructorReturn(this, _getPrototypeOf(ColumnSorterIcon).call(this, props));
+    _this5.onIconClick = _this5.onIconClick.bind(_assertThisInitialized(_this5));
+    _this5.memoized = {
       isActive: (0, _memoizeOne["default"])(ColumnSorterIcon.isActive)
     };
-    return _this4;
+    return _this5;
   }
   /**
    * Sorts column or opens/closes multisort menu
@@ -545,15 +545,15 @@ function (_React$PureComponent3) {
     key: "onIconClick",
     value: function onIconClick(e) {
       e.preventDefault();
-      var _this$props7 = this.props,
-          _this$props7$columnDe = _this$props7.columnDefinition,
-          field = _this$props7$columnDe.field,
-          _this$props7$columnDe2 = _this$props7$columnDe.sort_fields,
-          sort_fields = _this$props7$columnDe2 === void 0 ? [] : _this$props7$columnDe2,
-          _this$props7$showingS = _this$props7.showingSortOptionsMenu,
-          showingSortOptionsMenu = _this$props7$showingS === void 0 ? false : _this$props7$showingS,
-          setShowingSortFieldsFor = _this$props7.setShowingSortFieldsFor,
-          sortByField = _this$props7.sortByField;
+      var _this$props6 = this.props,
+          _this$props6$columnDe = _this$props6.columnDefinition,
+          field = _this$props6$columnDe.field,
+          _this$props6$columnDe2 = _this$props6$columnDe.sort_fields,
+          sort_fields = _this$props6$columnDe2 === void 0 ? [] : _this$props6$columnDe2,
+          _this$props6$showingS = _this$props6.showingSortOptionsMenu,
+          showingSortOptionsMenu = _this$props6$showingS === void 0 ? false : _this$props6$showingS,
+          setShowingSortFieldsFor = _this$props6.setShowingSortFieldsFor,
+          sortByField = _this$props6.sortByField;
 
       if (showingSortOptionsMenu) {
         // We're currently showing options for this col/icon; unset.
@@ -574,14 +574,14 @@ function (_React$PureComponent3) {
   }, {
     key: "render",
     value: function render() {
-      var _this$props8 = this.props,
-          columnDefinition = _this$props8.columnDefinition,
-          _this$props8$active = _this$props8.active,
-          active = _this$props8$active === void 0 ? null : _this$props8$active,
-          _this$props8$showingS = _this$props8.showingSortOptionsMenu,
-          showingSortOptionsMenu = _this$props8$showingS === void 0 ? false : _this$props8$showingS,
-          _this$props8$isLoadin = _this$props8.isLoading,
-          isLoading = _this$props8$isLoadin === void 0 ? false : _this$props8$isLoadin;
+      var _this$props7 = this.props,
+          columnDefinition = _this$props7.columnDefinition,
+          _this$props7$active = _this$props7.active,
+          active = _this$props7$active === void 0 ? null : _this$props7$active,
+          _this$props7$showingS = _this$props7.showingSortOptionsMenu,
+          showingSortOptionsMenu = _this$props7$showingS === void 0 ? false : _this$props7$showingS,
+          _this$props7$isLoadin = _this$props7.isLoading,
+          isLoading = _this$props7$isLoadin === void 0 ? false : _this$props7$isLoadin;
       var field = columnDefinition.field,
           _columnDefinition$sor = columnDefinition.sort_fields,
           sort_fields = _columnDefinition$sor === void 0 ? [] : _columnDefinition$sor;

--- a/es/components/browse/components/table-commons/HeadersRow.js
+++ b/es/components/browse/components/table-commons/HeadersRow.js
@@ -209,7 +209,10 @@ function (_React$PureComponent) {
         style: {
           'width': width || null // Only passed in from ItemPage
 
-        }
+        },
+        "data-showing-sort-fields-for": showingSortFieldsForColumn
+      }, _react["default"].createElement("div", {
+        className: "headers-columns-overflow-container"
       }, _react["default"].createElement("div", {
         className: "columns clearfix",
         style: {
@@ -224,7 +227,7 @@ function (_React$PureComponent) {
           width: _this3.getWidthFor(columnDefinition, index),
           key: columnDefinition.field
         }));
-      })));
+      }))));
     }
   }]);
 
@@ -340,11 +343,12 @@ function (_React$PureComponent2) {
         });
       }
 
+      var cls = "search-headers-column-block" + (noSort ? " no-sort" : '') + (field === showingSortFieldsForColumn ? " showing-sort-field-options" : "");
       return _react["default"].createElement("div", {
         "data-field": field,
         "data-column-key": field,
         key: field,
-        className: "search-headers-column-block" + (noSort ? " no-sort" : ''),
+        className: cls,
         style: {
           width: width
         }

--- a/es/components/browse/components/table-commons/HeadersRow.js
+++ b/es/components/browse/components/table-commons/HeadersRow.js
@@ -667,7 +667,8 @@ var SortOptionsMenuContainer = _react["default"].memo(function (props) {
     }
 
     return -1;
-  }, [columnDefinitions, showingSortFieldsForColumn]);
+  }, [columnDefinitions, showingSortFieldsForColumn]); // Position it under col for which open for in headers row.
+
   var widthUntilActiveColumnEnd = (0, _react.useMemo)(function () {
     var sumWidths = 0;
 
@@ -678,11 +679,11 @@ var SortOptionsMenuContainer = _react["default"].memo(function (props) {
     return sumWidths;
   }, [alignedWidths, activeColumnDefinitionIndex]);
   var activeColumnDefinition = columnDefinitions[activeColumnDefinitionIndex];
-  var sort_fields = activeColumnDefinition.sort_fields;
-  var style = {
-    left: Math.max(205, widthUntilActiveColumnEnd + leftOffset)
-  }; // Align it to col in headers row.
+  var sort_fields = activeColumnDefinition.sort_fields; // Account for scrollLeft of searchresults/header; 200 is min width for menu
 
+  var style = {
+    left: Math.max(200, widthUntilActiveColumnEnd + leftOffset)
+  };
   return _react["default"].createElement("div", {
     className: "headers-columns-dropdown-menu-container"
   }, _react["default"].createElement(SortOptionsMenu, {
@@ -695,7 +696,11 @@ var SortOptionsMenuContainer = _react["default"].memo(function (props) {
 });
 
 var SortOptionsMenu = _react["default"].memo(function (_ref7) {
-  var currentSortColumn = _ref7.currentSortColumn,
+  var _ref7$header = _ref7.header,
+      header = _ref7$header === void 0 ? _react["default"].createElement("h5", {
+    className: "dropdown-header mt-0 px-3 pt-03 text-600"
+  }, "Sort by") : _ref7$header,
+      currentSortColumn = _ref7.currentSortColumn,
       sort_fields = _ref7.sort_fields,
       sortByField = _ref7.sortByField,
       _ref7$descend = _ref7.descend,
@@ -721,7 +726,7 @@ var SortOptionsMenu = _react["default"].memo(function (_ref7) {
   return _react["default"].createElement("div", {
     className: "dropdown-menu show",
     style: style
-  }, options);
+  }, header, options);
 });
 
 var ColumnSorterIconElement = _react["default"].memo(function (_ref9) {

--- a/es/components/browse/components/table-commons/HeadersRow.js
+++ b/es/components/browse/components/table-commons/HeadersRow.js
@@ -400,29 +400,43 @@ function (_React$PureComponent3) {
 
     _this5 = _possibleConstructorReturn(this, _getPrototypeOf(ColumnSorterIcon).call(this, props));
     _this5.onIconClick = _this5.onIconClick.bind(_assertThisInitialized(_this5));
+    _this5.sortByField = _this5.sortByField.bind(_assertThisInitialized(_this5));
     _this5.memoized = {
       isActive: (0, _memoizeOne["default"])(ColumnSorterIcon.isActive)
+    };
+    _this5.state = {
+      isLoading: false
     };
     return _this5;
   }
 
   _createClass(ColumnSorterIcon, [{
+    key: "componentDidUpdate",
+    value: function componentDidUpdate(pastProps) {
+      var isLoading = this.state.isLoading;
+      if (!isLoading) return;
+      var _this$props6 = this.props,
+          currentSortColumn = _this$props6.currentSortColumn,
+          descend = _this$props6.descend;
+
+      if (currentSortColumn !== pastProps.currentSortColumn || descend !== pastProps.descend) {
+        this.setState({
+          isLoading: false
+        });
+      }
+    }
+  }, {
     key: "onIconClick",
     value: function onIconClick(e) {
       e.preventDefault();
-      var _this$props6 = this.props,
-          _this$props6$columnDe = _this$props6.columnDefinition,
-          field = _this$props6$columnDe.field,
-          _this$props6$columnDe2 = _this$props6$columnDe.sort_fields,
-          sort_fields = _this$props6$columnDe2 === void 0 ? [] : _this$props6$columnDe2,
-          _this$props6$descend = _this$props6.descend,
-          descend = _this$props6$descend === void 0 ? false : _this$props6$descend,
-          _this$props6$currentS = _this$props6.currentSortColumn,
-          currentSortColumn = _this$props6$currentS === void 0 ? null : _this$props6$currentS,
-          sortByFxn = _this$props6.sortByFxn,
-          _this$props6$showingS = _this$props6.showingSortFieldsForColumn,
-          showingSortFieldsForColumn = _this$props6$showingS === void 0 ? null : _this$props6$showingS,
-          setShowingSortFieldsFor = _this$props6.setShowingSortFieldsFor;
+      var _this$props7 = this.props,
+          _this$props7$columnDe = _this$props7.columnDefinition,
+          field = _this$props7$columnDe.field,
+          _this$props7$columnDe2 = _this$props7$columnDe.sort_fields,
+          sort_fields = _this$props7$columnDe2 === void 0 ? [] : _this$props7$columnDe2,
+          _this$props7$showingS = _this$props7.showingSortFieldsForColumn,
+          showingSortFieldsForColumn = _this$props7$showingS === void 0 ? null : _this$props7$showingS,
+          setShowingSortFieldsFor = _this$props7.setShowingSortFieldsFor;
 
       if (showingSortFieldsForColumn === field) {
         // We're currently showing options for this col/icon; unset.
@@ -438,23 +452,32 @@ function (_React$PureComponent3) {
       // Whether is a single item in sort_fields list or the field/key of column (if no sort_fields).
 
 
-      var useField = sort_fields[0] || field;
-      sortByFxn(useField, currentSortColumn !== useField || !descend && currentSortColumn === useField);
-
-      if (showingSortFieldsForColumn !== null) {
-        setShowingSortFieldsFor(null);
-      }
+      this.sortByField(sort_fields[0] || field);
+    }
+  }, {
+    key: "sortByField",
+    value: function sortByField(field) {
+      var _this$props8 = this.props,
+          descend = _this$props8.descend,
+          currentSortColumn = _this$props8.currentSortColumn,
+          sortByFxn = _this$props8.sortByFxn;
+      var isActive = currentSortColumn === field;
+      this.setState({
+        isLoading: true
+      }, function () {
+        sortByFxn(field, !isActive || isActive && !descend);
+      });
     }
   }, {
     key: "render",
     value: function render() {
-      var _this$props7 = this.props,
-          columnDefinition = _this$props7.columnDefinition,
-          descend = _this$props7.descend,
-          currentSortColumn = _this$props7.currentSortColumn,
-          sortByFxn = _this$props7.sortByFxn,
-          _this$props7$showingS = _this$props7.showingSortFieldsForColumn,
-          showingSortFieldsForColumn = _this$props7$showingS === void 0 ? null : _this$props7$showingS;
+      var _this$props9 = this.props,
+          columnDefinition = _this$props9.columnDefinition,
+          descend = _this$props9.descend,
+          currentSortColumn = _this$props9.currentSortColumn,
+          _this$props9$showingS = _this$props9.showingSortFieldsForColumn,
+          showingSortFieldsForColumn = _this$props9$showingS === void 0 ? null : _this$props9$showingS;
+      var isLoading = this.state.isLoading;
       var field = columnDefinition.field,
           _columnDefinition$sor2 = columnDefinition.sort_fields,
           sort_fields = _columnDefinition$sor2 === void 0 ? [] : _columnDefinition$sor2;
@@ -470,21 +493,24 @@ function (_React$PureComponent3) {
       var icon = _react["default"].createElement("span", {
         className: cls,
         onClick: this.onIconClick
-      }, _react["default"].createElement(ColumnSorterIconElement, {
-        descend: !isActive || descend,
+      }, _react["default"].createElement(ColumnSorterIconElement, _extends({
+        isLoading: isLoading,
         isShowingSortFields: isShowingSortFields
-      }));
+      }, {
+        descend: !isActive || descend
+      })));
 
       if (!isShowingSortFields) {
         return icon;
       }
 
-      return _react["default"].createElement(_react["default"].Fragment, null, icon, _react["default"].createElement(SortOptionsMenu, {
+      return _react["default"].createElement(_react["default"].Fragment, null, icon, _react["default"].createElement(SortOptionsMenu, _extends({
         currentSortColumn: currentSortColumn,
         sort_fields: sort_fields,
-        sortByFxn: sortByFxn,
         descend: descend
-      }));
+      }, {
+        sortByField: this.sortByField
+      })));
     }
   }]);
 
@@ -507,7 +533,7 @@ _defineProperty(ColumnSorterIcon, "defaultProps", {
 var SortOptionsMenu = _react["default"].memo(function (_ref3) {
   var currentSortColumn = _ref3.currentSortColumn,
       sort_fields = _ref3.sort_fields,
-      sortByFxn = _ref3.sortByFxn,
+      sortByField = _ref3.sortByField,
       _ref3$descend = _ref3.descend,
       descend = _ref3$descend === void 0 ? false : _ref3$descend;
   var options = sort_fields.map(function (_ref4) {
@@ -516,16 +542,15 @@ var SortOptionsMenu = _react["default"].memo(function (_ref3) {
         title = _ref4$title === void 0 ? null : _ref4$title;
     // TODO grab title from schemas if not provided.
     var isActive = currentSortColumn === field;
-    var cls = "dropdown-item" + (isActive ? " active" : "");
-    return _react["default"].createElement("a", {
+    var cls = "dropdown-item clickable" + (isActive ? " active" : "");
+    var onClick = sortByField.bind(sortByField, field);
+    return _react["default"].createElement("div", {
       className: cls,
-      href: "#",
       key: field,
-      onClick: function onMenuItemClick(evt) {
-        evt.preventDefault();
-        sortByFxn(field, !isActive || !descend && isActive);
-      }
-    }, title || field);
+      onClick: onClick
+    }, title || field, !isActive ? null : _react["default"].createElement("i", {
+      className: "icon fas ml-1 icon-angle-".concat(descend ? "down" : "up")
+    }));
   });
   return _react["default"].createElement("div", {
     className: "dropdown-menu dropdown-menu-right show"
@@ -534,7 +559,15 @@ var SortOptionsMenu = _react["default"].memo(function (_ref3) {
 
 var ColumnSorterIconElement = _react["default"].memo(function (_ref5) {
   var descend = _ref5.descend,
-      isShowingSortFields = _ref5.isShowingSortFields;
+      isShowingSortFields = _ref5.isShowingSortFields,
+      _ref5$isLoading = _ref5.isLoading,
+      isLoading = _ref5$isLoading === void 0 ? false : _ref5$isLoading;
+
+  if (isLoading) {
+    return _react["default"].createElement("i", {
+      className: "icon icon-fw icon-circle-o-notch icon-spin fas"
+    });
+  }
 
   if (isShowingSortFields) {
     return _react["default"].createElement("i", {

--- a/es/components/browse/components/table-commons/HeadersRow.js
+++ b/es/components/browse/components/table-commons/HeadersRow.js
@@ -326,7 +326,7 @@ function (_React$PureComponent2) {
           _columnDefinition$des = columnDefinition.description,
           description = _columnDefinition$des === void 0 ? null : _columnDefinition$des;
       var titleTooltip = this.memoized.showTooltip(width, typeof colTitle === "string" ? colTitle : title) ? title : null;
-      var tooltip = description ? titleTooltip ? "<h5 class=\"mt-0 mb-03\">".concat(titleTooltip, "</h5>") + description : description : titleTooltip ? titleTooltip : null;
+      var tooltip = description ? titleTooltip ? "<h5 class=\"mb-03\">".concat(titleTooltip, "</h5>") + description : description : titleTooltip ? titleTooltip : null;
       var sorterIcon;
 
       if (!noSort && typeof sortByFxn === 'function' && width >= 50) {
@@ -344,16 +344,18 @@ function (_React$PureComponent2) {
         "data-field": field,
         "data-column-key": field,
         key: field,
-        "data-tip": tooltip,
         className: "search-headers-column-block" + (noSort ? " no-sort" : ''),
         style: {
           width: width
         }
       }, _react["default"].createElement("div", {
         className: "inner"
-      }, _react["default"].createElement("span", {
+      }, _react["default"].createElement("div", {
         className: "column-title"
-      }, colTitle || title), sorterIcon), columnWidths && typeof onAdjusterDrag === "function" ? _react["default"].createElement(_reactDraggable["default"], {
+      }, _react["default"].createElement("span", {
+        "data-tip": tooltip,
+        "data-html": true
+      }, colTitle || title)), sorterIcon), columnWidths && typeof onAdjusterDrag === "function" ? _react["default"].createElement(_reactDraggable["default"], {
         position: {
           x: width,
           y: 0
@@ -503,15 +505,30 @@ function (_React$PureComponent3) {
       }
 
       var isActive = this.memoized.isActive(columnDefinition, currentSortColumn);
+      var hasMultipleSortOptions = sort_fields.length >= 2;
       var isShowingSortFields = showingSortFieldsForColumn === field;
-      var cls = (isActive ? 'active ' : '') + (sort_fields.length >= 2 ? 'multiple-sort-options ' : '') + 'column-sort-icon';
+      var cls = (isActive ? 'active ' : '') + (hasMultipleSortOptions ? 'multiple-sort-options ' : '') + 'column-sort-icon';
+      var tooltip = null;
+
+      if (isShowingSortFields) {
+        tooltip = "Close sort options";
+      } else if (hasMultipleSortOptions && isActive) {
+        var sortedBy = sort_fields.find(function (_ref3) {
+          var f = _ref3.field;
+          return f === currentSortColumn;
+        });
+        tooltip = sortedBy ? "Sorted by <span class=\"text-600\">".concat(sortedBy.title || sortedBy.field, "</span>") : null;
+      }
 
       var icon = _react["default"].createElement("span", {
         className: cls,
-        onClick: this.onIconClick
+        onClick: this.onIconClick,
+        "data-tip": tooltip,
+        "data-html": true
       }, _react["default"].createElement(ColumnSorterIconElement, _extends({
         isLoading: isLoading,
-        isShowingSortFields: isShowingSortFields
+        isShowingSortFields: isShowingSortFields,
+        hasMultipleSortOptions: hasMultipleSortOptions
       }, {
         descend: !isActive || descend
       })));
@@ -546,26 +563,26 @@ _defineProperty(ColumnSorterIcon, "defaultProps", {
   'descend': false
 });
 
-var SortOptionsMenu = _react["default"].memo(function (_ref3) {
-  var currentSortColumn = _ref3.currentSortColumn,
-      sort_fields = _ref3.sort_fields,
-      sortByField = _ref3.sortByField,
-      _ref3$descend = _ref3.descend,
-      descend = _ref3$descend === void 0 ? false : _ref3$descend;
-  var options = sort_fields.map(function (_ref4) {
-    var field = _ref4.field,
-        _ref4$title = _ref4.title,
-        title = _ref4$title === void 0 ? null : _ref4$title;
+var SortOptionsMenu = _react["default"].memo(function (_ref4) {
+  var currentSortColumn = _ref4.currentSortColumn,
+      sort_fields = _ref4.sort_fields,
+      sortByField = _ref4.sortByField,
+      _ref4$descend = _ref4.descend,
+      descend = _ref4$descend === void 0 ? false : _ref4$descend;
+  var options = sort_fields.map(function (_ref5) {
+    var field = _ref5.field,
+        _ref5$title = _ref5.title,
+        title = _ref5$title === void 0 ? null : _ref5$title;
     // TODO grab title from schemas if not provided.
     var isActive = currentSortColumn === field;
-    var cls = "dropdown-item clickable no-highlight d-flex align-items-center justify-content-between" + (isActive ? " active" : "");
+    var cls = "dropdown-item" + " clickable no-highlight no-user-select" + " d-flex align-items-center justify-content-between" + (isActive ? " active" : "");
     var onClick = sortByField.bind(sortByField, field);
     return _react["default"].createElement("div", {
       className: cls,
       key: field,
       onClick: onClick
     }, title || field, !isActive ? null : _react["default"].createElement("i", {
-      className: "icon fas ml-12 icon-angle-".concat(descend ? "down" : "up")
+      className: "small icon fas ml-12 icon-arrow-".concat(descend ? "down" : "up")
     }));
   });
   return _react["default"].createElement("div", {
@@ -573,11 +590,11 @@ var SortOptionsMenu = _react["default"].memo(function (_ref3) {
   }, options);
 });
 
-var ColumnSorterIconElement = _react["default"].memo(function (_ref5) {
-  var descend = _ref5.descend,
-      isShowingSortFields = _ref5.isShowingSortFields,
-      _ref5$isLoading = _ref5.isLoading,
-      isLoading = _ref5$isLoading === void 0 ? false : _ref5$isLoading;
+var ColumnSorterIconElement = _react["default"].memo(function (_ref6) {
+  var descend = _ref6.descend,
+      isShowingSortFields = _ref6.isShowingSortFields,
+      _ref6$isLoading = _ref6.isLoading,
+      isLoading = _ref6$isLoading === void 0 ? false : _ref6$isLoading;
 
   if (isLoading) {
     return _react["default"].createElement("i", {
@@ -587,17 +604,17 @@ var ColumnSorterIconElement = _react["default"].memo(function (_ref5) {
 
   if (isShowingSortFields) {
     return _react["default"].createElement("i", {
-      className: "icon icon-fw icon-times-circle far"
+      className: "icon icon-fw icon-times fas"
     });
   }
 
   if (descend) {
     return _react["default"].createElement("i", {
-      className: "sort-icon icon icon-fw icon-angle-down fas"
+      className: "sort-icon icon icon-fw icon-arrow-down fas"
     });
   } else {
     return _react["default"].createElement("i", {
-      className: "sort-icon icon icon-fw icon-angle-up fas"
+      className: "sort-icon icon icon-fw icon-arrow-up fas"
     });
   }
 });

--- a/es/components/browse/components/table-commons/HeadersRow.js
+++ b/es/components/browse/components/table-commons/HeadersRow.js
@@ -322,8 +322,11 @@ function (_React$PureComponent2) {
       var noSort = columnDefinition.noSort,
           colTitle = columnDefinition.colTitle,
           title = columnDefinition.title,
-          field = columnDefinition.field;
-      var tooltip = this.memoized.showTooltip(width, typeof colTitle === "string" ? colTitle : title) ? title : null;
+          field = columnDefinition.field,
+          _columnDefinition$des = columnDefinition.description,
+          description = _columnDefinition$des === void 0 ? null : _columnDefinition$des;
+      var titleTooltip = this.memoized.showTooltip(width, typeof colTitle === "string" ? colTitle : title) ? title : null;
+      var tooltip = description ? titleTooltip ? "<h5 class=\"mt-0 mb-03\">".concat(titleTooltip, "</h5>") + description : description : titleTooltip ? titleTooltip : null;
       var sorterIcon;
 
       if (!noSort && typeof sortByFxn === 'function' && width >= 50) {
@@ -425,6 +428,13 @@ function (_React$PureComponent3) {
         });
       }
     }
+    /**
+     * Sorts column or opens/closes multisort menu
+     * if multiple options.
+     *
+     * @param {React.SyntheticEvent} e - Click event object.
+     */
+
   }, {
     key: "onIconClick",
     value: function onIconClick(e) {
@@ -454,6 +464,12 @@ function (_React$PureComponent3) {
 
       this.sortByField(sort_fields[0] || field);
     }
+    /**
+     * Determines direction of next sort (descending vs ascending) and sets
+     * `state.isLoading` to true (to be unset by `componentDidUpdate`)
+     * before calling `props.sortByFxn`.
+     */
+
   }, {
     key: "sortByField",
     value: function sortByField(field) {
@@ -542,14 +558,14 @@ var SortOptionsMenu = _react["default"].memo(function (_ref3) {
         title = _ref4$title === void 0 ? null : _ref4$title;
     // TODO grab title from schemas if not provided.
     var isActive = currentSortColumn === field;
-    var cls = "dropdown-item clickable" + (isActive ? " active" : "");
+    var cls = "dropdown-item clickable no-highlight d-flex align-items-center justify-content-between" + (isActive ? " active" : "");
     var onClick = sortByField.bind(sortByField, field);
     return _react["default"].createElement("div", {
       className: cls,
       key: field,
       onClick: onClick
     }, title || field, !isActive ? null : _react["default"].createElement("i", {
-      className: "icon fas ml-1 icon-angle-".concat(descend ? "down" : "up")
+      className: "icon fas ml-12 icon-angle-".concat(descend ? "down" : "up")
     }));
   });
   return _react["default"].createElement("div", {

--- a/es/components/browse/components/table-commons/ResultRowColumnBlockValue.js
+++ b/es/components/browse/components/table-commons/ResultRowColumnBlockValue.js
@@ -148,7 +148,7 @@ function (_React$Component) {
       var field = columnDefinition.field,
           _columnDefinition$ren = columnDefinition.render,
           renderFxn = _columnDefinition$ren === void 0 ? null : _columnDefinition$ren;
-      var value = renderFxn ? renderFxn(result, _underscore["default"].omit(this.props, 'columnDefinition', 'result')) : this.memoized.transformIfNeeded(result, field, termTransformFxn); // Simple fallback transformation to unique arrays
+      var value = renderFxn ? renderFxn(result, _underscore["default"].omit(this.props, 'result')) : this.memoized.transformIfNeeded(result, field, termTransformFxn); // Simple fallback transformation to unique arrays
       // Wrap `value` in a span (provides ellipsis, etc) if is primitive (not custom render fxn output)
       // Could prly make this less verbose later.. we _do_ want to wrap primitive values output from custom render fxn.
 

--- a/es/components/browse/components/table-commons/ResultRowColumnBlockValue.js
+++ b/es/components/browse/components/table-commons/ResultRowColumnBlockValue.js
@@ -137,7 +137,9 @@ function (_React$Component) {
           className = _this$props2.className,
           termTransformFxn = _this$props2.termTransformFxn;
       var renderFxn = columnDefinition.render || this.memoized.transformIfNeeded;
-      var value = sanitizeOutputValue(renderFxn(result, columnDefinition, _underscore["default"].omit(this.props, 'columnDefinition', 'result'), termTransformFxn));
+      var value = sanitizeOutputValue(renderFxn(result, columnDefinition, _underscore["default"].omit(this.props, 'columnDefinition', 'result'), termTransformFxn)); // Wrap `value` in a span (provides ellipsis, etc) if is primitive (not custom render fxn output)
+      // Could prly make this less verbose later.. we _do_ want to wrap primitive values output from custom render fxn.
+
       var tooltip;
 
       if (typeof value === 'number') {
@@ -147,19 +149,28 @@ function (_React$Component) {
       } else if (typeof value === 'string') {
         if (propTooltip === true && value.length > 25) tooltip = value;
         value = _react["default"].createElement("span", {
-          className: "value"
+          className: "value text-center"
         }, value);
       } else if (value === null) {
         value = _react["default"].createElement("small", {
-          className: "value"
+          className: "value text-center"
         }, "-");
       } else if (_react["default"].isValidElement(value) && value.type === "a") {
         // We let other columnRender funcs define their `value` container (if any)
         // But if is link, e.g. from termTransformFxn, then wrap it to center it.
         value = _react["default"].createElement("span", {
-          className: "value"
+          className: "value text-center"
         }, value);
-      }
+      } else if (typeof value === "boolean") {
+        value = _react["default"].createElement("span", {
+          className: "value text-center"
+        }, value);
+      } else if (renderFxn === this.memoized.transformIfNeeded) {
+        value = _react["default"].createElement("span", {
+          className: "value"
+        }, value); // JSX from termTransformFxn - assume doesn't take table cell layouting into account.
+      } // else is likely JSX from custom render function -- leave as-is
+
 
       var cls = "inner";
 

--- a/es/components/browse/components/table-commons/ResultRowColumnBlockValue.js
+++ b/es/components/browse/components/table-commons/ResultRowColumnBlockValue.js
@@ -18,6 +18,14 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "d
 
 function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function (obj) { return typeof obj; }; } else { _typeof = function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
+function _toConsumableArray(arr) { return _arrayWithoutHoles(arr) || _iterableToArray(arr) || _nonIterableSpread(); }
+
+function _nonIterableSpread() { throw new TypeError("Invalid attempt to spread non-iterable instance"); }
+
+function _iterableToArray(iter) { if (Symbol.iterator in Object(iter) || Object.prototype.toString.call(iter) === "[object Arguments]") return Array.from(iter); }
+
+function _arrayWithoutHoles(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = new Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } }
+
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
@@ -53,49 +61,50 @@ function (_React$Component) {
      * Default value rendering function. Fallback when no `render` func defined in columnDefinition.
      * Uses columnDefinition field (column key) to get nested property value from result and display it.
      *
+     * @todo Maybe use Sets if more performant.
      * @param {Item} result - JSON object representing row data.
-     * @param {ColumnDefinition} columnDefinition - Object with column definition data - field, title, widthMap, render function (self)
-     * @param {Object} props - Props passed down from SearchResultTable/ResultRowColumnBlock instance.
-     * @param {number} width - Unused. Todo - remove?
+     * @param {string} field - Field for which this value is for.
+     * @param {function} termTransformFxn - Transform value(s)
      * @returns {string|null} String value or null. Your function may return a React element, as well.
      */
-    value: function transformIfNeeded(result, columnDefinition, props, termTransformFxn) {
-      function filterAndUniq(vals) {
-        return _underscore["default"].uniq(_underscore["default"].filter(vals, function (v) {
-          return v !== null && typeof v !== 'undefined';
-        }));
+    value: function transformIfNeeded(result, field, termTransformFxn) {
+      function flattenSet(valArr) {
+        var uniqSet = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : null;
+        uniqSet = uniqSet || new Set();
+
+        if (Array.isArray(valArr)) {
+          for (var i = 0; i < valArr.length; i++) {
+            flattenSet(valArr[i], uniqSet);
+          }
+
+          return uniqSet;
+        } // Else is single value (not array) -
+
+
+        if (valArr !== null && typeof valArr !== 'undefined') {
+          uniqSet.add(valArr);
+        }
+
+        return uniqSet;
       }
 
-      var value = (0, _object.getNestedProperty)(result, columnDefinition.field, true);
-      if (typeof value === "undefined") value = null;
+      var uniquedValues = _toConsumableArray(flattenSet((0, _object.getNestedProperty)(result, field, true)));
 
-      if (Array.isArray(value)) {
-        // getNestedProperty may return a multidimensional array, # of dimennsions depending on how many child arrays were encountered in original result obj.
-        value = filterAndUniq(value.map(function (v) {
-          if (Array.isArray(v)) {
-            v = filterAndUniq(v);
-            if (v.length === 1) v = v[0];
-            if (v.length === 0) v = null;
-          }
+      var uniquedValuesLen = uniquedValues.length; // No value found - let it default to 'null' and be handled as such
 
-          if (typeof termTransformFxn === 'function') {
-            return termTransformFxn(columnDefinition.field, v, false);
-          }
-
-          console.warn("No termTransformFxn supplied.");
-          return v;
-        })).map(function (v) {
-          if (typeof termTransformFxn === 'function') {
-            return termTransformFxn(columnDefinition.field, v, false);
-          }
-
-          return v;
-        }).join(', ');
-      } else if (typeof termTransformFxn === 'function') {
-        value = termTransformFxn(columnDefinition.field, value, true);
+      if (uniquedValuesLen === 0) {
+        // All null or undefined.
+        return null;
       }
 
-      return value;
+      if (typeof termTransformFxn === "function") {
+        return uniquedValues.map(function (v) {
+          return termTransformFxn(field, v, false);
+        }).join(', '); // Most often will be just 1 value in set/array.
+      } else {
+        console.warn("No termTransformFxn supplied.");
+        return uniquedValues.join(', ');
+      }
     }
   }]);
 
@@ -136,8 +145,11 @@ function (_React$Component) {
           propTooltip = _this$props2.tooltip,
           className = _this$props2.className,
           termTransformFxn = _this$props2.termTransformFxn;
-      var renderFxn = columnDefinition.render || this.memoized.transformIfNeeded;
-      var value = sanitizeOutputValue(renderFxn(result, columnDefinition, _underscore["default"].omit(this.props, 'columnDefinition', 'result'), termTransformFxn)); // Wrap `value` in a span (provides ellipsis, etc) if is primitive (not custom render fxn output)
+      var field = columnDefinition.field,
+          _columnDefinition$ren = columnDefinition.render,
+          renderFxn = _columnDefinition$ren === void 0 ? null : _columnDefinition$ren;
+      var value = renderFxn ? renderFxn(result, _underscore["default"].omit(this.props, 'columnDefinition', 'result')) : this.memoized.transformIfNeeded(result, field, termTransformFxn); // Simple fallback transformation to unique arrays
+      // Wrap `value` in a span (provides ellipsis, etc) if is primitive (not custom render fxn output)
       // Could prly make this less verbose later.. we _do_ want to wrap primitive values output from custom render fxn.
 
       var tooltip;
@@ -165,7 +177,7 @@ function (_React$Component) {
         value = _react["default"].createElement("span", {
           className: "value text-center"
         }, value);
-      } else if (renderFxn === this.memoized.transformIfNeeded) {
+      } else if (!renderFxn) {
         value = _react["default"].createElement("span", {
           className: "value"
         }, value); // JSX from termTransformFxn - assume doesn't take table cell layouting into account.

--- a/es/components/browse/components/table-commons/basicColumnExtensionMap.js
+++ b/es/components/browse/components/table-commons/basicColumnExtensionMap.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.TableRowToggleOpenButton = exports.DisplayTitleColumn = exports.basicColumnExtensionMap = exports.DEFAULT_WIDTH_MAP = void 0;
+exports.TableRowToggleOpenButton = exports.DisplayTitleColumnWrapper = exports.DisplayTitleColumnDefault = exports.DisplayTitleColumnUser = exports.basicColumnExtensionMap = exports.DEFAULT_WIDTH_MAP = void 0;
 
 var _react = _interopRequireWildcard(require("react"));
 
@@ -33,8 +33,6 @@ function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { va
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
-function _extends() { _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
-
 var DEFAULT_WIDTH_MAP = {
   'lg': 200,
   'md': 180,
@@ -53,9 +51,33 @@ var basicColumnExtensionMap = {
     'minColumnWidth': 90,
     'order': -100,
     'render': function (result, parentProps) {
-      return _react["default"].createElement(DisplayTitleColumn, _extends({}, parentProps, {
-        result: result
-      }));
+      var href = parentProps.href,
+          context = parentProps.context,
+          rowNumber = parentProps.rowNumber,
+          detailOpen = parentProps.detailOpen,
+          toggleDetailOpen = parentProps.toggleDetailOpen;
+      var _result$Type = result['@type'],
+          itemTypeList = _result$Type === void 0 ? ["Item"] : _result$Type;
+      var renderElem;
+
+      if (itemTypeList[0] === "User") {
+        renderElem = _react["default"].createElement(DisplayTitleColumnUser, {
+          result: result
+        });
+      } else {
+        renderElem = _react["default"].createElement(DisplayTitleColumnDefault, {
+          result: result
+        });
+      }
+
+      return _react["default"].createElement(DisplayTitleColumnWrapper, {
+        result: result,
+        href: href,
+        context: context,
+        rowNumber: rowNumber,
+        detailOpen: detailOpen,
+        toggleDetailOpen: toggleDetailOpen
+      }, renderElem);
     }
   },
   '@type': {
@@ -143,6 +165,47 @@ var basicColumnExtensionMap = {
     'order': 515
   }
 };
+exports.basicColumnExtensionMap = basicColumnExtensionMap;
+
+var DisplayTitleColumnUser = _react["default"].memo(function (_ref) {
+  var result = _ref.result,
+      link = _ref.link,
+      onClick = _ref.onClick;
+  var _result$email = result.email,
+      email = _result$email === void 0 ? null : _result$email; // `href` and `context` reliably refer to search href and context here, i.e. will be passed in from VirtualHrefController.
+
+  var title = _object.itemUtil.getTitleStringFromContext(result); // Gets display_title || title || accession || ...
+
+
+  var tooltip = typeof title === "string" && title.length > 20 && title || null;
+  var hasPhoto = false;
+
+  if (link) {
+    // This should be the case always
+    title = _react["default"].createElement("a", {
+      key: "title",
+      href: link || '#',
+      onClick: onClick
+    }, title);
+
+    if (typeof email === 'string' && email.indexOf('@') > -1) {
+      // Specific case for User items. May be removed or more cases added, if needed.
+      hasPhoto = true;
+      title = _react["default"].createElement(_react["default"].Fragment, null, _object.itemUtil.User.gravatar(email, 32, {
+        'className': 'in-search-table-title-image',
+        'data-tip': email
+      }, 'mm'), title);
+    }
+  }
+
+  var cls = "title-block" + (hasPhoto ? " has-photo d-flex align-items-center" : " text-ellipsis-container");
+  return _react["default"].createElement("div", {
+    key: "title-container",
+    className: cls,
+    "data-tip": tooltip,
+    "data-delay-show": 750
+  }, title);
+});
 /**
  * @todo
  * Think about how to more easily customize this for different Item types.
@@ -151,30 +214,53 @@ var basicColumnExtensionMap = {
  * overrides/extensions.
  */
 
-exports.basicColumnExtensionMap = basicColumnExtensionMap;
 
-var DisplayTitleColumn = _react["default"].memo(function (props) {
-  var result = props.result,
-      columnDefinition = props.columnDefinition,
-      termTransformFxn = props.termTransformFxn,
-      width = props.width,
-      href = props.href,
-      context = props.context,
-      rowNumber = props.rowNumber,
-      detailOpen = props.detailOpen,
-      toggleDetailOpen = props.toggleDetailOpen; // `href` and `context` reliably refer to search href and context here, i.e. will be passed in from VirtualHrefController.
+exports.DisplayTitleColumnUser = DisplayTitleColumnUser;
+
+var DisplayTitleColumnDefault = _react["default"].memo(function (_ref2) {
+  var result = _ref2.result,
+      link = _ref2.link,
+      onClick = _ref2.onClick;
 
   var title = _object.itemUtil.getTitleStringFromContext(result); // Gets display_title || title || accession || ...
   // Monospace accessions, file formats
 
 
   var shouldMonospace = _object.itemUtil.isDisplayTitleAccession(result, title) || result.file_format && result.file_format === title;
+  var tooltip = typeof title === "string" && title.length > 20 && title || null;
+
+  if (link) {
+    // This should be the case always
+    title = _react["default"].createElement("a", {
+      key: "title",
+      href: link || '#',
+      onClick: onClick
+    }, title);
+  }
+
+  var cls = "title-block text-ellipsis-container" + (shouldMonospace ? " text-monospace text-small" : "");
+  return _react["default"].createElement("div", {
+    key: "title-container",
+    className: cls,
+    "data-tip": tooltip,
+    "data-delay-show": 750
+  }, title);
+});
+
+exports.DisplayTitleColumnDefault = DisplayTitleColumnDefault;
+
+var DisplayTitleColumnWrapper = _react["default"].memo(function (props) {
+  var result = props.result,
+      children = props.children,
+      href = props.href,
+      context = props.context,
+      rowNumber = props.rowNumber,
+      detailOpen = props.detailOpen,
+      toggleDetailOpen = props.toggleDetailOpen;
 
   var link = _object.itemUtil.atId(result);
-
-  var tooltip = title && (title.length > 20 || width < 100) && title || null;
-  var hasPhoto = false;
   /** Registers a list click event for Google Analytics then performs navigation. */
+
 
   var onClick = (0, _react.useMemo)(function () {
     return function (evt) {
@@ -192,43 +278,27 @@ var DisplayTitleColumn = _react["default"].memo(function (props) {
     };
   }, [link, rowNumber]);
 
-  if (link) {
-    // This should be the case always
-    title = _react["default"].createElement("a", {
-      key: "title",
-      href: link || '#',
+  var renderChildren = _react["default"].Children.map(children, function (child) {
+    return _react["default"].cloneElement(child, {
+      link: link,
       onClick: onClick
-    }, title);
+    });
+  });
 
-    if (typeof result.email === 'string' && result.email.indexOf('@') > -1) {
-      // Specific case for User items. May be removed or more cases added, if needed.
-      hasPhoto = true;
-      title = _react["default"].createElement(_react["default"].Fragment, null, _object.itemUtil.User.gravatar(result.email, 32, {
-        'className': 'in-search-table-title-image',
-        'data-tip': result.email
-      }, 'mm'), title);
-    }
-  }
-
-  var cls = "title-block" + (hasPhoto ? " has-photo d-flex align-items-center" : " text-ellipsis-container") + (shouldMonospace ? " text-monospace text-small" : "");
   return _react["default"].createElement(_react["default"].Fragment, null, _react["default"].createElement(TableRowToggleOpenButton, {
     open: detailOpen,
     onClick: toggleDetailOpen
-  }), _react["default"].createElement("div", {
-    key: "title-container",
-    className: cls,
-    "data-tip": tooltip
-  }, title));
+  }), renderChildren);
 });
 /** Button shown in first column (display_title) to open/close detail pane. */
 
 
-exports.DisplayTitleColumn = DisplayTitleColumn;
+exports.DisplayTitleColumnWrapper = DisplayTitleColumnWrapper;
 
-var TableRowToggleOpenButton = _react["default"].memo(function (_ref) {
-  var onClick = _ref.onClick,
-      toggleDetailOpen = _ref.toggleDetailOpen,
-      open = _ref.open;
+var TableRowToggleOpenButton = _react["default"].memo(function (_ref3) {
+  var onClick = _ref3.onClick,
+      toggleDetailOpen = _ref3.toggleDetailOpen,
+      open = _ref3.open;
   return _react["default"].createElement("div", {
     className: "toggle-detail-button-container"
   }, _react["default"].createElement("button", {

--- a/es/components/browse/components/table-commons/basicColumnExtensionMap.js
+++ b/es/components/browse/components/table-commons/basicColumnExtensionMap.js
@@ -47,6 +47,10 @@ var basicColumnExtensionMap = {
     'minColumnWidth': 90,
     'order': -100,
     'render': function (result, columnDefinition, props, termTransformFxn, width) {
+      // TODO think about how to more easily customize this for different Item types.
+      // Likely make reusable component containing handleClick and most of its UI...
+      // which this and portals can use for "display_title" column, and then have per-type
+      // overrides/extensions.
       var href = props.href,
           context = props.context,
           rowNumber = props.rowNumber,

--- a/es/components/browse/components/table-commons/basicColumnExtensionMap.js
+++ b/es/components/browse/components/table-commons/basicColumnExtensionMap.js
@@ -3,9 +3,9 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.TableRowToggleOpenButton = exports.basicColumnExtensionMap = exports.DEFAULT_WIDTH_MAP = void 0;
+exports.TableRowToggleOpenButton = exports.DisplayTitleColumn = exports.basicColumnExtensionMap = exports.DEFAULT_WIDTH_MAP = void 0;
 
-var _react = _interopRequireDefault(require("react"));
+var _react = _interopRequireWildcard(require("react"));
 
 var _url = _interopRequireDefault(require("url"));
 
@@ -23,11 +23,17 @@ var _LocalizedTime = require("./../../../ui/LocalizedTime");
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
+function _getRequireWildcardCache() { if (typeof WeakMap !== "function") return null; var cache = new WeakMap(); _getRequireWildcardCache = function _getRequireWildcardCache() { return cache; }; return cache; }
+
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } var cache = _getRequireWildcardCache(); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; if (obj != null) { var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj["default"] = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
+
 function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
 
 function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(source, true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(source).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+function _extends() { _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
 
 var DEFAULT_WIDTH_MAP = {
   'lg': 200,
@@ -46,91 +52,36 @@ var basicColumnExtensionMap = {
     },
     'minColumnWidth': 90,
     'order': -100,
-    'render': function (result, columnDefinition, props, termTransformFxn, width) {
-      // TODO think about how to more easily customize this for different Item types.
-      // Likely make reusable component containing handleClick and most of its UI...
-      // which this and portals can use for "display_title" column, and then have per-type
-      // overrides/extensions.
-      var href = props.href,
-          context = props.context,
-          rowNumber = props.rowNumber,
-          detailOpen = props.detailOpen,
-          toggleDetailOpen = props.toggleDetailOpen; // `href` and `context` reliably refer to search href and context here, i.e. will be passed in from VirtualHrefController.
-
-      var title = _object.itemUtil.getTitleStringFromContext(result); // Monospace accessions, file formats
-
-
-      var shouldMonospace = _object.itemUtil.isDisplayTitleAccession(result, title) || result.file_format && result.file_format === title;
-
-      var link = _object.itemUtil.atId(result);
-
-      var tooltip;
-      var hasPhoto = false;
-      /** Registers a list click event for Google Analytics then performs navigation. */
-
-      function handleClick(evt) {
-        evt.preventDefault();
-        evt.stopPropagation();
-        (0, _analytics.productClick)(result, {
-          list: (0, _analytics.hrefToListName)(href),
-          position: rowNumber + 1
-        }, function () {
-          // We explicitly use globalPageNavigate here and not props.navigate, as props.navigate might refer
-          // to VirtualHrefController.virtualNavigate and would not bring you to new page.
-          (0, _navigate.navigate)(link);
-        }, context);
-        return false;
-      }
-
-      if (title && (title.length > 20 || width < 100)) tooltip = title;
-
-      if (link) {
-        // This should be the case always
-        title = _react["default"].createElement("a", {
-          key: "title",
-          href: link || '#',
-          onClick: handleClick
-        }, title);
-
-        if (typeof result.email === 'string' && result.email.indexOf('@') > -1) {
-          // Specific case for User items. May be removed or more cases added, if needed.
-          hasPhoto = true;
-          title = _react["default"].createElement(_react["default"].Fragment, null, _object.itemUtil.User.gravatar(result.email, 32, {
-            'className': 'in-search-table-title-image',
-            'data-tip': result.email
-          }, 'mm'), title);
-        }
-      }
-
-      var cls = "title-block" + (hasPhoto ? " has-photo d-flex align-items-center" : " text-ellipsis-container") + (shouldMonospace ? " text-monospace text-small" : "");
-      return _react["default"].createElement(_react["default"].Fragment, null, _react["default"].createElement(TableRowToggleOpenButton, {
-        open: detailOpen,
-        onClick: toggleDetailOpen
-      }), _react["default"].createElement("div", {
-        key: "title-container",
-        className: cls,
-        "data-tip": tooltip
-      }, title));
+    'render': function (result, parentProps) {
+      return _react["default"].createElement(DisplayTitleColumn, _extends({}, parentProps, {
+        result: result
+      }));
     }
   },
   '@type': {
     'noSort': true,
     'order': -80,
-    'render': function render(result, columnDefinition, props) {
+    'render': function render(result, props) {
       if (!Array.isArray(result['@type'])) return null;
+      var _props$schemas = props.schemas,
+          schemas = _props$schemas === void 0 ? null : _props$schemas,
+          _props$href = props.href,
+          href = _props$href === void 0 ? null : _props$href,
+          _props$navigate = props.navigate,
+          propNavigate = _props$navigate === void 0 ? null : _props$navigate;
       var leafItemType = (0, _schemaTransforms.getItemType)(result);
-      var itemTypeTitle = (0, _schemaTransforms.getTitleForType)(leafItemType, props.schemas || null);
+      var itemTypeTitle = (0, _schemaTransforms.getTitleForType)(leafItemType, schemas);
       return _react["default"].createElement(_react["default"].Fragment, null, _react["default"].createElement("div", {
         className: "icon-container"
       }, _react["default"].createElement("i", {
         className: "icon icon-fw fas icon-filter clickable mr-08",
         onClick: function onClick(e) {
           // Preserve search query, if any, but remove filters (which are usually per-type).
-          if (!props.href || props.href.indexOf('/search/') === -1) return;
+          if (!href || href.indexOf('/search/') === -1) return;
           e.preventDefault();
           e.stopPropagation();
 
-          var urlParts = _url["default"].parse(props.href, true);
+          var urlParts = _url["default"].parse(href, true);
 
           var query = _objectSpread({}, urlParts.query, {
             'type': leafItemType
@@ -142,7 +93,7 @@ var basicColumnExtensionMap = {
           // since we're navigating to a search href here.
 
 
-          (props.navigate || _navigate.navigate)(nextHref);
+          (propNavigate || _navigate.navigate)(nextHref);
         },
         "data-tip": "Filter down to only " + itemTypeTitle
       })), _react["default"].createElement("span", {
@@ -177,21 +128,102 @@ var basicColumnExtensionMap = {
       'sm': 120
     },
     'render': function (result) {
-      if (!result.last_modified) return null;
-      if (!result.last_modified.date_modified) return null;
+      var _result$last_modified = result.last_modified;
+      _result$last_modified = _result$last_modified === void 0 ? {} : _result$last_modified;
+      var _result$last_modified2 = _result$last_modified.date_modified,
+          date_modified = _result$last_modified2 === void 0 ? null : _result$last_modified2;
+      if (!date_modified) return null;
       return _react["default"].createElement("span", {
         className: "value"
       }, _react["default"].createElement(_LocalizedTime.LocalizedTime, {
-        timestamp: result.last_modified.date_modified,
+        timestamp: date_modified,
         formatType: "date-sm"
       }));
     },
     'order': 515
   }
 };
-/** Button shown in first column (display_title) to open/close detail pane. */
+/**
+ * @todo
+ * Think about how to more easily customize this for different Item types.
+ * Likely make reusable component containing handleClick and most of its UI...
+ * which this and portals can use for "display_title" column, and then have per-type
+ * overrides/extensions.
+ */
 
 exports.basicColumnExtensionMap = basicColumnExtensionMap;
+
+var DisplayTitleColumn = _react["default"].memo(function (props) {
+  var result = props.result,
+      columnDefinition = props.columnDefinition,
+      termTransformFxn = props.termTransformFxn,
+      width = props.width,
+      href = props.href,
+      context = props.context,
+      rowNumber = props.rowNumber,
+      detailOpen = props.detailOpen,
+      toggleDetailOpen = props.toggleDetailOpen; // `href` and `context` reliably refer to search href and context here, i.e. will be passed in from VirtualHrefController.
+
+  var title = _object.itemUtil.getTitleStringFromContext(result); // Gets display_title || title || accession || ...
+  // Monospace accessions, file formats
+
+
+  var shouldMonospace = _object.itemUtil.isDisplayTitleAccession(result, title) || result.file_format && result.file_format === title;
+
+  var link = _object.itemUtil.atId(result);
+
+  var tooltip = title && (title.length > 20 || width < 100) && title || null;
+  var hasPhoto = false;
+  /** Registers a list click event for Google Analytics then performs navigation. */
+
+  var onClick = (0, _react.useMemo)(function () {
+    return function (evt) {
+      evt.preventDefault();
+      evt.stopPropagation();
+      (0, _analytics.productClick)(result, {
+        list: (0, _analytics.hrefToListName)(href),
+        position: rowNumber + 1
+      }, function () {
+        // We explicitly use globalPageNavigate here and not props.navigate, as props.navigate might refer
+        // to VirtualHrefController.virtualNavigate and would not bring you to new page.
+        (0, _navigate.navigate)(link);
+      }, context);
+      return false;
+    };
+  }, [link, rowNumber]);
+
+  if (link) {
+    // This should be the case always
+    title = _react["default"].createElement("a", {
+      key: "title",
+      href: link || '#',
+      onClick: onClick
+    }, title);
+
+    if (typeof result.email === 'string' && result.email.indexOf('@') > -1) {
+      // Specific case for User items. May be removed or more cases added, if needed.
+      hasPhoto = true;
+      title = _react["default"].createElement(_react["default"].Fragment, null, _object.itemUtil.User.gravatar(result.email, 32, {
+        'className': 'in-search-table-title-image',
+        'data-tip': result.email
+      }, 'mm'), title);
+    }
+  }
+
+  var cls = "title-block" + (hasPhoto ? " has-photo d-flex align-items-center" : " text-ellipsis-container") + (shouldMonospace ? " text-monospace text-small" : "");
+  return _react["default"].createElement(_react["default"].Fragment, null, _react["default"].createElement(TableRowToggleOpenButton, {
+    open: detailOpen,
+    onClick: toggleDetailOpen
+  }), _react["default"].createElement("div", {
+    key: "title-container",
+    className: cls,
+    "data-tip": tooltip
+  }, title));
+});
+/** Button shown in first column (display_title) to open/close detail pane. */
+
+
+exports.DisplayTitleColumn = DisplayTitleColumn;
 
 var TableRowToggleOpenButton = _react["default"].memo(function (_ref) {
   var onClick = _ref.onClick,

--- a/es/components/browse/components/table-commons/basicColumnExtensionMap.js
+++ b/es/components/browse/components/table-commons/basicColumnExtensionMap.js
@@ -53,7 +53,10 @@ var basicColumnExtensionMap = {
           detailOpen = props.detailOpen,
           toggleDetailOpen = props.toggleDetailOpen; // `href` and `context` reliably refer to search href and context here, i.e. will be passed in from VirtualHrefController.
 
-      var title = _object.itemUtil.getTitleStringFromContext(result);
+      var title = _object.itemUtil.getTitleStringFromContext(result); // Monospace accessions, file formats
+
+
+      var shouldMonospace = _object.itemUtil.isDisplayTitleAccession(result, title) || result.file_format && result.file_format === title;
 
       var link = _object.itemUtil.atId(result);
 
@@ -88,21 +91,20 @@ var basicColumnExtensionMap = {
         if (typeof result.email === 'string' && result.email.indexOf('@') > -1) {
           // Specific case for User items. May be removed or more cases added, if needed.
           hasPhoto = true;
-          title = _react["default"].createElement("span", {
-            key: "title"
-          }, _object.itemUtil.User.gravatar(result.email, 32, {
+          title = _react["default"].createElement(_react["default"].Fragment, null, _object.itemUtil.User.gravatar(result.email, 32, {
             'className': 'in-search-table-title-image',
             'data-tip': result.email
           }, 'mm'), title);
         }
       }
 
+      var cls = "title-block" + (hasPhoto ? " has-photo d-flex align-items-center" : " text-ellipsis-container") + (shouldMonospace ? " text-monospace text-small" : "");
       return _react["default"].createElement(_react["default"].Fragment, null, _react["default"].createElement(TableRowToggleOpenButton, {
         open: detailOpen,
         onClick: toggleDetailOpen
       }), _react["default"].createElement("div", {
         key: "title-container",
-        className: "title-block" + (hasPhoto ? ' has-photo' : " text-ellipsis-container"),
+        className: cls,
         "data-tip": tooltip
       }, title));
     }
@@ -117,7 +119,7 @@ var basicColumnExtensionMap = {
       return _react["default"].createElement(_react["default"].Fragment, null, _react["default"].createElement("div", {
         className: "icon-container"
       }, _react["default"].createElement("i", {
-        className: "icon icon-fw fas icon-filter clickable mr-05",
+        className: "icon icon-fw fas icon-filter clickable mr-08",
         onClick: function onClick(e) {
           // Preserve search query, if any, but remove filters (which are usually per-type).
           if (!props.href || props.href.indexOf('/search/') === -1) return;
@@ -192,7 +194,7 @@ var TableRowToggleOpenButton = _react["default"].memo(function (_ref) {
       toggleDetailOpen = _ref.toggleDetailOpen,
       open = _ref.open;
   return _react["default"].createElement("div", {
-    className: "inline-block toggle-detail-button-container"
+    className: "toggle-detail-button-container"
   }, _react["default"].createElement("button", {
     type: "button",
     className: "toggle-detail-button",

--- a/es/components/browse/components/table-commons/index.js
+++ b/es/components/browse/components/table-commons/index.js
@@ -21,6 +21,24 @@ Object.defineProperty(exports, "TableRowToggleOpenButton", {
     return _basicColumnExtensionMap.TableRowToggleOpenButton;
   }
 });
+Object.defineProperty(exports, "DisplayTitleColumnWrapper", {
+  enumerable: true,
+  get: function get() {
+    return _basicColumnExtensionMap.DisplayTitleColumnWrapper;
+  }
+});
+Object.defineProperty(exports, "DisplayTitleColumnDefault", {
+  enumerable: true,
+  get: function get() {
+    return _basicColumnExtensionMap.DisplayTitleColumnDefault;
+  }
+});
+Object.defineProperty(exports, "DisplayTitleColumnUser", {
+  enumerable: true,
+  get: function get() {
+    return _basicColumnExtensionMap.DisplayTitleColumnUser;
+  }
+});
 Object.defineProperty(exports, "ColumnCombiner", {
   enumerable: true,
   get: function get() {

--- a/es/components/ui/DropdownButton.js
+++ b/es/components/ui/DropdownButton.js
@@ -1,0 +1,133 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.DropdownMenu = exports.DropdownButton = void 0;
+
+var _react = _interopRequireDefault(require("react"));
+
+var _WindowClickEventDelegator = require("./../util/WindowClickEventDelegator");
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+
+function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function (obj) { return typeof obj; }; } else { _typeof = function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function (o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function (o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+// THIS IS A WORK IN PROGRESS
+// TODO: create a "DropdownWindowClickManager" or similarly-named global singleton class
+// Will keep track of all DropdownButtons mounted in view to ensure only one open ever at once.
+// Will be similar to WindowClickEventDelegator BUT should be more performant
+// (else can just use WindowClickEventDelegator directly, as is in code below now)
+// by only iterating over clicked element's ancestors (to see if clicked elem is child of _the only_ open dropdown menu) once re: all dropdowns.
+var DropdownButton =
+/*#__PURE__*/
+function (_React$PureComponent) {
+  _inherits(DropdownButton, _React$PureComponent);
+
+  function DropdownButton(props) {
+    var _this;
+
+    _classCallCheck(this, DropdownButton);
+
+    _this = _possibleConstructorReturn(this, _getPrototypeOf(DropdownButton).call(this, props));
+    _this.onWindowClick = _this.onWindowClick.bind(_assertThisInitialized(_this));
+    _this.state = {
+      'open': false
+    };
+    return _this;
+  }
+
+  _createClass(DropdownButton, [{
+    key: "componentDidMount",
+    value: function componentDidMount() {
+      _WindowClickEventDelegator.WindowClickEventDelegator.addHandler(this.onWindowClick);
+    }
+  }, {
+    key: "componentWillUnmount",
+    value: function componentWillUnmount() {
+      _WindowClickEventDelegator.WindowClickEventDelegator.removeHandler(this.onWindowClick);
+    }
+    /** Close dropdown on window click unless click within menu. */
+
+  }, {
+    key: "onWindowClick",
+    value: function onWindowClick() {// TODO check event target, see if parent of it is our dropdown-menu, if so cancel, else close.
+      // Funcs already exist for this in utils/layout
+    }
+  }, {
+    key: "render",
+    value: function render() {
+      var _this$props = this.props,
+          children = _this$props.children,
+          title = _this$props.title,
+          variant = _this$props.variant,
+          size = _this$props.size;
+      var open = this.state.open;
+      return _react["default"].createElement("div", {
+        className: "dropdown"
+      }, _react["default"].createElement("button", {
+        type: "button",
+        className: // TODO finish handling other props
+        "dropdown-toggle btn" + ("btn-" + (variant || "primary")) + ("btn-" + (size || "md")),
+        role: "button",
+        "data-toggle": "dropdown",
+        "aria-haspopup": "true",
+        "aria-expanded": "false"
+      }, title), _react["default"].createElement(DropdownMenu, {
+        children: children,
+        open: open
+      }));
+    }
+  }]);
+
+  return DropdownButton;
+}(_react["default"].PureComponent);
+
+exports.DropdownButton = DropdownButton;
+
+_defineProperty(DropdownButton, "defaultProps", {
+  'children': [_react["default"].createElement("a", {
+    className: "dropdown-item",
+    href: "#",
+    key: 1
+  }, "Action"), _react["default"].createElement("a", {
+    className: "dropdown-item",
+    href: "#",
+    key: 2
+  }, "Another action"), _react["default"].createElement("a", {
+    className: "dropdown-item",
+    href: "#",
+    key: 3
+  }, "Something else here")],
+  'title': "Hello World"
+});
+
+var DropdownMenu = _react["default"].memo(function (props) {
+  var children = props.children,
+      open = props.open;
+  if (!open) return null;
+  return _react["default"].createElement("div", {
+    className: "dropdown-menu show"
+  }, children);
+}); // TODO create plain Dropdown. Or not. Idk. Can easily create (more) custom Dropdown togglers and whatnot by emulating the above DropdownButton so not sure is worth adding more complexity...
+
+
+exports.DropdownMenu = DropdownMenu;

--- a/es/components/ui/ItemDetailList.js
+++ b/es/components/ui/ItemDetailList.js
@@ -1081,7 +1081,7 @@ _defineProperty(Detail, "defaultProps", {
   'end_date', 'project', 'uri', 'ID', // Document
   'attachment', // Things to go at bottom consistently
   'aliases'],
-  'alwaysCollapsibleKeys': ['@type', 'accession', 'schema_version', 'uuid', 'replicate_exps', 'dbxrefs', 'status', 'external_references', 'date_created', 'last_modified', 'submitted_by', 'project_release', 'short_attribution', 'validation-errors'],
+  'alwaysCollapsibleKeys': ['@type', 'accession', 'schema_version', 'uuid', 'replicate_exps', 'status', 'external_references', 'date_created', 'last_modified', 'submitted_by', 'project_release', 'short_attribution', 'validation-errors'],
   'open': null,
   'columnDefinitionMap': {
     '@id': {

--- a/es/components/util/WindowClickEventDelegator.js
+++ b/es/components/util/WindowClickEventDelegator.js
@@ -1,0 +1,97 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.WindowClickEventDelegator = void 0;
+
+var _misc = require("./../util/misc");
+
+/* eslint-disable no-invalid-this */
+
+/**
+ * Global singleton.
+ *
+ * To avoid attaching event listeners to window, can import this
+ * singleton class instance and add/remove event handlers upon
+ * mount and dismount.
+ *
+ * This is the way classes/instances r created in JS under the modern ECMAScript hood :-P.
+ *
+ * @todo maybe handle more events rather than just click.
+ */
+var WindowClickEventDelegator = new function () {
+  if ((0, _misc.isServerSide)()) {
+    console.warn("WindowClickEventDelegator is not supported server-side.");
+    return;
+  } // Private inaccessible variables
+
+  /** @type {Object.<string,Set<function>>} */
+
+
+  var handlersByEvent = {};
+  /** @type {Object.<string,function>} */
+
+  var windowEventHandlersByEvent = {};
+  /** @type {Object.<string,boolean>} */
+
+  var isInitializedByEvent = {};
+
+  function onWindowEvent(eventName, eventObject) {
+    var _iteratorNormalCompletion = true;
+    var _didIteratorError = false;
+    var _iteratorError = undefined;
+
+    try {
+      for (var _iterator = handlersByEvent[eventName][Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+        var handlerFxn = _step.value;
+        handlerFxn(eventObject);
+      }
+    } catch (err) {
+      _didIteratorError = true;
+      _iteratorError = err;
+    } finally {
+      try {
+        if (!_iteratorNormalCompletion && _iterator["return"] != null) {
+          _iterator["return"]();
+        }
+      } finally {
+        if (_didIteratorError) {
+          throw _iteratorError;
+        }
+      }
+    }
+  } // Exposed Methods
+
+
+  this.addHandler = function (eventName, eventHandlerFxn) {
+    if (typeof windowEventHandlersByEvent[eventName] === "undefined") {
+      windowEventHandlersByEvent[eventName] = onWindowEvent.bind(null, eventName);
+    }
+
+    if (typeof handlersByEvent[eventName] === "undefined") {
+      handlersByEvent[eventName] = new Set();
+    }
+
+    handlersByEvent[eventName].add(eventHandlerFxn);
+
+    if (!isInitializedByEvent[eventName]) {
+      isInitializedByEvent[eventName] = true;
+      window.addEventListener(eventName, windowEventHandlersByEvent[eventName], {
+        passive: true
+      });
+    }
+  };
+
+  this.removeHandler = function (eventName, eventHandlerFxn) {
+    handlersByEvent[eventName]["delete"](eventHandlerFxn);
+
+    if (handlersByEvent[eventName].size === 0) {
+      window.removeEventListener(eventName, windowEventHandlersByEvent[eventName]);
+      delete handlersByEvent[eventName];
+      delete isInitializedByEvent[eventName];
+      delete windowEventHandlersByEvent[eventName];
+    }
+  };
+}();
+exports.WindowClickEventDelegator = WindowClickEventDelegator;

--- a/es/components/util/index.js
+++ b/es/components/util/index.js
@@ -33,6 +33,12 @@ Object.defineProperty(exports, "navigate", {
     return _navigate.navigate;
   }
 });
+Object.defineProperty(exports, "WindowClickEventDelegator", {
+  enumerable: true,
+  get: function get() {
+    return _WindowClickEventDelegator.WindowClickEventDelegator;
+  }
+});
 exports.submissionStateUtil = exports.commonFileUtil = exports.valueTransforms = exports.schemaTransforms = exports.searchFilters = exports.JWT = exports.typedefs = exports.console = exports.ajax = exports.layout = exports.analytics = exports.object = void 0;
 
 var _misc = require("./misc");
@@ -62,6 +68,8 @@ var valueTransformsImported = _interopRequireWildcard(require("./value-transform
 var fileUtilities = _interopRequireWildcard(require("./file"));
 
 var submissionViewUtilities = _interopRequireWildcard(require("./submission-view"));
+
+var _WindowClickEventDelegator = require("./WindowClickEventDelegator");
 
 function _getRequireWildcardCache() { if (typeof WeakMap !== "function") return null; var cache = new WeakMap(); _getRequireWildcardCache = function _getRequireWildcardCache() { return cache; }; return cache; }
 

--- a/es/components/util/layout.js
+++ b/es/components/util/layout.js
@@ -12,6 +12,7 @@ exports.getPageVerticalScrollPosition = getPageVerticalScrollPosition;
 exports.animateScrollTo = animateScrollTo;
 exports.toggleBodyClass = toggleBodyClass;
 exports.isDOMElementChildOfElementWithClass = isDOMElementChildOfElementWithClass;
+exports.findParentElement = findParentElement;
 exports.BrowserFeat = exports.elementIsChildOfLink = exports.textContentWidth = exports.textHeight = exports.textWidth = exports.responsiveGridState = exports.shortenString = void 0;
 
 var _react = _interopRequireDefault(require("react"));
@@ -433,6 +434,27 @@ function isDOMElementChildOfElementWithClass(elem, className) {
   return false;
 }
 /**
+ * Designed to work similarly to `Array.find()`.
+ *
+ * @param {HTMLElement} Element to find ancestor (or self) of.
+ * @param {function} Assertion function, should return `true` if valid element or false if not.
+ * @returns {HTMLElement|undefined} Ancestor (or self) element for which searchFxn returns true, if any.
+ */
+
+
+function findParentElement(startElement, searchFxn) {
+  var domElem = startElement;
+
+  while (domElem) {
+    if (searchFxn(domElem)) {
+      return domElem;
+    }
+
+    domElem = domElem.parentElement;
+  } // undefined
+
+}
+/**
  * Meant to be used in click handlers. See app.js.
  * Memoized in case multiple click handlers bound to
  * event bubble chain (same event bubbles up).
@@ -440,13 +462,11 @@ function isDOMElementChildOfElementWithClass(elem, className) {
 
 
 var elementIsChildOfLink = (0, _memoizeOne["default"])(function (initDomElement) {
-  var domElem = initDomElement; // SVG anchor elements have tagName == 'a' while HTML anchor elements have tagName == 'A'
-
-  while (domElem && domElem.tagName.toLowerCase() !== 'a' && !domElem.getAttribute('data-href')) {
-    domElem = domElem.parentElement;
-  }
-
-  return domElem;
+  var foundElem = findParentElement(initDomElement, function (domElem) {
+    // SVG anchor elements have tagName == 'a' while HTML anchor elements have tagName == 'A'
+    return domElem.tagName.toLowerCase() === "a" || domElem.getAttribute('data-href');
+  });
+  return foundElem || initDomElement;
 });
 /**
  * Handle browser capabilities, a la Modernizr.

--- a/scss/facet-list.scss
+++ b/scss/facet-list.scss
@@ -412,7 +412,7 @@ $facetlist-term-block-height: default !default;
                 float: right;
                 text-align: left;
                 @include font-size($facetlist-facet-font-size);
-                @include no-user-select();
+                @include no-user-select;
 
                 span {
                     cursor: pointer;

--- a/scss/misc-ui-components.scss
+++ b/scss/misc-ui-components.scss
@@ -92,3 +92,7 @@
 .line-height-1 {
     line-height: 1;
 }
+
+.no-user-select {
+	@include no-user-select;
+}

--- a/scss/search-view-table.scss
+++ b/scss/search-view-table.scss
@@ -3,18 +3,21 @@
 
 /*** In Parent Portal CSS, must define "postition: sticky" for HeadersRow + top offset, depending on usage/placement ***/
 
+$search-results-edge-background-color : #f8f8f8 !default;
 $search-results-edge-shadow-color : rgba(0,0,0,0.125) !default;
+
 $search-results-result-row-height: 46px !default;
+
+$search-results-header-row-height: $search-results-result-row-height !default;
+$search-results-header-text-color: #fff !default;
+
 $search-results-above-results-row-height: 40px !default;
 $search-results-above-results-row-bottom-padding: 5px !default;
-$search-results-header-text-color: #fff !default;
 
 // Common definitions
 @mixin search-result-column-and-header-block {
-	//float: left;
-	//transform: translate3d(0,0,0);
 	> .inner {
-		height : $search-results-result-row-height;
+		// height : $search-results-result-row-height;
 		padding: 0 8px;
 		line-height: 16px;
 		// text-align: center;
@@ -28,13 +31,17 @@ $search-results-header-text-color: #fff !default;
 }
 
 @mixin search-result-column-block {
-    @include search-result-column-and-header-block;
-
-    > .inner > .value {
-        // Default style -- can be overriden
-        @include text-ellipsis-container;
-        flex-grow: 1;
-    }
+	@include search-result-column-and-header-block;
+	
+	> .inner {
+		height: $search-results-result-row-height;
+		> .value {
+			// Default style -- can be overriden
+			overflow: hidden;
+			text-overflow: ellipsis;
+			flex-grow: 1;
+		}
+	}
 
     /** Some Common Styles **/
     &[data-field="display_title"],
@@ -151,7 +158,7 @@ $search-results-header-text-color: #fff !default;
 
 	.search-results-container {
 		position: relative;
-		transform: translate3d(0,0,0); // New coordplane/topleft for position:fixed children
+		// transform: translate3d(0,0,0); // New coordplane/topleft for position:fixed children
 
 		&:not(.fully-loaded){
 			::-webkit-scrollbar {
@@ -169,7 +176,7 @@ $search-results-header-text-color: #fff !default;
 				position: absolute;
 				top: 0;
 				bottom: 0;
-				background: #f8f8f8;
+				background: $search-results-edge-background-color;
 				width: 15px;
 				pointer-events: all;
 				opacity: 1;
@@ -198,7 +205,7 @@ $search-results-header-text-color: #fff !default;
 				&.right-edge {
 					right: -15px;
 					border-radius: 0 4px 4px 0;
-					box-shadow: inset -5px 0 10px #fff, -5px 0 10px -5px $search-results-edge-shadow-color;
+					box-shadow: inset -5px 0 10px #fff2, -5px 0 10px -5px $search-results-edge-shadow-color;
 					&:hover {
 						box-shadow: -5px 0 10px -5px $search-results-edge-shadow-color;
 					}
@@ -206,7 +213,7 @@ $search-results-header-text-color: #fff !default;
 				&.left-edge {
 					left: -15px;
 					border-radius: 4px 0 0 4px;
-					box-shadow: inset 5px 0 10px #fff, 5px 0 10px -5px $search-results-edge-shadow-color;
+					box-shadow: inset 5px 0 10px #fff2, 5px 0 10px -5px $search-results-edge-shadow-color;
 					&:hover {
 						box-shadow: 5px 0 10px -5px $search-results-edge-shadow-color;
 					}
@@ -292,7 +299,14 @@ $search-results-header-text-color: #fff !default;
 							}
 						}
 						.title-block {
-							display: inline-block;
+							flex-grow: 1;
+							flex-shrink: 1;
+							flex-basis: auto;
+							min-width: 0;
+							a {
+								overflow: hidden;
+    							text-overflow: ellipsis;
+							}
 						}
 					}
 
@@ -380,7 +394,8 @@ $search-results-header-text-color: #fff !default;
 				height : 67px;
 				line-height: $search-results-result-row-height;
 				transition: transform .5s ease;
-				border-bottom: none;
+				box-shadow: none !important;
+				border: none !important;
 			}
 
 			&.empty-block {
@@ -516,6 +531,7 @@ $search-results-header-text-color: #fff !default;
 				}
 
 				> .inner {
+					height: $search-results-header-row-height;
 					color: $search-results-header-text-color;
 					font-weight: 500;
 					padding-right: 32px;
@@ -729,7 +745,7 @@ $search-results-header-text-color: #fff !default;
 				font-size: $font-size-base * 1.125;
                 display: flex;
                 align-items: center;
-                height: $search-results-result-row-height;
+                height: $search-results-header-row-height;
 				padding-left: 10px;
     			padding-right: 10px;
 				font-weight: 500;

--- a/scss/search-view-table.scss
+++ b/scss/search-view-table.scss
@@ -39,6 +39,7 @@ $search-results-above-results-row-bottom-padding: 5px !default;
 			// Default style -- can be overriden
 			overflow: hidden;
 			text-overflow: ellipsis;
+			white-space: nowrap; // Need to consider how could make multiline...
 			flex-grow: 1;
 		}
 	}
@@ -303,6 +304,11 @@ $search-results-above-results-row-bottom-padding: 5px !default;
 							flex-shrink: 1;
 							flex-basis: auto;
 							min-width: 0;
+							max-height: 100%;
+							// This can be overriden on a per-Item basis.
+							// If rowHeight is high and title for type is
+							// expected be short.
+							white-space: nowrap;
 							a {
 								overflow: hidden;
     							text-overflow: ellipsis;
@@ -455,11 +461,12 @@ $search-results-above-results-row-bottom-padding: 5px !default;
 				line-height: $search-results-result-row-height;
 				height: $search-results-result-row-height + 1px;
 				font-style: italic;
-				border-bottom: none;
-				background-color: #fff;
 				position: relative;
 				transition: transform .3s ease;
 				width: 100%; // overriden by px value after mount. Should visually remain same.
+
+				box-shadow: none !important;
+				border: none !important;
 				> .inner {
 					// position: fixed;
 					width: inherit;

--- a/scss/search-view-table.scss
+++ b/scss/search-view-table.scss
@@ -17,10 +17,10 @@ $search-results-header-text-color: #fff !default;
 		height : $search-results-result-row-height;
 		padding: 0 8px;
 		line-height: 16px;
-		text-align: center;
-		overflow: hidden;
-		text-overflow: ellipsis;
-        white-space: nowrap;
+		// text-align: center;
+		// overflow: hidden;
+		// text-overflow: ellipsis;
+        // white-space: nowrap;
         display: flex;
 		align-items: center;
 		line-height: $line-height-base;
@@ -492,125 +492,146 @@ $search-results-header-text-color: #fff !default;
 	z-index: 50;
 	transform: translate3d(0,0,0) !important;
 
-	> .columns {
-		display: -webkit-box;
-		display: flex;
-		position: relative;
+	> .headers-columns-overflow-container {
 
-		> .search-headers-column-block {
-			@include search-result-column-and-header-block;
-			flex-shrink: 0;
+		// Prevent columns from escaping parent container
+		// Needs to be disabled when open sort options menu (shows up below headers row).
+		overflow: hidden;
+
+		> .columns {
+			display: -webkit-box;
+			display: flex;
 			position: relative;
 
-			&.no-sort {
+			> .search-headers-column-block {
+				@include search-result-column-and-header-block;
+				flex-shrink: 0;
+				position: relative;
+				transition: opacity .35s ease-out;
+
+				&.no-sort {
+					> .inner {
+						padding-right: 8px;
+					}
+				}
+
 				> .inner {
-					padding-right: 8px;
-				}
-			}
+					color: $search-results-header-text-color;
+					font-weight: 500;
+					padding-right: 32px;
+					display: flex;
 
-			> .inner {
-				color: $search-results-header-text-color;
-				font-weight: 500;
-                padding-right: 32px;
-                display: flex;
-
-                > .column-title {
-                    flex-grow: 1;
-                    text-align: center;
-                    @include text-ellipsis-container;
-                }
-
-				> .column-sort-icon {
-					color: transparentize($color: $search-results-header-text-color, $amount: 0.65); //   rgba(255,255,255,0.35);
-					text-decoration: none !important;
-					padding-left: 0;
-					padding-right: 5px;
-					display: inline-block;
-					/* float: right; */
-					position: absolute;
-					cursor: pointer;
-					right: 9px;
-					transition: color .35s ease-out;
-					&:hover, &:active, &:focus {
-						color: $search-results-header-text-color;
-					}
-					&.active {
-						color: $search-results-header-text-color;
-						text-shadow: 0 0 0 $search-results-header-text-color;
+					> .column-title {
+						flex-grow: 1;
+						text-align: center;
+						@include text-ellipsis-container;
 					}
 
-					&.multiple-sort-options {
-						> i {
-							&:after {
-								content: "\f141";
-								position: absolute;
-								display: block;
-								//top: 1px;
-								bottom: -1px;
-								right: 2px;
-								font-size: 50%;
-								font-family: $fa-font-family;
-								font-weight: 900; /* fas */
-								opacity: 0;
-								transition: opacity .35s ease-out;
+					> .column-sort-icon {
+						color: transparentize($color: $search-results-header-text-color, $amount: 0.65); //   rgba(255,255,255,0.35);
+						text-decoration: none !important;
+						padding-left: 0;
+						padding-right: 5px;
+						display: inline-block;
+						/* float: right; */
+						position: absolute;
+						cursor: pointer;
+						right: 9px;
+						transition: color .35s ease-out;
+						&:hover, &:active, &:focus {
+							color: $search-results-header-text-color;
+						}
+						&.active {
+							color: $search-results-header-text-color;
+							text-shadow: 0 0 0 $search-results-header-text-color;
+						}
+
+						&.multiple-sort-options {
+							> i {
+								&:after {
+									content: "\f141";
+									position: absolute;
+									display: block;
+									//top: 1px;
+									bottom: -1px;
+									right: 2px;
+									font-size: 50%;
+									font-family: $fa-font-family;
+									font-weight: 900; /* fas */
+									opacity: 0;
+									transition: opacity .35s ease-out;
+								}
+								&.sort-icon:after {
+									opacity: 1;
+								}
+								&.icon-times {
+									color: $search-results-header-text-color;
+								}
 							}
-							&.sort-icon:after {
-								opacity: 1;
-							}
-							&.icon-times {
-								color: $search-results-header-text-color;
+							&.active > i.sort-icon:after {
+								opacity: 0.8;
 							}
 						}
-						&.active > i.sort-icon:after {
-							opacity: 0.8;
-						}
+					}
+
+				}
+				&:hover{
+					z-index: 10;
+				}
+				&[data-field="display_title"]{
+					padding-left: 40px;
+				}
+				> .width-adjuster {
+					position: absolute;
+					color: $search-results-header-text-color;
+					padding-left: 10px;
+					padding-right: 15px;
+					left: 0;
+					top : 0;
+					margin-left: -12px;
+					z-index: 10;
+					cursor: col-resize;
+					width: 28px;
+					height: 100%;
+
+					&:after {
+						content: ' ';
+						border-left-width: 1px;
+						border-right-width: 1px;
+						border-left-style: dotted;
+						border-right-style: dotted;
+						border-color: $search-results-header-text-color;
+						opacity: 0.6;
+						width: 3px;
+						left: 10px;
+
+						top: 9.5px;
+						bottom: 9.5px;
+						position: absolute;
+					}
+					&:hover:after {
+						opacity: 1;
 					}
 				}
+			}
+		}
 
-			}
-			&:hover{
-				z-index: 10;
-			}
-			&[data-field="display_title"]{
-				padding-left: 40px;
-			}
-			> .width-adjuster {
-				position: absolute;
-				color: $search-results-header-text-color;
-				padding-left: 10px;
-				padding-right: 15px;
-				left: 0;
-				top : 0;
-				margin-left: -12px;
-				z-index: 10;
-				cursor: col-resize;
-				width: 28px;
-				height: 100%;
+	}
 
-				&:after {
-					content: ' ';
-					border-left-width: 1px;
-                    border-right-width: 1px;
-                    border-left-style: dotted;
-                    border-right-style: dotted;
-                    border-color: $search-results-header-text-color;
-                    opacity: 0.6;
-					width: 3px;
-					left: 10px;
-
-					top: 9.5px;
-					bottom: 9.5px;
-					position: absolute;
-				}
-				&:hover:after {
-					opacity: 1;
-				}
-			}
+	&[data-showing-sort-fields-for] > .headers-columns-overflow-container {
+		overflow: visible;
+		> .columns > .search-headers-column-block:not(.showing-sort-field-options) {
+			// Some of these may now overlap elements to side(s) of table,
+			// so need to hide somehow/somewhat.
+			opacity: 0;
+			transition: none;
+			pointer-events: none;
+			z-index: -10;
 		}
 	}
 
 	&.non-adjustable {
-		> .columns > .search-headers-column-block > .inner {
+		> .headers-columns-overflow-container > .columns > .search-headers-column-block > .inner {
 			padding-right: 8px;
 		}
 	}
@@ -620,7 +641,7 @@ $search-results-header-text-color: #fff !default;
 	}
 
 	&.no-detail-pane {
-		> .columns {
+		> .headers-columns-overflow-container > .columns {
 			> .search-headers-column-block {
 				&[data-field="display_title"]{
 					padding-left: 10px;

--- a/scss/search-view-table.scss
+++ b/scss/search-view-table.scss
@@ -486,11 +486,11 @@ $search-results-header-text-color: #fff !default;
 } // .search-results-outer-container
 
 
+
 .search-headers-row {
 	background-color: $brand-primary-dark;
 	z-index: 50;
 	transform: translate3d(0,0,0) !important;
-	overflow-x: hidden;
 
 	> .columns {
 		display: -webkit-box;

--- a/scss/search-view-table.scss
+++ b/scss/search-view-table.scss
@@ -521,7 +521,7 @@ $search-results-header-text-color: #fff !default;
                 }
 
 				> .column-sort-icon {
-					color: rgba(255,255,255,0.5);
+					color: transparentize($color: $search-results-header-text-color, $amount: 0.65); //   rgba(255,255,255,0.35);
 					text-decoration: none !important;
 					padding-left: 0;
 					padding-right: 5px;
@@ -530,12 +530,40 @@ $search-results-header-text-color: #fff !default;
 					position: absolute;
 					cursor: pointer;
 					right: 9px;
+					transition: color .35s ease-out;
 					&:hover, &:active, &:focus {
 						color: $search-results-header-text-color;
 					}
 					&.active {
 						color: $search-results-header-text-color;
 						text-shadow: 0 0 0 $search-results-header-text-color;
+					}
+
+					&.multiple-sort-options {
+						> i {
+							&:after {
+								content: "\f141";
+								position: absolute;
+								display: block;
+								//top: 1px;
+								bottom: -1px;
+								right: 2px;
+								font-size: 50%;
+								font-family: $fa-font-family;
+								font-weight: 900; /* fas */
+								opacity: 0;
+								transition: opacity .35s ease-out;
+							}
+							&.sort-icon:after {
+								opacity: 1;
+							}
+							&.icon-times {
+								color: $search-results-header-text-color;
+							}
+						}
+						&.active > i.sort-icon:after {
+							opacity: 0.8;
+						}
 					}
 				}
 

--- a/scss/search-view-table.scss
+++ b/scss/search-view-table.scss
@@ -528,7 +528,7 @@ $search-results-header-text-color: #fff !default;
 					}
 
 					> .column-sort-icon {
-						color: transparentize($color: $search-results-header-text-color, $amount: 0.65); //   rgba(255,255,255,0.35);
+						color: transparentize($color: $search-results-header-text-color, $amount: 0.6); //   rgba(255,255,255,0.35);
 						text-decoration: none !important;
 						padding-left: 0;
 						padding-right: 5px;
@@ -549,16 +549,17 @@ $search-results-header-text-color: #fff !default;
 						&.multiple-sort-options {
 							> i {
 								&:after {
-									content: "\f141";
+									content: "\f142";
 									position: absolute;
 									display: block;
-									//top: 1px;
-									bottom: -1px;
-									right: 2px;
-									font-size: 50%;
+									top: 50%;
+									margin-top: -5px;
+									right: 1px;
+									font-size: 65%;
 									font-family: $fa-font-family;
 									font-weight: 900; /* fas */
 									opacity: 0;
+									text-shadow: none;
 									transition: opacity .35s ease-out;
 								}
 								&.sort-icon:after {
@@ -618,15 +619,16 @@ $search-results-header-text-color: #fff !default;
 
 	}
 
+	> .headers-columns-dropdown-menu-container { // Sibling to headers-columns-overflow-container, since don't want it clipped.
+		> .dropdown-menu {
+			min-width: 200px;
+			transform: translate(-100%, 0);
+		}
+	}
+
 	&[data-showing-sort-fields-for] > .headers-columns-overflow-container {
-		overflow: visible;
 		> .columns > .search-headers-column-block:not(.showing-sort-field-options) {
-			// Some of these may now overlap elements to side(s) of table,
-			// so need to hide somehow/somewhat.
-			opacity: 0;
-			transition: none;
-			pointer-events: none;
-			z-index: -10;
+			opacity: 0.6;
 		}
 	}
 

--- a/src/components/browse/SearchView.js
+++ b/src/components/browse/SearchView.js
@@ -95,6 +95,7 @@ export class SearchView extends React.PureComponent {
             ...passProps,
             currentAction,
             schemas,
+            windowWidth,
             isOwnPage: true,
             facets: propFacets || contextFacets
         };
@@ -102,7 +103,7 @@ export class SearchView extends React.PureComponent {
         let controllersAndView = (
             <WindowNavigationController {...{ href, context }} navigate={propNavigate}>
                 <ColumnCombiner {...{ columns, columnExtensionMap }}>
-                    <CustomColumnController {...{ windowWidth }}>
+                    <CustomColumnController>
                         <SortController>
                             <ControlsAndResults {...childViewProps} />
                         </SortController>

--- a/src/components/browse/components/FacetList/FacetTermsList.js
+++ b/src/components/browse/components/FacetList/FacetTermsList.js
@@ -228,7 +228,6 @@ export class FacetTermsList extends React.PureComponent {
         const {
             facet,
             terms,
-            tooltip,
             title,
             isStatic,
             anyTermsSelected: anySelected,
@@ -239,6 +238,7 @@ export class FacetTermsList extends React.PureComponent {
             termTransformFxn,
             facetOpen
         } = this.props;
+        const { description = null } = facet;
         const { expanded } = this.state;
         const termsLen = terms.length;
         const allTermsSelected = termsSelectedCount === termsLen;
@@ -275,7 +275,7 @@ export class FacetTermsList extends React.PureComponent {
                         <i className={"icon icon-fw icon-" + (allTermsSelected ? "dot-circle far" : (facetOpen ? "minus" : "plus") + " fas")}/>
                     </span>
                     <div className="col px-0 line-height-1">
-                        <span data-tip={tooltip} data-place="right">{ title }</span>
+                        <span data-tip={description} data-html data-place="right">{ title }</span>
                     </div>
                     { indicator }
                 </h5>

--- a/src/components/browse/components/FacetList/TermsFacet.js
+++ b/src/components/browse/components/FacetList/TermsFacet.js
@@ -70,7 +70,7 @@ export class TermsFacet extends React.PureComponent {
             isStatic
         } = this.props;
         const { filtering } = this.state;
-        const { field, title, description = null } = facet || {};
+        const { field, title } = facet || {};
 
         const showTitle = title || field;
 
@@ -78,7 +78,7 @@ export class TermsFacet extends React.PureComponent {
             // Only one term exists.
             return <StaticSingleTerm {...{ facet, term : terms[0], filtering, showTitle, onClick : this.handleStaticClick, getTermStatus, extraClassname, termTransformFxn }} />;
         } else {
-            return <FacetTermsList {...this.props} onTermClick={this.handleTermClick} tooltip={description} title={showTitle} />;
+            return <FacetTermsList {...this.props} onTermClick={this.handleTermClick} title={showTitle} />;
         }
 
     }

--- a/src/components/browse/components/SearchResultTable.js
+++ b/src/components/browse/components/SearchResultTable.js
@@ -277,7 +277,7 @@ class ResultRow extends React.PureComponent {
         // to make more reusable re: e.g. `selectedFiles` (= 4DN-specific).
         const { columnDefinitions, selectedFiles } = this.props;
         // Contains required 'result', 'rowNumber', 'href', 'columnWidths', 'mounted', 'windowWidth', 'schemas', 'currentAction', 'detailOpen'
-        const commonProps = _.omit(this.props, 'tableContainerWidth', 'tableContainerScrollLeft', 'renderDetailPane', 'id');
+        const commonProps = _.omit(this.props, 'tableContainerWidth', 'tableContainerScrollLeft', 'renderDetailPane', 'id', 'toggleDetailPaneOpen');
         return columnDefinitions.map((columnDefinition, columnNumber) => { // todo: rename columnNumber to columnIndex
             const { field } = columnDefinition;
             const passedProps = {

--- a/src/components/browse/components/SearchResultTable.js
+++ b/src/components/browse/components/SearchResultTable.js
@@ -69,8 +69,8 @@ const DefaultDetailPane = React.memo(function DefaultDetailPane({ result }){
 class ResultDetail extends React.PureComponent{
 
     static propTypes = {
-        'result'    : PropTypes.object.isRequired,
-        'open'      : PropTypes.bool.isRequired,
+        'result' : PropTypes.object.isRequired,
+        'open' : PropTypes.bool.isRequired,
         'renderDetailPane': PropTypes.func.isRequired,
         'rowNumber' : PropTypes.number,
         'toggleDetailOpen' : PropTypes.func.isRequired,
@@ -189,16 +189,7 @@ class ResultRow extends React.PureComponent {
         'rowNumber'         : PropTypes.number.isRequired,
         'rowHeight'         : PropTypes.number,
         'mounted'           : PropTypes.bool.isRequired,
-        'columnDefinitions'     : PropTypes.arrayOf(PropTypes.shape({
-            'title'             : PropTypes.string.isRequired,
-            'field'             : PropTypes.string.isRequired,
-            'render'            : PropTypes.func,
-            'widthMap'          : PropTypes.shape({
-                'lg'                : PropTypes.number.isRequired,
-                'md'                : PropTypes.number.isRequired,
-                'sm'                : PropTypes.number.isRequired
-            })
-        })).isRequired,
+        'columnDefinitions'     : HeadersRow.propTypes.columnDefinitions,
         'columnWidths' : PropTypes.objectOf(PropTypes.number),
         'renderDetailPane'  : PropTypes.func.isRequired,
         'detailOpen' : PropTypes.bool.isRequired,

--- a/src/components/browse/components/SearchResultTable.js
+++ b/src/components/browse/components/SearchResultTable.js
@@ -858,8 +858,8 @@ class DimensioningContainer extends React.PureComponent {
                 nextScrollLeft = 0; // Might occur right after changing column widths or something.
             }
 
-            const headersElem = innerElem.parentElement.childNodes[0].childNodes[0];
-            headersElem.style.left = `-${nextScrollLeft}px`;
+            const columnsWrapperElement = innerElem.parentElement.childNodes[0].childNodes[0].childNodes[0];
+            columnsWrapperElement.style.left = `-${nextScrollLeft}px`;
 
             if (nextScrollLeft !== tableContainerScrollLeft) { // Shouldn't occur or matter but presence of this seems to improve smoothness (?)
                 this.setContainerScrollLeft(nextScrollLeft);

--- a/src/components/browse/components/table-commons/ColumnCombiner.js
+++ b/src/components/browse/components/table-commons/ColumnCombiner.js
@@ -152,10 +152,7 @@ export function columnsToColumnDefinitions(columns, columnDefinitionMap, default
             var colDef2 = _.extend({}, colDefOverride, colDef);
             colDef = colDef2;
         }
-        // Add defaults for any required-for-view but not-present properties.
-        if (colDef.widthMap && colDef.widthMap.sm && typeof colDef.widthMap.xs !== 'number'){
-            colDef.widthMap.xs = colDef.widthMap.sm;
-        }
+
         colDef.widthMap = colDef.widthMap || defaultWidthMap;
         colDef.render = colDef.render || null;
         colDef.order = typeof colDef.order === 'number' ? colDef.order : i;

--- a/src/components/browse/components/table-commons/HeadersRow.js
+++ b/src/components/browse/components/table-commons/HeadersRow.js
@@ -422,6 +422,8 @@ class ColumnSorterIcon extends React.PureComponent {
                 return title || field;
             }).join(", ");
             tooltip = sortedByFieldTitles.length > 0 ? `Sorted by <span class="text-600">${sortedByFieldTitles}</span>` : null;
+        } else if (hasMultipleSortOptions) {
+            tooltip = "" + sort_fields.length + " sort options";
         }
         return (
             <span className={cls} onClick={this.onIconClick} data-tip={tooltip} data-html>

--- a/src/components/browse/components/table-commons/HeadersRow.js
+++ b/src/components/browse/components/table-commons/HeadersRow.js
@@ -162,14 +162,15 @@ export class HeadersRow extends React.PureComponent {
         };
 
         return (
-            <div className={outerClassName} style={outerStyle}>
-                <div className="columns clearfix" style={innerStyle}>
-                    {
-                        columnDefinitions.map((columnDefinition, index) =>
+            <div className={outerClassName} style={outerStyle} data-showing-sort-fields-for={showingSortFieldsForColumn}>
+                <div className="headers-columns-overflow-container">
+                    <div className="columns clearfix" style={innerStyle}>
+                        { columnDefinitions.map((columnDefinition, index) =>
                             <HeadersRowColumn {...commonProps} {...{ columnDefinition, index }} width={this.getWidthFor(columnDefinition, index)} key={columnDefinition.field} />
-                        )
-                    }
+                        ) }
+                    </div>
                 </div>
+
             </div>
         );
     }
@@ -220,10 +221,13 @@ class HeadersRowColumn extends React.PureComponent {
         if (!noSort && typeof sortByFxn === 'function' && width >= 50){
             sorterIcon = <ColumnSorterIcon {...{ columnDefinition, sortByFxn, currentSortColumn, descend, showingSortFieldsForColumn, setShowingSortFieldsFor }} />;
         }
+        const cls = (
+            "search-headers-column-block"
+            + (noSort ? " no-sort" : '')
+            + (field === showingSortFieldsForColumn ? " showing-sort-field-options" : "")
+        );
         return (
-            <div data-field={field} data-column-key={field} key={field}
-                className={"search-headers-column-block" + (noSort ? " no-sort" : '')}
-                style={{ width }}>
+            <div data-field={field} data-column-key={field} key={field} className={cls} style={{ width }}>
                 <div className="inner">
                     <div className="column-title">
                         <span data-tip={tooltip} data-html>{ showTitle }</span>

--- a/src/components/browse/components/table-commons/HeadersRow.js
+++ b/src/components/browse/components/table-commons/HeadersRow.js
@@ -6,6 +6,7 @@ import Draggable from 'react-draggable';
 import { getColumnWidthFromDefinition } from './ColumnCombiner';
 import { WindowClickEventDelegator } from './../../../util/WindowClickEventDelegator';
 import { findParentElement } from './../../../util/layout';
+import { requestAnimationFrame as raf } from './../../../viz/utilities';
 
 /**
  * Assumes that is rendered by SearchResultTable and that a SortController instance
@@ -184,22 +185,20 @@ export class HeadersRow extends React.PureComponent {
 
     /** Updates CustomColumnController.state.columnWidths from HeadersRow.state.widths */
     setColumnWidthsFromState(){
-        const { setColumnWidths, columnWidths } = this.props;
-        const { widths } = this.state;
-        if (typeof setColumnWidths !== 'function'){
-            throw new Error('props.setHeaderWidths not a function');
-        }
-        setTimeout(function(){
+        raf(() => {
+            const { setColumnWidths, columnWidths } = this.props;
+            const { widths } = this.state;
+            if (typeof setColumnWidths !== 'function'){
+                throw new Error('props.setHeaderWidths not a function');
+            }
             setColumnWidths({ ...columnWidths, ...widths });
-        }, 0);
+        });
     }
 
     onAdjusterDrag(columnDefinition, evt, r){
         const { field } = columnDefinition;
-        this.setState(({ widths }, { defaultMinColumnWidth })=>{
-            const nextWidths = _.clone(widths);
-            nextWidths[field] = Math.max(columnDefinition.minColumnWidth || defaultMinColumnWidth || 55, r.x);
-            return { 'widths' : nextWidths };
+        this.setState(function({ widths }, { defaultMinColumnWidth }){
+            return { 'widths' : { ...widths, [field] : Math.max(columnDefinition.minColumnWidth || defaultMinColumnWidth || 55, r.x) } };
         });
     }
 

--- a/src/components/browse/components/table-commons/HeadersRow.js
+++ b/src/components/browse/components/table-commons/HeadersRow.js
@@ -212,9 +212,10 @@ class HeadersRowColumn extends React.PureComponent {
             showingSortFieldsForColumn,
             setShowingSortFieldsFor
         } = this.props;
-        const { noSort, colTitle, title, field } = columnDefinition;
+        const { noSort, colTitle, title, field, description = null } = columnDefinition;
         const showTitle = colTitle || title;
-        const tooltip = this.memoized.showTooltip(width, typeof colTitle === "string" ? colTitle : title) ? title : null;
+        const titleTooltip = this.memoized.showTooltip(width, typeof colTitle === "string" ? colTitle : title) ? title : null;
+        const tooltip = description ? (titleTooltip ? `<h5 class="mt-0 mb-03">${titleTooltip}</h5>` + description : description) : (titleTooltip? titleTooltip : null);
         let sorterIcon;
         if (!noSort && typeof sortByFxn === 'function' && width >= 50){
             sorterIcon = <ColumnSorterIcon {...{ columnDefinition, sortByFxn, currentSortColumn, descend, showingSortFieldsForColumn, setShowingSortFieldsFor }} />;
@@ -286,6 +287,12 @@ class ColumnSorterIcon extends React.PureComponent {
         }
     }
 
+    /**
+     * Sorts column or opens/closes multisort menu
+     * if multiple options.
+     *
+     * @param {React.SyntheticEvent} e - Click event object.
+     */
     onIconClick(e){
         e.preventDefault();
         const {
@@ -311,6 +318,11 @@ class ColumnSorterIcon extends React.PureComponent {
         this.sortByField(sort_fields[0] || field);
     }
 
+    /**
+     * Determines direction of next sort (descending vs ascending) and sets
+     * `state.isLoading` to true (to be unset by `componentDidUpdate`)
+     * before calling `props.sortByFxn`.
+     */
     sortByField(field){
         const { descend, currentSortColumn, sortByFxn } = this.props;
         const isActive = currentSortColumn === field;
@@ -358,12 +370,12 @@ const SortOptionsMenu = React.memo(function SortOptionsMenu({ currentSortColumn,
     const options = sort_fields.map(function({ field, title = null }){
         // TODO grab title from schemas if not provided.
         const isActive = currentSortColumn === field;
-        const cls = ("dropdown-item clickable" + (isActive ? " active" : ""));
+        const cls = ("dropdown-item clickable no-highlight d-flex align-items-center justify-content-between" + (isActive ? " active" : ""));
         const onClick = sortByField.bind(sortByField, field);
         return (
             <div className={cls} key={field} onClick={onClick}>
                 { title || field }
-                { !isActive ? null : <i className={`icon fas ml-1 icon-angle-${descend ? "down" : "up"}`}/> }
+                { !isActive ? null : <i className={`icon fas ml-12 icon-angle-${descend ? "down" : "up"}`}/> }
             </div>
         );
     });

--- a/src/components/browse/components/table-commons/HeadersRow.js
+++ b/src/components/browse/components/table-commons/HeadersRow.js
@@ -458,7 +458,7 @@ const SortOptionsMenuContainer = React.memo(function SortOptionsMenuContainer(pr
         return -1;
     }, [ columnDefinitions, showingSortFieldsForColumn ]);
 
-
+    // Position it under col for which open for in headers row.
     const widthUntilActiveColumnEnd = useMemo(function(){
         let sumWidths = 0;
         for (var i = 0; i <= activeColumnDefinitionIndex; i++){
@@ -469,9 +469,8 @@ const SortOptionsMenuContainer = React.memo(function SortOptionsMenuContainer(pr
 
     const activeColumnDefinition = columnDefinitions[activeColumnDefinitionIndex];
     const { sort_fields } = activeColumnDefinition;
-    const style = {
-        left: Math.max(205, widthUntilActiveColumnEnd + leftOffset)
-    }; // Align it to col in headers row.
+    // Account for scrollLeft of searchresults/header; 200 is min width for menu
+    const style = { left: Math.max(200, widthUntilActiveColumnEnd + leftOffset) };
 
     return (
         <div className="headers-columns-dropdown-menu-container">
@@ -480,8 +479,14 @@ const SortOptionsMenuContainer = React.memo(function SortOptionsMenuContainer(pr
     );
 });
 
-const SortOptionsMenu = React.memo(function SortOptionsMenu({ currentSortColumn, sort_fields, sortByField, descend = false, style = null }){
-
+const SortOptionsMenu = React.memo(function SortOptionsMenu({
+    header = <h5 className="dropdown-header mt-0 px-3 pt-03 text-600">Sort by</h5>,
+    currentSortColumn,
+    sort_fields,
+    sortByField,
+    descend = false,
+    style = null
+}){
     const options = sort_fields.map(function({ field, title = null }){
         // TODO grab title from schemas if not provided.
         const isActive = currentSortColumn === field;
@@ -500,7 +505,12 @@ const SortOptionsMenu = React.memo(function SortOptionsMenu({ currentSortColumn,
         );
     });
 
-    return <div className="dropdown-menu show" style={style}>{ options }</div>;
+    return (
+        <div className="dropdown-menu show" style={style}>
+            { header }
+            { options }
+        </div>
+    );
 });
 
 const ColumnSorterIconElement = React.memo(function ColumnSorterIconElement({ descend, showingSortOptionsMenu, isLoading = false }){

--- a/src/components/browse/components/table-commons/ResultRowColumnBlockValue.js
+++ b/src/components/browse/components/table-commons/ResultRowColumnBlockValue.js
@@ -100,7 +100,7 @@ export class ResultRowColumnBlockValue extends React.Component {
 
 
         let value = renderFxn ?
-            renderFxn(result, _.omit(this.props, 'columnDefinition', 'result'))
+            renderFxn(result, _.omit(this.props, 'result'))
             : this.memoized.transformIfNeeded(result, field, termTransformFxn); // Simple fallback transformation to unique arrays
 
         // Wrap `value` in a span (provides ellipsis, etc) if is primitive (not custom render fxn output)

--- a/src/components/browse/components/table-commons/ResultRowColumnBlockValue.js
+++ b/src/components/browse/components/table-commons/ResultRowColumnBlockValue.js
@@ -99,19 +99,26 @@ export class ResultRowColumnBlockValue extends React.Component {
             renderFxn(result, columnDefinition, _.omit(this.props, 'columnDefinition', 'result'), termTransformFxn)
         );
 
+        // Wrap `value` in a span (provides ellipsis, etc) if is primitive (not custom render fxn output)
+        // Could prly make this less verbose later.. we _do_ want to wrap primitive values output from custom render fxn.
+
         let tooltip;
         if (typeof value === 'number'){
             value = <span className="value">{ value }</span>;
         } else if (typeof value === 'string') {
             if (propTooltip === true && value.length > 25) tooltip = value;
-            value = <span className="value">{ value }</span>;
+            value = <span className="value text-center">{ value }</span>;
         } else if (value === null){
-            value = <small className="value">-</small>;
+            value = <small className="value text-center">-</small>;
         } else if (React.isValidElement(value) && value.type === "a") {
             // We let other columnRender funcs define their `value` container (if any)
             // But if is link, e.g. from termTransformFxn, then wrap it to center it.
-            value = <span className="value">{ value }</span>;
-        }
+            value = <span className="value text-center">{ value }</span>;
+        } else if (typeof value === "boolean") {
+            value = <span className="value text-center">{ value }</span>;
+        } else if (renderFxn === this.memoized.transformIfNeeded){
+            value = <span className="value">{ value }</span>; // JSX from termTransformFxn - assume doesn't take table cell layouting into account.
+        } // else is likely JSX from custom render function -- leave as-is
 
         let cls = "inner";
         if (typeof className === 'string'){

--- a/src/components/browse/components/table-commons/basicColumnExtensionMap.js
+++ b/src/components/browse/components/table-commons/basicColumnExtensionMap.js
@@ -20,6 +20,8 @@ export const basicColumnExtensionMap = {
             const { href, context, rowNumber, detailOpen, toggleDetailOpen } = props;
             // `href` and `context` reliably refer to search href and context here, i.e. will be passed in from VirtualHrefController.
             let title = itemUtil.getTitleStringFromContext(result);
+            // Monospace accessions, file formats
+            const shouldMonospace = (itemUtil.isDisplayTitleAccession(result, title) || (result.file_format && result.file_format === title));
             const link = itemUtil.atId(result);
             let tooltip;
             let hasPhoto = false;
@@ -48,18 +50,28 @@ export const basicColumnExtensionMap = {
                     // Specific case for User items. May be removed or more cases added, if needed.
                     hasPhoto = true;
                     title = (
-                        <span key="title">
+                        <React.Fragment>
                             { itemUtil.User.gravatar(result.email, 32, { 'className' : 'in-search-table-title-image', 'data-tip' : result.email }, 'mm') }
                             { title }
-                        </span>
+                        </React.Fragment>
                     );
                 }
             }
 
+            const cls = (
+                "title-block"
+                + (hasPhoto ? " has-photo d-flex align-items-center"
+                    : " text-ellipsis-container"
+                )
+                + (shouldMonospace ? " text-monospace text-small" : "")
+            );
+
             return (
                 <React.Fragment>
                     <TableRowToggleOpenButton open={detailOpen} onClick={toggleDetailOpen} />
-                    <div key="title-container" className={"title-block" + (hasPhoto ? ' has-photo' : " text-ellipsis-container")} data-tip={tooltip}>{ title }</div>
+                    <div key="title-container" className={cls} data-tip={tooltip}>
+                        { title }
+                    </div>
                 </React.Fragment>
             );
         }
@@ -88,7 +100,7 @@ export const basicColumnExtensionMap = {
             return (
                 <React.Fragment>
                     <div className="icon-container">
-                        <i className="icon icon-fw fas icon-filter clickable mr-05" onClick={onClick} data-tip={"Filter down to only " + itemTypeTitle}/>
+                        <i className="icon icon-fw fas icon-filter clickable mr-08" onClick={onClick} data-tip={"Filter down to only " + itemTypeTitle}/>
                     </div>
                     <span className="item-type-title value">{ itemTypeTitle }</span>
                 </React.Fragment>
@@ -128,7 +140,7 @@ export const basicColumnExtensionMap = {
 /** Button shown in first column (display_title) to open/close detail pane. */
 export const TableRowToggleOpenButton = React.memo(function TableRowToggleOpenButton({ onClick, toggleDetailOpen, open }){
     return (
-        <div className="inline-block toggle-detail-button-container">
+        <div className="toggle-detail-button-container">
             <button type="button" className="toggle-detail-button" onClick={onClick || toggleDetailOpen}>
                 <div className="icon-container">
                     <i className={"icon icon-fw fas icon-" + (open ? 'minus' : 'plus') }/>

--- a/src/components/browse/components/table-commons/basicColumnExtensionMap.js
+++ b/src/components/browse/components/table-commons/basicColumnExtensionMap.js
@@ -17,6 +17,12 @@ export const basicColumnExtensionMap = {
         'minColumnWidth' : 90,
         'order' : -100,
         'render' : function renderDisplayTitleColumn(result, columnDefinition, props, termTransformFxn, width){
+
+            // TODO think about how to more easily customize this for different Item types.
+            // Likely make reusable component containing handleClick and most of its UI...
+            // which this and portals can use for "display_title" column, and then have per-type
+            // overrides/extensions.
+
             const { href, context, rowNumber, detailOpen, toggleDetailOpen } = props;
             // `href` and `context` reliably refer to search href and context here, i.e. will be passed in from VirtualHrefController.
             let title = itemUtil.getTitleStringFromContext(result);

--- a/src/components/browse/components/table-commons/index.js
+++ b/src/components/browse/components/table-commons/index.js
@@ -4,7 +4,10 @@
 export {
     basicColumnExtensionMap,
     DEFAULT_WIDTH_MAP,
-    TableRowToggleOpenButton                    // Might be useful if defining some wicked custom tables.
+    TableRowToggleOpenButton,                    // Might be useful if defining some wicked custom tables.
+    DisplayTitleColumnWrapper,
+    DisplayTitleColumnDefault,
+    DisplayTitleColumnUser
 } from './basicColumnExtensionMap';
 
 export {

--- a/src/components/ui/DropdownButton.js
+++ b/src/components/ui/DropdownButton.js
@@ -1,0 +1,76 @@
+/* eslint-disable no-invalid-this */
+import React from 'react';
+import { WindowClickEventDelegator } from './../util/WindowClickEventDelegator';
+
+// THIS IS A WORK IN PROGRESS
+
+// TODO: create a "DropdownWindowClickManager" or similarly-named global singleton class
+// Will keep track of all DropdownButtons mounted in view to ensure only one open ever at once.
+// Will be similar to WindowClickEventDelegator BUT should be more performant
+// (else can just use WindowClickEventDelegator directly, as is in code below now)
+// by only iterating over clicked element's ancestors (to see if clicked elem is child of _the only_ open dropdown menu) once re: all dropdowns.
+
+export class DropdownButton extends React.PureComponent {
+
+    static defaultProps = {
+        'children' : [
+            <a className="dropdown-item" href="#" key={1}>Action</a>,
+            <a className="dropdown-item" href="#" key={2}>Another action</a>,
+            <a className="dropdown-item" href="#" key={3}>Something else here</a>
+        ],
+        'title' : "Hello World"
+    };
+
+    constructor(props){
+        super(props);
+        this.onWindowClick = this.onWindowClick.bind(this);
+        this.state = { 'open' : false };
+    }
+
+    componentDidMount(){
+        WindowClickEventDelegator.addHandler(this.onWindowClick);
+    }
+
+    componentWillUnmount(){
+        WindowClickEventDelegator.removeHandler(this.onWindowClick);
+    }
+
+    /** Close dropdown on window click unless click within menu. */
+    onWindowClick(evt){
+        // TODO check event target, see if parent of it is our dropdown-menu, if so cancel, else close.
+        // Funcs already exist for this in utils/layout
+    }
+
+    render(){
+        const { children, title, variant, size } = this.props;
+        const { open } = this.state;
+        const cls = ( // TODO finish handling other props
+            "dropdown-toggle btn" +
+            ("btn-" + (variant || "primary")) +
+            ("btn-" + (size || "md"))
+        );
+        return (
+            <div className="dropdown">
+                <button type="button" className={cls} role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    { title }
+                </button>
+                <DropdownMenu {...{ children, open }} />
+            </div>
+        );
+    }
+
+}
+
+
+export const DropdownMenu = React.memo(function DropdownMenu(props){
+    const { children, open } = props;
+    if (!open) return null;
+    return (
+        <div className="dropdown-menu show">
+            { children }
+        </div>
+    );
+});
+
+// TODO create plain Dropdown. Or not. Idk. Can easily create (more) custom Dropdown togglers and whatnot by emulating the above DropdownButton so not sure is worth adding more complexity...
+

--- a/src/components/ui/ItemDetailList.js
+++ b/src/components/ui/ItemDetailList.js
@@ -805,7 +805,6 @@ export class Detail extends React.PureComponent {
             'schema_version',
             'uuid',
             'replicate_exps',
-            'dbxrefs',
             'status',
             'external_references',
             'date_created',

--- a/src/components/util/WindowClickEventDelegator.js
+++ b/src/components/util/WindowClickEventDelegator.js
@@ -1,0 +1,68 @@
+/* eslint-disable no-invalid-this */
+import { isServerSide } from './../util/misc';
+
+
+/**
+ * Global singleton.
+ *
+ * To avoid attaching event listeners to window, can import this
+ * singleton class instance and add/remove event handlers upon
+ * mount and dismount.
+ *
+ * This is the way classes/instances r created in JS under the modern ECMAScript hood :-P.
+ *
+ * @todo maybe handle more events rather than just click.
+ */
+export const WindowClickEventDelegator = new (function(){
+
+    if (isServerSide()){
+        console.warn("WindowClickEventDelegator is not supported server-side.");
+        return;
+    }
+
+    // Private inaccessible variables
+
+    /** @type {Object.<string,Set<function>>} */
+    const handlersByEvent = {};
+    /** @type {Object.<string,function>} */
+    const windowEventHandlersByEvent = {};
+    /** @type {Object.<string,boolean>} */
+    const isInitializedByEvent = {};
+
+    function onWindowEvent(eventName, eventObject){
+        for (const handlerFxn of handlersByEvent[eventName]) {
+            handlerFxn(eventObject);
+        }
+    }
+
+    // Exposed Methods
+
+    this.addHandler = function(eventName, eventHandlerFxn){
+
+        if (typeof windowEventHandlersByEvent[eventName] === "undefined") {
+            windowEventHandlersByEvent[eventName] = onWindowEvent.bind(null, eventName);
+        }
+
+        if (typeof handlersByEvent[eventName] === "undefined") {
+            handlersByEvent[eventName] = new Set();
+        }
+
+        handlersByEvent[eventName].add(eventHandlerFxn);
+
+        if (!isInitializedByEvent[eventName]) {
+            isInitializedByEvent[eventName] = true;
+            window.addEventListener(eventName, windowEventHandlersByEvent[eventName], { passive: true });
+        }
+    };
+
+    this.removeHandler = function(eventName, eventHandlerFxn){
+        handlersByEvent[eventName].delete(eventHandlerFxn);
+        if (handlersByEvent[eventName].size === 0) {
+            window.removeEventListener(eventName, windowEventHandlersByEvent[eventName]);
+            delete handlersByEvent[eventName];
+            delete isInitializedByEvent[eventName];
+            delete windowEventHandlersByEvent[eventName];
+        }
+    };
+
+})();

--- a/src/components/util/index.js
+++ b/src/components/util/index.js
@@ -79,3 +79,5 @@ export const commonFileUtil = fileUtilities;
 // Helpers for managing SubmissionView state (Context, Hierarchy, etc.)
 import * as submissionViewUtilities from './submission-view';
 export const submissionStateUtil = submissionViewUtilities;
+
+export { WindowClickEventDelegator } from './WindowClickEventDelegator';

--- a/src/components/util/layout.js
+++ b/src/components/util/layout.js
@@ -371,6 +371,24 @@ export function isDOMElementChildOfElementWithClass(elem, className, maxDepth=5)
     return false;
 }
 
+/**
+ * Designed to work similarly to `Array.find()`.
+ *
+ * @param {HTMLElement} Element to find ancestor (or self) of.
+ * @param {function} Assertion function, should return `true` if valid element or false if not.
+ * @returns {HTMLElement|undefined} Ancestor (or self) element for which searchFxn returns true, if any.
+ */
+export function findParentElement(startElement, searchFxn) {
+    let domElem = startElement;
+    while (domElem) {
+        if (searchFxn(domElem)) {
+            return domElem;
+        }
+        domElem = domElem.parentElement;
+    }
+    return; // undefined
+}
+
 
 /**
  * Meant to be used in click handlers. See app.js.
@@ -378,12 +396,11 @@ export function isDOMElementChildOfElementWithClass(elem, className, maxDepth=5)
  * event bubble chain (same event bubbles up).
  */
 export const elementIsChildOfLink = memoize(function(initDomElement){
-    let domElem = initDomElement;
-    // SVG anchor elements have tagName == 'a' while HTML anchor elements have tagName == 'A'
-    while (domElem && (domElem.tagName.toLowerCase() !== 'a' && !domElem.getAttribute('data-href'))) {
-        domElem = domElem.parentElement;
-    }
-    return domElem;
+    const foundElem = findParentElement(initDomElement, function(domElem){
+        // SVG anchor elements have tagName == 'a' while HTML anchor elements have tagName == 'A'
+        return (domElem.tagName.toLowerCase() === "a" || domElem.getAttribute('data-href'));
+    });
+    return foundElem || initDomElement;
 });
 
 


### PR DESCRIPTION
**Should be merged with CGAP PR https://github.com/dbmi-bgm/cgap-portal/pull/109 & 4DN portal updated re: new columnExtensionMap render function signature**

### Once merged / released, do NOT update 4DN SPC version past this version until update columnExtensionMap render functions/signatures

## Changes

This is mostly refactoring of various things relating to SearchResultTable in order to allow in CGAP to create table cells which have multiple lines, as well as to allow multiple sort options. Some code/functionality that is not too clean has been removed (i.e. forceUpdate method usage and such). Flexboxes allow lot more layout possibilities with ease than historical pre-CSS3 approaches.

Following this, "Display Title" column block styling has been updated a bit to take advantage of flexbox display. "Width" as a prop (of the table cell) becomes largely irrelevant for most things and might be worth stopping passing it down to ResultRowColumnBlock at all (aside from where is applied as width of element).

What was started on at one point was converting SearchResultTable cells from having `display: inline-block` or `float: left` (whichever it was back in the day) to `display: flex`, this branch largely attempts to finish that up. The actual component to render multiple values will be created in context of Variants Item data, once it exists.

## Previews

[Video Preview as of 04/12/2020](https://gyazo.com/af697255aef82def14a9d8326f413b00)

Screenshot as of 04/13/2020:
![](https://i.gyazo.com/048b075cb1af7bb0daee9b2ee1e6b73c.png)
(+ "multiple options" indicator appended to bottom right of sort icon)

Screenshot as of 04/14/2020:
![](https://i.gyazo.com/6562eaa88f1d562a1997b565f740ae08.png)

This PR is first of multiple ones for table improvements re: new CGAP UXD.

Should be relatively self-explanatory; UX should be what think should be heuristically expected for such feature and code to enable it is stable/readable/performant.

The following PR will be styling/content of results row re: new CGAP UX+design+styling (e.g. col striping).


_Low-Priority Longer Term Stuff:_
- Consider to no longer ever use React-Bootstrap and instead favor Bootstrap (official library) CSS + own JS. If possible. Lmk thoughts.
  - And ~~later~~ maybe way later to refactor/remove react-bootstrap dependency completely, creating drop-in replacements for still-used common components such as `DropdownButton` (straightforward: global singleton class tracks all dropdown instances to only allow 1 to be open at once, close when click off).
- Styling for CGAP dropdowns to match CGAP branding intents (any that we know of now, anyway) slightly better. Something better than plain white BG + 1px border + border radius.
