### PR TITLE
fix for findValidationState; update parent valid. state on obj submission

### DIFF
--- a/es/components/browse/SearchView.js
+++ b/es/components/browse/SearchView.js
@@ -79,45 +79,15 @@ function _defineProperties(target, props) { for (var i = 0; i < props.length; i+
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
-
-function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function (o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
-
-function _createSuper(Derived) {
-  function isNativeReflectConstruct() {
-    if (typeof Reflect === "undefined" || !Reflect.construct) return false;
-    if (Reflect.construct.sham) return false;
-    if (typeof Proxy === "function") return true;
-
-    try {
-      Date.prototype.toString.call(Reflect.construct(Date, [], function () {}));
-      return true;
-    } catch (e) {
-      return false;
-    }
-  }
-
-  return function () {
-    var Super = _getPrototypeOf(Derived),
-        result;
-
-    if (isNativeReflectConstruct()) {
-      var NewTarget = _getPrototypeOf(this).constructor;
-
-      result = Reflect.construct(Super, arguments, NewTarget);
-    } else {
-      result = Super.apply(this, arguments);
-    }
-
-    return _possibleConstructorReturn(this, result);
-  };
-}
-
 function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function (o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function (o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
@@ -126,12 +96,10 @@ var SearchView =
 function (_React$PureComponent) {
   _inherits(SearchView, _React$PureComponent);
 
-  var _super = _createSuper(SearchView);
-
   function SearchView() {
     _classCallCheck(this, SearchView);
 
-    return _super.apply(this, arguments);
+    return _possibleConstructorReturn(this, _getPrototypeOf(SearchView).apply(this, arguments));
   }
 
   _createClass(SearchView, [{
@@ -177,7 +145,7 @@ function (_React$PureComponent) {
       // in each controller that's child of <ColumnCombiner {...{ context, columns, columnExtensionMap }}>.
       // As well as in ControlsAndResults.
 
-      var childViewProps = _objectSpread(_objectSpread({}, passProps), {}, {
+      var childViewProps = _objectSpread({}, passProps, {
         currentAction: currentAction,
         schemas: schemas,
         windowWidth: windowWidth,
@@ -185,32 +153,20 @@ function (_React$PureComponent) {
         facets: propFacets || contextFacets
       });
 
-      var controllersAndView =
-      /*#__PURE__*/
-      _react["default"].createElement(_WindowNavigationController.WindowNavigationController, _extends({
+      var controllersAndView = _react["default"].createElement(_WindowNavigationController.WindowNavigationController, _extends({
         href: href,
         context: context
       }, {
         navigate: propNavigate
-      }),
-      /*#__PURE__*/
-      _react["default"].createElement(_tableCommons.ColumnCombiner, {
+      }), _react["default"].createElement(_tableCommons.ColumnCombiner, {
         columns: columns,
         columnExtensionMap: columnExtensionMap
-      },
-      /*#__PURE__*/
-      _react["default"].createElement(_CustomColumnController.CustomColumnController, null,
-      /*#__PURE__*/
-      _react["default"].createElement(_SortController.SortController, null,
-      /*#__PURE__*/
-      _react["default"].createElement(_ControlsAndResults.ControlsAndResults, childViewProps)))));
+      }, _react["default"].createElement(_CustomColumnController.CustomColumnController, null, _react["default"].createElement(_SortController.SortController, null, _react["default"].createElement(_ControlsAndResults.ControlsAndResults, childViewProps)))));
 
       if ((0, _misc.isSelectAction)(currentAction)) {
         // We don't allow "SelectionMode" unless is own page.
         // Could consider changing later once a use case exists.
-        controllersAndView =
-        /*#__PURE__*/
-        // SelectedItemsController must be above ColumnCombiner because it adjusts
+        controllersAndView = // SelectedItemsController must be above ColumnCombiner because it adjusts
         // columnExtensionMap, rather than columnDefinitions. This can be easily changed
         // though if desired.
         _react["default"].createElement(_SelectedItemsController.SelectedItemsController, {
@@ -219,17 +175,12 @@ function (_React$PureComponent) {
         }, controllersAndView);
       }
 
-      return (
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: "search-page-container"
-        },
-        /*#__PURE__*/
-        _react["default"].createElement(_AboveSearchTablePanel.AboveSearchTablePanel, {
-          context: context,
-          placeholderReplacementFxn: placeholderReplacementFxn
-        }), controllersAndView)
-      );
+      return _react["default"].createElement("div", {
+        className: "search-page-container"
+      }, _react["default"].createElement(_AboveSearchTablePanel.AboveSearchTablePanel, {
+        context: context,
+        placeholderReplacementFxn: placeholderReplacementFxn
+      }), controllersAndView);
     }
   }]);
 

--- a/es/components/browse/components/FacetList/FacetTermsList.js
+++ b/es/components/browse/components/FacetList/FacetTermsList.js
@@ -50,45 +50,15 @@ function _defineProperties(target, props) { for (var i = 0; i < props.length; i+
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
-
-function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function (o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
-
-function _createSuper(Derived) {
-  function isNativeReflectConstruct() {
-    if (typeof Reflect === "undefined" || !Reflect.construct) return false;
-    if (Reflect.construct.sham) return false;
-    if (typeof Proxy === "function") return true;
-
-    try {
-      Date.prototype.toString.call(Reflect.construct(Date, [], function () {}));
-      return true;
-    } catch (e) {
-      return false;
-    }
-  }
-
-  return function () {
-    var Super = _getPrototypeOf(Derived),
-        result;
-
-    if (isNativeReflectConstruct()) {
-      var NewTarget = _getPrototypeOf(this).constructor;
-
-      result = Reflect.construct(Super, arguments, NewTarget);
-    } else {
-      result = Super.apply(this, arguments);
-    }
-
-    return _possibleConstructorReturn(this, result);
-  };
-}
-
 function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function (o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
-function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function (o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function (o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
 /**
  * Used in FacetList
@@ -202,14 +172,12 @@ var Term =
 function (_React$PureComponent) {
   _inherits(Term, _React$PureComponent);
 
-  var _super = _createSuper(Term);
-
   function Term(props) {
     var _this;
 
     _classCallCheck(this, Term);
 
-    _this = _super.call(this, props);
+    _this = _possibleConstructorReturn(this, _getPrototypeOf(Term).call(this, props));
     _this.handleClick = _underscore["default"].debounce(_this.handleClick.bind(_assertThisInitialized(_this)), 500, true);
     _this.state = {
       'filtering': false
@@ -279,21 +247,15 @@ function (_React$PureComponent) {
       var icon = null;
 
       if (filtering) {
-        icon =
-        /*#__PURE__*/
-        _react["default"].createElement("i", {
+        icon = _react["default"].createElement("i", {
           className: "icon fas icon-circle-notch icon-spin icon-fw"
         });
       } else if (status === 'selected' || status === 'omitted') {
-        icon =
-        /*#__PURE__*/
-        _react["default"].createElement("i", {
+        icon = _react["default"].createElement("i", {
           className: "icon icon-minus-circle icon-fw fas"
         });
       } else {
-        icon =
-        /*#__PURE__*/
-        _react["default"].createElement("i", {
+        icon = _react["default"].createElement("i", {
           className: "icon icon-circle icon-fw unselected far"
         });
       }
@@ -303,35 +265,24 @@ function (_React$PureComponent) {
       }
 
       var statusClassName = status !== 'none' ? status === 'selected' ? " selected" : " omitted" : '';
-      return (
-        /*#__PURE__*/
-        _react["default"].createElement("li", {
-          className: "facet-list-element " + statusClassName,
-          key: term.key,
-          "data-key": term.key
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("a", {
-          className: "term",
-          "data-selected": status !== 'none',
-          href: "#",
-          onClick: this.handleClick,
-          "data-term": term.key
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("span", {
-          className: "facet-selector"
-        }, icon),
-        /*#__PURE__*/
-        _react["default"].createElement("span", {
-          className: "facet-item",
-          "data-tip": title.length > 30 ? title : null
-        }, title),
-        /*#__PURE__*/
-        _react["default"].createElement("span", {
-          className: "facet-count"
-        }, count)))
-      );
+      return _react["default"].createElement("li", {
+        className: "facet-list-element " + statusClassName,
+        key: term.key,
+        "data-key": term.key
+      }, _react["default"].createElement("a", {
+        className: "term",
+        "data-selected": status !== 'none',
+        href: "#",
+        onClick: this.handleClick,
+        "data-term": term.key
+      }, _react["default"].createElement("span", {
+        className: "facet-selector"
+      }, icon), _react["default"].createElement("span", {
+        className: "facet-item",
+        "data-tip": title.length > 30 ? title : null
+      }, title), _react["default"].createElement("span", {
+        className: "facet-count"
+      }, count)));
     }
   }]);
 
@@ -356,14 +307,12 @@ var FacetTermsList =
 function (_React$PureComponent2) {
   _inherits(FacetTermsList, _React$PureComponent2);
 
-  var _super2 = _createSuper(FacetTermsList);
-
   function FacetTermsList(props) {
     var _this3;
 
     _classCallCheck(this, FacetTermsList);
 
-    _this3 = _super2.call(this, props);
+    _this3 = _possibleConstructorReturn(this, _getPrototypeOf(FacetTermsList).call(this, props));
     _this3.handleOpenToggleClick = _this3.handleOpenToggleClick.bind(_assertThisInitialized(_this3));
     _this3.handleExpandListToggleClick = _this3.handleExpandListToggleClick.bind(_assertThisInitialized(_this3));
     _this3.state = {
@@ -417,89 +366,62 @@ function (_React$PureComponent2) {
       var indicator; // @todo: much of this code (including mergeTerms and anyTermsSelected above) were moved to index; consider moving these too
 
       if (isStatic || termsLen === 1) {
-        indicator =
-        /*#__PURE__*/
-        // Small indicator to help represent how many terms there are available for this Facet.
+        indicator = // Small indicator to help represent how many terms there are available for this Facet.
         _react["default"].createElement(_Fade.Fade, {
           "in": !facetOpen
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("span", {
+        }, _react["default"].createElement("span", {
           className: "closed-terms-count col-auto px-0" + (anySelected ? " some-selected" : ""),
           "data-tip": "No useful options (1 total)" + (anySelected ? "; is selected" : ""),
           "data-place": "right",
           "data-any-selected": anySelected
-        },
-        /*#__PURE__*/
-        _react["default"].createElement(CountIndicator, {
+        }, _react["default"].createElement(CountIndicator, {
           count: termsLen,
           countActive: termsSelectedCount
         })));
       } else {
-        indicator =
-        /*#__PURE__*/
-        // Small indicator to help represent how many terms there are available for this Facet.
+        indicator = // Small indicator to help represent how many terms there are available for this Facet.
         _react["default"].createElement(_Fade.Fade, {
           "in": !facetOpen
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("span", {
+        }, _react["default"].createElement("span", {
           className: "closed-terms-count col-auto px-0" + (anySelected ? " some-selected" : ""),
           "data-tip": "".concat(termsLen, " options with ").concat(termsSelectedCount, " selected"),
           "data-place": "right",
           "data-any-selected": anySelected
-        },
-        /*#__PURE__*/
-        _react["default"].createElement(CountIndicator, {
+        }, _react["default"].createElement(CountIndicator, {
           count: termsLen,
           countActive: termsSelectedCount
         })));
       } // List of terms
 
 
-      return (
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: "facet" + (facetOpen || allTermsSelected ? ' open' : ' closed'),
-          "data-field": facet.field
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("h5", {
-          className: "facet-title",
-          onClick: this.handleOpenToggleClick
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("span", {
-          className: "expand-toggle col-auto px-0"
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("i", {
-          className: "icon icon-fw icon-" + (allTermsSelected ? "dot-circle far" : (facetOpen ? "minus" : "plus") + " fas")
-        })),
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: "col px-0 line-height-1"
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("span", {
-          "data-tip": description,
-          "data-html": true,
-          "data-place": "right"
-        }, title)), indicator),
-        /*#__PURE__*/
-        _react["default"].createElement(ListOfTerms, _extends({
-          facet: facet,
-          facetOpen: facetOpen,
-          terms: terms,
-          persistentCount: persistentCount,
-          onTermClick: onTermClick,
-          expanded: expanded,
-          getTermStatus: getTermStatus,
-          termTransformFxn: termTransformFxn
-        }, {
-          onToggleExpanded: this.handleExpandListToggleClick
-        })))
-      );
+      return _react["default"].createElement("div", {
+        className: "facet" + (facetOpen || allTermsSelected ? ' open' : ' closed'),
+        "data-field": facet.field
+      }, _react["default"].createElement("h5", {
+        className: "facet-title",
+        onClick: this.handleOpenToggleClick
+      }, _react["default"].createElement("span", {
+        className: "expand-toggle col-auto px-0"
+      }, _react["default"].createElement("i", {
+        className: "icon icon-fw icon-" + (allTermsSelected ? "dot-circle far" : (facetOpen ? "minus" : "plus") + " fas")
+      })), _react["default"].createElement("div", {
+        className: "col px-0 line-height-1"
+      }, _react["default"].createElement("span", {
+        "data-tip": description,
+        "data-html": true,
+        "data-place": "right"
+      }, title)), indicator), _react["default"].createElement(ListOfTerms, _extends({
+        facet: facet,
+        facetOpen: facetOpen,
+        terms: terms,
+        persistentCount: persistentCount,
+        onTermClick: onTermClick,
+        expanded: expanded,
+        getTermStatus: getTermStatus,
+        termTransformFxn: termTransformFxn
+      }, {
+        onToggleExpanded: this.handleExpandListToggleClick
+      })));
     }
   }]);
 
@@ -526,18 +448,15 @@ var ListOfTerms = _react["default"].memo(function (props) {
 
   var _useMemo = (0, _react.useMemo)(function () {
     var _segmentTermComponent = segmentTermComponentsByStatus(terms.map(function (term) {
-      return (
-        /*#__PURE__*/
-        _react["default"].createElement(Term, _extends({
-          facet: facet,
-          term: term,
-          termTransformFxn: termTransformFxn
-        }, {
-          onClick: onTermClick,
-          key: term.key,
-          status: getTermStatus(term, facet)
-        }))
-      );
+      return _react["default"].createElement(Term, _extends({
+        facet: facet,
+        term: term,
+        termTransformFxn: termTransformFxn
+      }, {
+        onClick: onTermClick,
+        key: term.key,
+        status: getTermStatus(term, facet)
+      }));
     })),
         _segmentTermComponent2 = _segmentTermComponent.selected,
         selectedTermComponents = _segmentTermComponent2 === void 0 ? [] : _segmentTermComponent2,
@@ -609,68 +528,40 @@ var ListOfTerms = _react["default"].memo(function (props) {
     var expandButtonTitle;
 
     if (expanded) {
-      expandButtonTitle =
-      /*#__PURE__*/
-      _react["default"].createElement("span", null,
-      /*#__PURE__*/
-      _react["default"].createElement("i", {
+      expandButtonTitle = _react["default"].createElement("span", null, _react["default"].createElement("i", {
         className: "icon icon-fw icon-minus fas"
       }), " Collapse");
     } else {
-      expandButtonTitle =
-      /*#__PURE__*/
-      _react["default"].createElement("span", null,
-      /*#__PURE__*/
-      _react["default"].createElement("i", {
+      expandButtonTitle = _react["default"].createElement("span", null, _react["default"].createElement("i", {
         className: "icon icon-fw icon-plus fas"
-      }), " View ", collapsibleTermsCount, " More",
-      /*#__PURE__*/
-      _react["default"].createElement("span", {
+      }), " View ", collapsibleTermsCount, " More", _react["default"].createElement("span", {
         className: "pull-right"
       }, collapsibleTermsItemCount));
     }
 
-    return (
-      /*#__PURE__*/
-      _react["default"].createElement("div", commonProps,
-      /*#__PURE__*/
-      _react["default"].createElement(_PartialList.PartialList, {
-        className: "mb-0 active-terms-pl",
-        open: facetOpen,
-        persistent: activeTermComponents,
-        collapsible:
-        /*#__PURE__*/
-        _react["default"].createElement(_react["default"].Fragment, null,
-        /*#__PURE__*/
-        _react["default"].createElement(_PartialList.PartialList, {
-          className: "mb-0",
-          open: expanded,
-          persistent: persistentTerms,
-          collapsible: collapsibleTerms
-        }),
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: "pt-08 pb-0"
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: "view-more-button",
-          onClick: onToggleExpanded
-        }, expandButtonTitle)))
-      }))
-    );
+    return _react["default"].createElement("div", commonProps, _react["default"].createElement(_PartialList.PartialList, {
+      className: "mb-0 active-terms-pl",
+      open: facetOpen,
+      persistent: activeTermComponents,
+      collapsible: _react["default"].createElement(_react["default"].Fragment, null, _react["default"].createElement(_PartialList.PartialList, {
+        className: "mb-0",
+        open: expanded,
+        persistent: persistentTerms,
+        collapsible: collapsibleTerms
+      }), _react["default"].createElement("div", {
+        className: "pt-08 pb-0"
+      }, _react["default"].createElement("div", {
+        className: "view-more-button",
+        onClick: onToggleExpanded
+      }, expandButtonTitle)))
+    }));
   } else {
-    return (
-      /*#__PURE__*/
-      _react["default"].createElement("div", commonProps,
-      /*#__PURE__*/
-      _react["default"].createElement(_PartialList.PartialList, {
-        className: "mb-0 active-terms-pl",
-        open: facetOpen,
-        persistent: activeTermComponents,
-        collapsible: unselectedTermComponents
-      }))
-    );
+    return _react["default"].createElement("div", commonProps, _react["default"].createElement(_PartialList.PartialList, {
+      className: "mb-0 active-terms-pl",
+      open: facetOpen,
+      persistent: activeTermComponents,
+      collapsible: unselectedTermComponents
+    }));
   }
 });
 
@@ -692,30 +583,24 @@ var CountIndicator = _react["default"].memo(function (_ref4) {
 
     var colIdx = Math.floor(idx / 3); // Flip both axes so going bottom right to top left.
 
-    return (
-      /*#__PURE__*/
-      _react["default"].createElement("circle", {
-        cx: width - x + 1,
-        cy: height - y + 1,
-        r: 2,
-        key: idx,
-        "data-original-index": idx,
-        style: {
-          opacity: 1 - colIdx * .125
-        },
-        className: dotCountToShow - idx <= countActive ? "active" : null
-      })
-    );
+    return _react["default"].createElement("circle", {
+      cx: width - x + 1,
+      cy: height - y + 1,
+      r: 2,
+      key: idx,
+      "data-original-index": idx,
+      style: {
+        opacity: 1 - colIdx * .125
+      },
+      className: dotCountToShow - idx <= countActive ? "active" : null
+    });
   });
-  return (
-    /*#__PURE__*/
-    _react["default"].createElement("svg", {
-      className: "svg-count-indicator",
-      viewBox: "0 0 ".concat(width + 2, " ").concat(height + 2),
-      width: width + 2,
-      height: height + 2
-    }, dots)
-  );
+  return _react["default"].createElement("svg", {
+    className: "svg-count-indicator",
+    viewBox: "0 0 ".concat(width + 2, " ").concat(height + 2),
+    width: width + 2,
+    height: height + 2
+  }, dots);
 });
 
 exports.CountIndicator = CountIndicator;

--- a/es/components/browse/components/FacetList/RangeFacet.js
+++ b/es/components/browse/components/FacetList/RangeFacet.js
@@ -44,6 +44,12 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function (o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
 function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
@@ -51,42 +57,6 @@ function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _d
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
 
 function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function (o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
-
-function _createSuper(Derived) {
-  function isNativeReflectConstruct() {
-    if (typeof Reflect === "undefined" || !Reflect.construct) return false;
-    if (Reflect.construct.sham) return false;
-    if (typeof Proxy === "function") return true;
-
-    try {
-      Date.prototype.toString.call(Reflect.construct(Date, [], function () {}));
-      return true;
-    } catch (e) {
-      return false;
-    }
-  }
-
-  return function () {
-    var Super = _getPrototypeOf(Derived),
-        result;
-
-    if (isNativeReflectConstruct()) {
-      var NewTarget = _getPrototypeOf(this).constructor;
-
-      result = Reflect.construct(Super, arguments, NewTarget);
-    } else {
-      result = Super.apply(this, arguments);
-    }
-
-    return _possibleConstructorReturn(this, result);
-  };
-}
-
-function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
-
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
-
-function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function (o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
 function getRangeValuesFromFiltersByField() {
   var facets = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : [];
@@ -127,8 +97,6 @@ var RangeFacet =
 /*#__PURE__*/
 function (_React$PureComponent) {
   _inherits(RangeFacet, _React$PureComponent);
-
-  var _super = _createSuper(RangeFacet);
 
   _createClass(RangeFacet, null, [{
     key: "parseNumber",
@@ -241,7 +209,7 @@ function (_React$PureComponent) {
 
     _classCallCheck(this, RangeFacet);
 
-    _this = _super.call(this, props);
+    _this = _possibleConstructorReturn(this, _getPrototypeOf(RangeFacet).call(this, props));
     _this.handleOpenToggleClick = _this.handleOpenToggleClick.bind(_assertThisInitialized(_this));
     _this.setFrom = _this.setFrom.bind(_assertThisInitialized(_this));
     _this.setTo = _this.setTo.bind(_assertThisInitialized(_this));
@@ -338,7 +306,7 @@ function (_React$PureComponent) {
           onFilter = _this$props.onFilter,
           facet = _this$props.facet;
       var fromVal = this.state.fromVal;
-      onFilter(_objectSpread(_objectSpread({}, facet), {}, {
+      onFilter(_objectSpread({}, facet, {
         field: facet.field + ".from"
       }), {
         key: fromVal
@@ -351,7 +319,7 @@ function (_React$PureComponent) {
           onFilter = _this$props2.onFilter,
           facet = _this$props2.facet;
       var toVal = this.state.toVal;
-      onFilter(_objectSpread(_objectSpread({}, facet), {}, {
+      onFilter(_objectSpread({}, facet, {
         field: facet.field + ".to"
       }), {
         key: toVal
@@ -426,134 +394,83 @@ function (_React$PureComponent) {
           toIncrements = _this$memoized$validI.toIncrements;
 
       var isOpen = facetOpen || savedFromVal !== null || savedToVal !== null;
-      return (
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: "facet range-facet" + (isOpen ? ' open' : ' closed'),
-          "data-field": facet.field
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("h5", {
-          className: "facet-title",
-          onClick: this.handleOpenToggleClick
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("span", {
-          className: "expand-toggle col-auto px-0"
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("i", {
-          className: "icon icon-fw icon-" + (savedFromVal !== null || savedToVal !== null ? "dot-circle far" : isOpen ? "minus fas" : "plus fas")
-        })),
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: "col px-0 line-height-1"
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("span", {
-          "data-tip": tooltip,
-          "data-place": "right"
-        }, propTitle || facetTitle || field)),
-        /*#__PURE__*/
-        _react["default"].createElement(_reactBootstrap.Fade, {
-          "in": !isOpen
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("span", {
-          className: "closed-terms-count col-auto px-0" + (savedFromVal !== null || savedToVal !== null ? " some-selected" : "")
-        }, isStatic ?
-        /*#__PURE__*/
-        _react["default"].createElement("i", {
-          className: "icon fas icon-" + (savedFromVal !== null || savedToVal !== null ? "circle" : "minus-circle"),
-          style: {
-            opacity: savedFromVal !== null || savedToVal !== null ? 0.75 : 0.25
-          }
-        }) :
-        /*#__PURE__*/
-        _react["default"].createElement("i", {
-          className: "icon icon-fw icon-greater-than-equal fas"
-        })))),
-        /*#__PURE__*/
-        _react["default"].createElement(_Collapse.Collapse, {
-          "in": isOpen
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: "inner-panel"
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: "row"
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("label", {
-          className: "col-auto mb-0"
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("i", {
-          className: "icon icon-fw icon-greater-than-equal fas small"
-        })),
-        /*#__PURE__*/
-        _react["default"].createElement(RangeDropdown, {
-          title: this.termTitle(facet.field, typeof fromVal === 'number' ? fromVal : min || 0),
-          value: fromVal,
-          savedValue: savedFromVal,
-          max: toVal || null,
-          increments: fromIncrements,
-          variant: typeof fromVal === "number" || savedFromVal ? "primary" : "outline-dark",
-          onSelect: this.setFrom,
-          update: this.performUpdateFrom,
-          termTransformFxn: this.termTitle,
-          facet: facet,
-          id: "from_" + field
-        }),
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: "clear-icon-container col-auto" + (fromVal === null ? " disabled" : " clickable"),
-          onClick: fromVal !== null ? this.resetFrom : null
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("i", {
-          className: "icon icon-fw fas icon-" + (fromVal === null ? "pencil" : "times-circle")
-        }))),
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: "row"
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("label", {
-          className: "col-auto mb-0"
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("i", {
-          className: "icon icon-fw icon-less-than-equal fas small"
-        })),
-        /*#__PURE__*/
-        _react["default"].createElement(RangeDropdown, {
-          title: this.termTitle(facet.field, typeof toVal === 'number' ? toVal : max) ||
-          /*#__PURE__*/
-          _react["default"].createElement("em", null, "Infinity"),
-          value: toVal,
-          savedValue: savedToVal,
-          min: fromVal || null,
-          increments: toIncrements,
-          variant: typeof toVal === "number" || savedToVal ? "primary" : "outline-dark",
-          onSelect: this.setTo,
-          update: this.performUpdateTo,
-          termTransformFxn: this.termTitle,
-          facet: facet,
-          id: "to_" + field
-        }),
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: "clear-icon-container col-auto" + (toVal === null ? " disabled" : " clickable"),
-          onClick: toVal !== null ? this.resetTo : null
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("i", {
-          className: "icon icon-fw fas icon-" + (toVal === null ? "pencil" : "times-circle")
-        }))))))
-      );
+      return _react["default"].createElement("div", {
+        className: "facet range-facet" + (isOpen ? ' open' : ' closed'),
+        "data-field": facet.field
+      }, _react["default"].createElement("h5", {
+        className: "facet-title",
+        onClick: this.handleOpenToggleClick
+      }, _react["default"].createElement("span", {
+        className: "expand-toggle col-auto px-0"
+      }, _react["default"].createElement("i", {
+        className: "icon icon-fw icon-" + (savedFromVal !== null || savedToVal !== null ? "dot-circle far" : isOpen ? "minus fas" : "plus fas")
+      })), _react["default"].createElement("div", {
+        className: "col px-0 line-height-1"
+      }, _react["default"].createElement("span", {
+        "data-tip": tooltip,
+        "data-place": "right"
+      }, propTitle || facetTitle || field)), _react["default"].createElement(_reactBootstrap.Fade, {
+        "in": !isOpen
+      }, _react["default"].createElement("span", {
+        className: "closed-terms-count col-auto px-0" + (savedFromVal !== null || savedToVal !== null ? " some-selected" : "")
+      }, isStatic ? _react["default"].createElement("i", {
+        className: "icon fas icon-" + (savedFromVal !== null || savedToVal !== null ? "circle" : "minus-circle"),
+        style: {
+          opacity: savedFromVal !== null || savedToVal !== null ? 0.75 : 0.25
+        }
+      }) : _react["default"].createElement("i", {
+        className: "icon icon-fw icon-greater-than-equal fas"
+      })))), _react["default"].createElement(_Collapse.Collapse, {
+        "in": isOpen
+      }, _react["default"].createElement("div", {
+        className: "inner-panel"
+      }, _react["default"].createElement("div", {
+        className: "row"
+      }, _react["default"].createElement("label", {
+        className: "col-auto mb-0"
+      }, _react["default"].createElement("i", {
+        className: "icon icon-fw icon-greater-than-equal fas small"
+      })), _react["default"].createElement(RangeDropdown, {
+        title: this.termTitle(facet.field, typeof fromVal === 'number' ? fromVal : min || 0),
+        value: fromVal,
+        savedValue: savedFromVal,
+        max: toVal || null,
+        increments: fromIncrements,
+        variant: typeof fromVal === "number" || savedFromVal ? "primary" : "outline-dark",
+        onSelect: this.setFrom,
+        update: this.performUpdateFrom,
+        termTransformFxn: this.termTitle,
+        facet: facet,
+        id: "from_" + field
+      }), _react["default"].createElement("div", {
+        className: "clear-icon-container col-auto" + (fromVal === null ? " disabled" : " clickable"),
+        onClick: fromVal !== null ? this.resetFrom : null
+      }, _react["default"].createElement("i", {
+        className: "icon icon-fw fas icon-" + (fromVal === null ? "pencil" : "times-circle")
+      }))), _react["default"].createElement("div", {
+        className: "row"
+      }, _react["default"].createElement("label", {
+        className: "col-auto mb-0"
+      }, _react["default"].createElement("i", {
+        className: "icon icon-fw icon-less-than-equal fas small"
+      })), _react["default"].createElement(RangeDropdown, {
+        title: this.termTitle(facet.field, typeof toVal === 'number' ? toVal : max) || _react["default"].createElement("em", null, "Infinity"),
+        value: toVal,
+        savedValue: savedToVal,
+        min: fromVal || null,
+        increments: toIncrements,
+        variant: typeof toVal === "number" || savedToVal ? "primary" : "outline-dark",
+        onSelect: this.setTo,
+        update: this.performUpdateTo,
+        termTransformFxn: this.termTitle,
+        facet: facet,
+        id: "to_" + field
+      }), _react["default"].createElement("div", {
+        className: "clear-icon-container col-auto" + (toVal === null ? " disabled" : " clickable"),
+        onClick: toVal !== null ? this.resetTo : null
+      }, _react["default"].createElement("i", {
+        className: "icon icon-fw fas icon-" + (toVal === null ? "pencil" : "times-circle")
+      }))))));
     }
   }]);
 
@@ -567,14 +484,12 @@ var RangeDropdown =
 function (_React$PureComponent2) {
   _inherits(RangeDropdown, _React$PureComponent2);
 
-  var _super2 = _createSuper(RangeDropdown);
-
   function RangeDropdown(props) {
     var _this2;
 
     _classCallCheck(this, RangeDropdown);
 
-    _this2 = _super2.call(this, props);
+    _this2 = _possibleConstructorReturn(this, _getPrototypeOf(RangeDropdown).call(this, props));
     _this2.onTextInputChange = _this2.onTextInputChange.bind(_assertThisInitialized(_this2));
     _this2.onDropdownSelect = _this2.onDropdownSelect.bind(_assertThisInitialized(_this2));
     _this2.onTextInputFormSubmit = _this2.onTextInputFormSubmit.bind(_assertThisInitialized(_this2));
@@ -660,67 +575,47 @@ function (_React$PureComponent2) {
 
         return m;
       }, new Set())).map(function (increment) {
-        return (
-          /*#__PURE__*/
-          _react["default"].createElement(_reactBootstrap.DropdownItem, {
-            disabled: typeof min === "number" && increment <= min || typeof max === "number" && increment >= max,
-            key: increment,
-            eventKey: increment,
-            active: increment === savedValue
-          }, termTransformFxn(facet.field, increment, true), increment === min ?
-          /*#__PURE__*/
-          _react["default"].createElement("small", null, " (min)") : null, increment === max ?
-          /*#__PURE__*/
-          _react["default"].createElement("small", null, " (max)") : null)
-        );
+        return _react["default"].createElement(_reactBootstrap.DropdownItem, {
+          disabled: typeof min === "number" && increment <= min || typeof max === "number" && increment >= max,
+          key: increment,
+          eventKey: increment,
+          active: increment === savedValue
+        }, termTransformFxn(facet.field, increment, true), increment === min ? _react["default"].createElement("small", null, " (min)") : null, increment === max ? _react["default"].createElement("small", null, " (max)") : null);
       });
 
-      return (
-        /*#__PURE__*/
-        _react["default"].createElement(_reactBootstrap.DropdownButton, _extends({
-          variant: variant,
-          disabled: disabled,
-          className: className,
-          title: title,
-          size: size,
-          id: id
-        }, {
-          alignRight: true,
-          onSelect: this.onDropdownSelect
-        }),
-        /*#__PURE__*/
-        _react["default"].createElement("form", {
-          className: "inline-input-container",
-          onSubmit: this.onTextInputFormSubmit
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: "input-element-container"
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("input", _extends({
-          type: "number",
-          className: "form-control"
-        }, {
-          min: min,
-          max: max,
-          value: value,
-          placeholder: placeholder,
-          step: step
-        }, {
-          onChange: this.onTextInputChange
-        }))),
-        /*#__PURE__*/
-        _react["default"].createElement("button", {
-          type: "submit",
-          disabled: !(savedValue !== value),
-          className: "btn"
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("i", {
-          className: "icon icon-fw icon-check fas"
-        }))), menuOptions)
-      );
+      return _react["default"].createElement(_reactBootstrap.DropdownButton, _extends({
+        variant: variant,
+        disabled: disabled,
+        className: className,
+        title: title,
+        size: size,
+        id: id
+      }, {
+        alignRight: true,
+        onSelect: this.onDropdownSelect
+      }), _react["default"].createElement("form", {
+        className: "inline-input-container",
+        onSubmit: this.onTextInputFormSubmit
+      }, _react["default"].createElement("div", {
+        className: "input-element-container"
+      }, _react["default"].createElement("input", _extends({
+        type: "number",
+        className: "form-control"
+      }, {
+        min: min,
+        max: max,
+        value: value,
+        placeholder: placeholder,
+        step: step
+      }, {
+        onChange: this.onTextInputChange
+      }))), _react["default"].createElement("button", {
+        type: "submit",
+        disabled: !(savedValue !== value),
+        className: "btn"
+      }, _react["default"].createElement("i", {
+        className: "icon icon-fw icon-check fas"
+      }))), menuOptions);
     }
   }]);
 

--- a/es/components/browse/components/FacetList/TermsFacet.js
+++ b/es/components/browse/components/FacetList/TermsFacet.js
@@ -27,45 +27,15 @@ function _defineProperties(target, props) { for (var i = 0; i < props.length; i+
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
-
-function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function (o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
-
-function _createSuper(Derived) {
-  function isNativeReflectConstruct() {
-    if (typeof Reflect === "undefined" || !Reflect.construct) return false;
-    if (Reflect.construct.sham) return false;
-    if (typeof Proxy === "function") return true;
-
-    try {
-      Date.prototype.toString.call(Reflect.construct(Date, [], function () {}));
-      return true;
-    } catch (e) {
-      return false;
-    }
-  }
-
-  return function () {
-    var Super = _getPrototypeOf(Derived),
-        result;
-
-    if (isNativeReflectConstruct()) {
-      var NewTarget = _getPrototypeOf(this).constructor;
-
-      result = Reflect.construct(Super, arguments, NewTarget);
-    } else {
-      result = Super.apply(this, arguments);
-    }
-
-    return _possibleConstructorReturn(this, result);
-  };
-}
-
 function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function (o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
-function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function (o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function (o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
 /**
  * Component to render out the FacetList for the Browse and ExperimentSet views.
@@ -85,14 +55,12 @@ var TermsFacet =
 function (_React$PureComponent) {
   _inherits(TermsFacet, _React$PureComponent);
 
-  var _super = _createSuper(TermsFacet);
-
   function TermsFacet(props) {
     var _this;
 
     _classCallCheck(this, TermsFacet);
 
-    _this = _super.call(this, props);
+    _this = _possibleConstructorReturn(this, _getPrototypeOf(TermsFacet).call(this, props));
     _this.handleStaticClick = _this.handleStaticClick.bind(_assertThisInitialized(_this));
     _this.handleTermClick = _this.handleTermClick.bind(_assertThisInitialized(_this));
     _this.state = {
@@ -164,27 +132,21 @@ function (_React$PureComponent) {
 
       if (separateSingleTermFacets && isStatic) {
         // Only one term exists.
-        return (
-          /*#__PURE__*/
-          _react["default"].createElement(_StaticSingleTerm.StaticSingleTerm, {
-            facet: facet,
-            term: terms[0],
-            filtering: filtering,
-            showTitle: showTitle,
-            onClick: this.handleStaticClick,
-            getTermStatus: getTermStatus,
-            extraClassname: extraClassname,
-            termTransformFxn: termTransformFxn
-          })
-        );
+        return _react["default"].createElement(_StaticSingleTerm.StaticSingleTerm, {
+          facet: facet,
+          term: terms[0],
+          filtering: filtering,
+          showTitle: showTitle,
+          onClick: this.handleStaticClick,
+          getTermStatus: getTermStatus,
+          extraClassname: extraClassname,
+          termTransformFxn: termTransformFxn
+        });
       } else {
-        return (
-          /*#__PURE__*/
-          _react["default"].createElement(_FacetTermsList.FacetTermsList, _extends({}, this.props, {
-            onTermClick: this.handleTermClick,
-            title: showTitle
-          }))
-        );
+        return _react["default"].createElement(_FacetTermsList.FacetTermsList, _extends({}, this.props, {
+          onTermClick: this.handleTermClick,
+          title: showTitle
+        }));
       }
     }
   }]);

--- a/es/components/browse/components/FacetList/index.js
+++ b/es/components/browse/components/FacetList/index.js
@@ -72,6 +72,12 @@ function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { va
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function (o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
 function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
@@ -79,42 +85,6 @@ function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _d
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
 
 function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function (o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
-
-function _createSuper(Derived) {
-  function isNativeReflectConstruct() {
-    if (typeof Reflect === "undefined" || !Reflect.construct) return false;
-    if (Reflect.construct.sham) return false;
-    if (typeof Proxy === "function") return true;
-
-    try {
-      Date.prototype.toString.call(Reflect.construct(Date, [], function () {}));
-      return true;
-    } catch (e) {
-      return false;
-    }
-  }
-
-  return function () {
-    var Super = _getPrototypeOf(Derived),
-        result;
-
-    if (isNativeReflectConstruct()) {
-      var NewTarget = _getPrototypeOf(this).constructor;
-
-      result = Reflect.construct(Super, arguments, NewTarget);
-    } else {
-      result = Super.apply(this, arguments);
-    }
-
-    return _possibleConstructorReturn(this, result);
-  };
-}
-
-function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
-
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
-
-function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function (o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
@@ -215,8 +185,6 @@ var FacetList =
 function (_React$PureComponent) {
   _inherits(FacetList, _React$PureComponent);
 
-  var _super = _createSuper(FacetList);
-
   _createClass(FacetList, null, [{
     key: "sortedFinalFacetObjects",
 
@@ -226,7 +194,7 @@ function (_React$PureComponent) {
         return f.field;
       }), // Ensure facets are unique, field-wise.
       function (f) {
-        var newFacet = _objectSpread(_objectSpread({}, f), {}, {
+        var newFacet = _objectSpread({}, f, {
           order: f.order || 0
         });
 
@@ -319,19 +287,16 @@ function (_React$PureComponent) {
               toVal = _ref$toVal === void 0 ? null : _ref$toVal;
 
           var isStatic = facet.min === facet.max;
-          return (
-            /*#__PURE__*/
-            _react["default"].createElement(_RangeFacet.RangeFacet, _extends({}, props, {
-              facet: facet,
-              key: facetField,
-              anyTermsSelected: fromVal !== null || toVal !== null
-            }, {
-              isStatic: isStatic,
-              grouping: grouping,
-              fromVal: fromVal,
-              toVal: toVal
-            }))
-          );
+          return _react["default"].createElement(_RangeFacet.RangeFacet, _extends({}, props, {
+            facet: facet,
+            key: facetField,
+            anyTermsSelected: fromVal !== null || toVal !== null
+          }, {
+            isStatic: isStatic,
+            grouping: grouping,
+            fromVal: fromVal,
+            toVal: toVal
+          }));
         }
 
         if (aggregation_type === "terms") {
@@ -341,19 +306,16 @@ function (_React$PureComponent) {
 
           var _isStatic = !_anySelected && facet.terms.length === 1;
 
-          return (
-            /*#__PURE__*/
-            _react["default"].createElement(_TermsFacet.TermsFacet, _extends({}, props, {
-              terms: facet.terms,
-              facet: facet,
-              key: facetField,
-              anyTermsSelected: _anySelected
-            }, {
-              isStatic: _isStatic,
-              grouping: grouping,
-              termsSelectedCount: termsSelectedCount
-            }))
-          );
+          return _react["default"].createElement(_TermsFacet.TermsFacet, _extends({}, props, {
+            terms: facet.terms,
+            facet: facet,
+            key: facetField,
+            anyTermsSelected: _anySelected
+          }, {
+            isStatic: _isStatic,
+            grouping: grouping,
+            termsSelectedCount: termsSelectedCount
+          }));
         }
 
         throw new Error("Unknown aggregation_type");
@@ -397,9 +359,7 @@ function (_React$PureComponent) {
           // Doesn't need to be in group, put back into `componentsToReturn`
           componentsToReturn.splice(index, 0, facetsInGroup[0]);
         } else {
-          componentsToReturn.splice(index, 0,
-          /*#__PURE__*/
-          // `facetGroup` contains `defaultGroupOpen`, `index`, `facets`.
+          componentsToReturn.splice(index, 0, // `facetGroup` contains `defaultGroupOpen`, `index`, `facets`.
           _react["default"].createElement(_FacetOfFacets.FacetOfFacets, _extends({}, props, facetGroup, {
             title: groupTitle,
             key: groupTitle
@@ -488,7 +448,7 @@ function (_React$PureComponent) {
 
     _classCallCheck(this, FacetList);
 
-    _this = _super.call(this, props);
+    _this = _possibleConstructorReturn(this, _getPrototypeOf(FacetList).call(this, props));
     _this.onFilterExtended = _this.onFilterExtended.bind(_assertThisInitialized(_this));
     _this.getTermStatus = _this.getTermStatus.bind(_assertThisInitialized(_this));
     _this.handleToggleFacetOpen = _this.handleToggleFacetOpen.bind(_assertThisInitialized(_this));
@@ -730,15 +690,12 @@ function (_React$PureComponent) {
       var openFacets = this.state.openFacets;
 
       if (!facets || !Array.isArray(facets) || facets.length === 0) {
-        return (
-          /*#__PURE__*/
-          _react["default"].createElement("div", {
-            className: "pt-2 pb-2",
-            style: {
-              color: "#aaa"
-            }
-          }, "No facets available")
-        );
+        return _react["default"].createElement("div", {
+          className: "pt-2 pb-2",
+          style: {
+            color: "#aaa"
+          }
+        }, "No facets available");
       }
 
       var bodyProps = {
@@ -753,70 +710,41 @@ function (_React$PureComponent) {
           selectableFacetElements = _this$renderFacetComp3.selectableFacetElements;
 
       var anyFacetsOpen = _underscore["default"].keys(openFacets).length !== 0;
-      return (
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: "facets-container facets" + (className ? ' ' + className : '')
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: "row facets-header"
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: "col facets-title-column text-ellipsis-container"
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("i", {
-          className: "icon icon-fw icon-filter fas"
-        }), "\xA0",
-        /*#__PURE__*/
-        _react["default"].createElement("h4", {
-          className: "facets-title"
-        }, title)),
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: "col-auto"
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: "btn-group btn-group-sm properties-controls",
-          role: "group",
-          "aria-label": "Properties Controls"
-        }, anyFacetsOpen ?
-        /*#__PURE__*/
-        _react["default"].createElement("button", {
-          type: "button",
-          className: "btn btn-outline-light",
-          onClick: this.handleCollapseAllFacets,
-          "data-tip": "Collapse all facets below"
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("i", {
-          className: "icon icon-fw icon-minus fas"
-        })) : null, showClearFiltersButton && typeof onClearFilters === "function" ?
-        /*#__PURE__*/
-        _react["default"].createElement("button", {
-          type: "button",
-          className: "btn btn-outline-light",
-          onClick: onClearFilters,
-          "data-tip": "Clear all filters"
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("i", {
-          className: "icon icon-fw icon-times fas"
-        })) : null))),
-        /*#__PURE__*/
-        _react["default"].createElement("div", bodyProps, selectableFacetElements, staticFacetElements.length > 0 ?
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: "row facet-list-separator"
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: "col-12"
-        }, staticFacetElements.length, " Common Properties")) : null, staticFacetElements))
-      );
+      return _react["default"].createElement("div", {
+        className: "facets-container facets" + (className ? ' ' + className : '')
+      }, _react["default"].createElement("div", {
+        className: "row facets-header"
+      }, _react["default"].createElement("div", {
+        className: "col facets-title-column text-ellipsis-container"
+      }, _react["default"].createElement("i", {
+        className: "icon icon-fw icon-filter fas"
+      }), "\xA0", _react["default"].createElement("h4", {
+        className: "facets-title"
+      }, title)), _react["default"].createElement("div", {
+        className: "col-auto"
+      }, _react["default"].createElement("div", {
+        className: "btn-group btn-group-sm properties-controls",
+        role: "group",
+        "aria-label": "Properties Controls"
+      }, anyFacetsOpen ? _react["default"].createElement("button", {
+        type: "button",
+        className: "btn btn-outline-light",
+        onClick: this.handleCollapseAllFacets,
+        "data-tip": "Collapse all facets below"
+      }, _react["default"].createElement("i", {
+        className: "icon icon-fw icon-minus fas"
+      })) : null, showClearFiltersButton && typeof onClearFilters === "function" ? _react["default"].createElement("button", {
+        type: "button",
+        className: "btn btn-outline-light",
+        onClick: onClearFilters,
+        "data-tip": "Clear all filters"
+      }, _react["default"].createElement("i", {
+        className: "icon icon-fw icon-times fas"
+      })) : null))), _react["default"].createElement("div", bodyProps, selectableFacetElements, staticFacetElements.length > 0 ? _react["default"].createElement("div", {
+        className: "row facet-list-separator"
+      }, _react["default"].createElement("div", {
+        className: "col-12"
+      }, staticFacetElements.length, " Common Properties")) : null, staticFacetElements));
     }
   }]);
 

--- a/es/components/browse/components/SearchResultTable.js
+++ b/es/components/browse/components/SearchResultTable.js
@@ -72,45 +72,15 @@ function _defineProperties(target, props) { for (var i = 0; i < props.length; i+
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
-
-function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function (o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
-
-function _createSuper(Derived) {
-  function isNativeReflectConstruct() {
-    if (typeof Reflect === "undefined" || !Reflect.construct) return false;
-    if (Reflect.construct.sham) return false;
-    if (typeof Proxy === "function") return true;
-
-    try {
-      Date.prototype.toString.call(Reflect.construct(Date, [], function () {}));
-      return true;
-    } catch (e) {
-      return false;
-    }
-  }
-
-  return function () {
-    var Super = _getPrototypeOf(Derived),
-        result;
-
-    if (isNativeReflectConstruct()) {
-      var NewTarget = _getPrototypeOf(this).constructor;
-
-      result = Reflect.construct(Super, arguments, NewTarget);
-    } else {
-      result = Super.apply(this, arguments);
-    }
-
-    return _possibleConstructorReturn(this, result);
-  };
-}
-
 function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function (o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
-function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function (o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function (o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
@@ -132,9 +102,7 @@ var ResultRowColumnBlock = _react["default"].memo(function (props) {
     blockWidth = (0, _ColumnCombiner.getColumnWidthFromDefinition)(columnDefinition, mounted, windowWidth);
   }
 
-  return (
-    /*#__PURE__*/
-    // props includes result
+  return (// props includes result
     _react["default"].createElement("div", {
       className: "search-result-column-block",
       style: {
@@ -142,9 +110,7 @@ var ResultRowColumnBlock = _react["default"].memo(function (props) {
       },
       "data-field": field,
       "data-column-even": columnNumber % 2 === 0
-    },
-    /*#__PURE__*/
-    _react["default"].createElement(_ResultRowColumnBlockValue.ResultRowColumnBlockValue, _extends({}, props, {
+    }, _react["default"].createElement(_ResultRowColumnBlockValue.ResultRowColumnBlockValue, _extends({}, props, {
       width: blockWidth,
       schemas: schemas
     })))
@@ -155,27 +121,16 @@ var ResultRowColumnBlock = _react["default"].memo(function (props) {
 
 var DefaultDetailPane = _react["default"].memo(function (_ref) {
   var result = _ref.result;
-  return (
-    /*#__PURE__*/
-    _react["default"].createElement("div", null, result.description ?
-    /*#__PURE__*/
-    _react["default"].createElement("div", {
-      className: "flexible-description-box result-table-result-heading"
-    }, result.description) : null,
-    /*#__PURE__*/
-    _react["default"].createElement("div", {
-      className: "item-page-detail"
-    },
-    /*#__PURE__*/
-    _react["default"].createElement("h4", {
-      className: "text-300"
-    }, "Details"),
-    /*#__PURE__*/
-    _react["default"].createElement(_ItemDetailList.Detail, {
-      context: result,
-      open: false
-    })))
-  );
+  return _react["default"].createElement("div", null, result.description ? _react["default"].createElement("div", {
+    className: "flexible-description-box result-table-result-heading"
+  }, result.description) : null, _react["default"].createElement("div", {
+    className: "item-page-detail"
+  }, _react["default"].createElement("h4", {
+    className: "text-300"
+  }, "Details"), _react["default"].createElement(_ItemDetailList.Detail, {
+    context: result,
+    open: false
+  })));
 });
 
 var ResultDetail =
@@ -183,14 +138,12 @@ var ResultDetail =
 function (_React$PureComponent) {
   _inherits(ResultDetail, _React$PureComponent);
 
-  var _super = _createSuper(ResultDetail);
-
   function ResultDetail(props) {
     var _this;
 
     _classCallCheck(this, ResultDetail);
 
-    _this = _super.call(this, props);
+    _this = _possibleConstructorReturn(this, _getPrototypeOf(ResultDetail).call(this, props));
     _this.setDetailHeightFromPane = _this.setDetailHeightFromPane.bind(_assertThisInitialized(_this));
     _this.state = {
       'closing': false
@@ -281,43 +234,32 @@ function (_React$PureComponent) {
       var closing = this.state.closing; // Account for vertical scrollbar decreasing width of container.
 
       var useWidth = isOwnPage ? tableContainerWidth : tableContainerWidth - 30;
-      return (
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: "result-table-detail-container detail-" + (open || closing ? 'open' : 'closed'),
-          style: {
-            minHeight: detailPaneHeight
-          }
-        }, open ?
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: "result-table-detail",
-          ref: this.detailRef,
-          style: {
-            width: useWidth,
-            transform: _utilities.style.translate3d(tableContainerScrollLeft)
-          }
-        }, renderDetailPane(result, rowNumber, useWidth, {
-          open: open,
-          tableContainerScrollLeft: tableContainerScrollLeft,
-          toggleDetailOpen: toggleDetailOpen,
-          setDetailHeight: setDetailHeight,
-          detailPaneHeight: detailPaneHeight,
-          setDetailHeightFromPane: this.setDetailHeightFromPane
-        }),
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: "close-button-container text-center",
-          onClick: toggleDetailOpen,
-          "data-tip": "Collapse Details"
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("i", {
-          className: "icon icon-angle-up fas"
-        }))) :
-        /*#__PURE__*/
-        _react["default"].createElement("div", null))
-      );
+      return _react["default"].createElement("div", {
+        className: "result-table-detail-container detail-" + (open || closing ? 'open' : 'closed'),
+        style: {
+          minHeight: detailPaneHeight
+        }
+      }, open ? _react["default"].createElement("div", {
+        className: "result-table-detail",
+        ref: this.detailRef,
+        style: {
+          width: useWidth,
+          transform: _utilities.style.translate3d(tableContainerScrollLeft)
+        }
+      }, renderDetailPane(result, rowNumber, useWidth, {
+        open: open,
+        tableContainerScrollLeft: tableContainerScrollLeft,
+        toggleDetailOpen: toggleDetailOpen,
+        setDetailHeight: setDetailHeight,
+        detailPaneHeight: detailPaneHeight,
+        setDetailHeightFromPane: this.setDetailHeightFromPane
+      }), _react["default"].createElement("div", {
+        className: "close-button-container text-center",
+        onClick: toggleDetailOpen,
+        "data-tip": "Collapse Details"
+      }, _react["default"].createElement("i", {
+        className: "icon icon-angle-up fas"
+      }))) : _react["default"].createElement("div", null));
     }
   }]);
 
@@ -341,8 +283,6 @@ var ResultRow =
 /*#__PURE__*/
 function (_React$PureComponent2) {
   _inherits(ResultRow, _React$PureComponent2);
-
-  var _super2 = _createSuper(ResultRow);
 
   _createClass(ResultRow, null, [{
     key: "areWidthsEqual",
@@ -374,7 +314,7 @@ function (_React$PureComponent2) {
 
     _classCallCheck(this, ResultRow);
 
-    _this2 = _super2.call(this, props);
+    _this2 = _possibleConstructorReturn(this, _getPrototypeOf(ResultRow).call(this, props));
     _this2.toggleDetailOpen = _underscore["default"].throttle(_this2.toggleDetailOpen.bind(_assertThisInitialized(_this2)), 250);
     _this2.setDetailHeight = _this2.setDetailHeight.bind(_assertThisInitialized(_this2));
     _this2.handleDragStart = _this2.handleDragStart.bind(_assertThisInitialized(_this2));
@@ -464,7 +404,7 @@ function (_React$PureComponent2) {
         // todo: rename columnNumber to columnIndex
         var field = columnDefinition.field;
 
-        var passedProps = _objectSpread(_objectSpread({}, commonProps), {}, {
+        var passedProps = _objectSpread({}, commonProps, {
           columnDefinition: columnDefinition,
           columnNumber: columnNumber,
           // Only needed on first column (contains title, checkbox)
@@ -472,12 +412,9 @@ function (_React$PureComponent2) {
           'selectedFiles': columnNumber === 0 ? selectedFiles : null
         });
 
-        return (
-          /*#__PURE__*/
-          _react["default"].createElement(ResultRowColumnBlock, _extends({}, passedProps, {
-            key: field
-          }))
-        );
+        return _react["default"].createElement(ResultRowColumnBlock, _extends({}, passedProps, {
+          key: field
+        }));
       });
     }
   }, {
@@ -501,37 +438,30 @@ function (_React$PureComponent2) {
       var detailProps = _underscore["default"].omit(this.props, 'mounted', 'columnDefinitions', 'detailOpen', 'setDetailHeight', 'columnWidths', 'setColumnWidths');
 
       var cls = "search-result-row" + " detail-" + (detailOpen ? 'open' : 'closed') + (isDraggable ? ' is-draggable' : '');
-      return (
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: cls,
-          "data-row-number": rowNumber,
-          style: styles.outer
-          /* ref={(r)=>{
-          // TODO POTENTIALLY: Use to set height on open/close icon & sticky title column.
-          var height = (r && r.offsetHeight) || null;
-          if (height && height !== this.rowFullHeight){
-          this.rowFullHeight = height;
-          }
-          }}*/
+      return _react["default"].createElement("div", {
+        className: cls,
+        "data-row-number": rowNumber,
+        style: styles.outer
+        /* ref={(r)=>{
+        // TODO POTENTIALLY: Use to set height on open/close icon & sticky title column.
+        var height = (r && r.offsetHeight) || null;
+        if (height && height !== this.rowFullHeight){
+        this.rowFullHeight = height;
+        }
+        }}*/
 
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: "columns clearfix result-table-row",
-          draggable: isDraggable,
-          style: styles.inner // Account for 1px border bottom on parent div
-          ,
-          onDragStart: isDraggable ? this.handleDragStart : null
-        }, this.renderColumns()),
-        /*#__PURE__*/
-        _react["default"].createElement(ResultDetail, _extends({}, detailProps, {
-          open: !!detailOpen,
-          detailPaneHeight: typeof detailOpen === "number" ? detailOpen : undefined,
-          toggleDetailOpen: this.toggleDetailOpen,
-          setDetailHeight: this.setDetailHeight
-        })))
-      );
+      }, _react["default"].createElement("div", {
+        className: "columns clearfix result-table-row",
+        draggable: isDraggable,
+        style: styles.inner // Account for 1px border bottom on parent div
+        ,
+        onDragStart: isDraggable ? this.handleDragStart : null
+      }, this.renderColumns()), _react["default"].createElement(ResultDetail, _extends({}, detailProps, {
+        open: !!detailOpen,
+        detailPaneHeight: typeof detailOpen === "number" ? detailOpen : undefined,
+        toggleDetailOpen: this.toggleDetailOpen,
+        setDetailHeight: this.setDetailHeight
+      })));
     }
   }]);
 
@@ -564,8 +494,6 @@ var LoadMoreAsYouScroll =
 function (_React$PureComponent3) {
   _inherits(LoadMoreAsYouScroll, _React$PureComponent3);
 
-  var _super3 = _createSuper(LoadMoreAsYouScroll);
-
   _createClass(LoadMoreAsYouScroll, null, [{
     key: "canLoadMore",
     value: function canLoadMore(totalExpected, results) {
@@ -596,7 +524,7 @@ function (_React$PureComponent3) {
 
     _classCallCheck(this, LoadMoreAsYouScroll);
 
-    _this4 = _super3.call(this, props);
+    _this4 = _possibleConstructorReturn(this, _getPrototypeOf(LoadMoreAsYouScroll).call(this, props));
     _this4.handleLoad = _underscore["default"].throttle(_this4.handleLoad.bind(_assertThisInitialized(_this4)), 3000); //this.handleScrollingStateChange = this.handleScrollingStateChange.bind(this);
     //this.handleScrollExt = this.handleScrollExt.bind(this);
 
@@ -732,14 +660,9 @@ function (_React$PureComponent3) {
           isLoading = _this$state.isLoading;
 
       if (!(propMounted || stateMounted)) {
-        return (
-          /*#__PURE__*/
-          _react["default"].createElement("div", {
-            className: "react-infinite-container"
-          },
-          /*#__PURE__*/
-          _react["default"].createElement("div", null, children))
-        );
+        return _react["default"].createElement("div", {
+          className: "react-infinite-container"
+        }, _react["default"].createElement("div", null, children));
       }
 
       var elementHeight = _underscore["default"].keys(openDetailPanes).length === 0 ? rowHeight : _react["default"].Children.map(children, function (c) {
@@ -752,30 +675,25 @@ function (_React$PureComponent3) {
 
         return rowHeight;
       });
-      return (
-        /*#__PURE__*/
-        _react["default"].createElement(_reactInfinite["default"], {
-          className: "react-infinite-container",
-          ref: this.infiniteComponentRef,
-          elementHeight: elementHeight,
-          containerHeight: !isOwnPage && maxHeight || undefined,
-          useWindowAsScrollContainer: isOwnPage,
-          onInfiniteLoad: this.handleLoad,
-          isInfiniteLoading: isLoading,
-          timeScrollStateLastsForAfterUserScrolls: 250 //onChangeScrollState={this.handleScrollingStateChange}
-          ,
-          loadingSpinnerDelegate:
-          /*#__PURE__*/
-          _react["default"].createElement(LoadingSpinner, {
-            width: tableContainerWidth,
-            scrollLeft: tableContainerScrollLeft
-          }),
-          infiniteLoadBeginEdgeOffset: canLoadMore ? 200 : undefined,
-          preloadAdditionalHeight: _reactInfinite["default"].containerHeightScaleFactor(1.5),
-          preloadBatchSize: _reactInfinite["default"].containerHeightScaleFactor(1.5),
-          styles: isOwnPage ? null : this.memoized.getStyles(maxHeight)
-        }, children)
-      );
+      return _react["default"].createElement(_reactInfinite["default"], {
+        className: "react-infinite-container",
+        ref: this.infiniteComponentRef,
+        elementHeight: elementHeight,
+        containerHeight: !isOwnPage && maxHeight || undefined,
+        useWindowAsScrollContainer: isOwnPage,
+        onInfiniteLoad: this.handleLoad,
+        isInfiniteLoading: isLoading,
+        timeScrollStateLastsForAfterUserScrolls: 250 //onChangeScrollState={this.handleScrollingStateChange}
+        ,
+        loadingSpinnerDelegate: _react["default"].createElement(LoadingSpinner, {
+          width: tableContainerWidth,
+          scrollLeft: tableContainerScrollLeft
+        }),
+        infiniteLoadBeginEdgeOffset: canLoadMore ? 200 : undefined,
+        preloadAdditionalHeight: _reactInfinite["default"].containerHeightScaleFactor(1.5),
+        preloadBatchSize: _reactInfinite["default"].containerHeightScaleFactor(1.5),
+        styles: isOwnPage ? null : this.memoized.getStyles(maxHeight)
+      }, children);
     }
   }]);
 
@@ -827,27 +745,18 @@ var LoadingSpinner = _react["default"].memo(function (_ref3) {
     maxWidth: maxWidth,
     'transform': _utilities.style.translate3d(scrollLeft)
   };
-  return (
-    /*#__PURE__*/
-    _react["default"].createElement("div", {
-      className: "search-result-row loading text-center d-flex align-items-center justify-content-center",
-      style: style
-    },
-    /*#__PURE__*/
-    _react["default"].createElement("span", null,
-    /*#__PURE__*/
-    _react["default"].createElement("i", {
-      className: "icon icon-circle-notch icon-spin fas"
-    }), "\xA0 Loading..."))
-  );
+  return _react["default"].createElement("div", {
+    className: "search-result-row loading text-center d-flex align-items-center justify-content-center",
+    style: style
+  }, _react["default"].createElement("span", null, _react["default"].createElement("i", {
+    className: "icon icon-circle-notch icon-spin fas"
+  }), "\xA0 Loading..."));
 });
 
 var ShadowBorderLayer =
 /*#__PURE__*/
 function (_React$Component) {
   _inherits(ShadowBorderLayer, _React$Component);
-
-  var _super4 = _createSuper(ShadowBorderLayer);
 
   _createClass(ShadowBorderLayer, null, [{
     key: "shadowStateClass",
@@ -886,7 +795,7 @@ function (_React$Component) {
 
     _classCallCheck(this, ShadowBorderLayer);
 
-    _this6 = _super4.call(this, props);
+    _this6 = _possibleConstructorReturn(this, _getPrototypeOf(ShadowBorderLayer).call(this, props));
     _this6.scrolling = false;
     _this6.performScrollAction = _this6.performScrollAction.bind(_assertThisInitialized(_this6));
     _this6.handleLeftScrollButtonMouseDown = _this6.handleScrollButtonMouseDown.bind(_assertThisInitialized(_this6), 'left');
@@ -981,34 +890,23 @@ function (_React$Component) {
       if (fullRowWidth <= tableContainerWidth) return null;
       var edges = this.memoized.edgeHiddenContentWidths(fullRowWidth, tableContainerScrollLeft, tableContainerWidth);
       var cls = "shadow-border-layer hidden-xs" + ShadowBorderLayer.shadowStateClass(edges.left, edges.right) + (fixedPositionArrows ? ' fixed-position-arrows' : '');
-      return (
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: cls
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: "edge-scroll-button left-edge" + (typeof edges.left !== 'number' || edges.left === 0 ? " faded-out" : ""),
-          onMouseDown: this.handleLeftScrollButtonMouseDown,
-          onMouseUp: this.handleScrollButtonUp,
-          onMouseOut: this.handleScrollButtonUp
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("i", {
-          className: "icon icon-caret-left fas"
-        })),
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: "edge-scroll-button right-edge" + (typeof edges.right !== 'number' || edges.right === 0 ? " faded-out" : ""),
-          onMouseDown: this.handleRightScrollButtonMouseDown,
-          onMouseUp: this.handleScrollButtonUp,
-          onMouseOut: this.handleScrollButtonUp
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("i", {
-          className: "icon icon-caret-right fas"
-        })))
-      );
+      return _react["default"].createElement("div", {
+        className: cls
+      }, _react["default"].createElement("div", {
+        className: "edge-scroll-button left-edge" + (typeof edges.left !== 'number' || edges.left === 0 ? " faded-out" : ""),
+        onMouseDown: this.handleLeftScrollButtonMouseDown,
+        onMouseUp: this.handleScrollButtonUp,
+        onMouseOut: this.handleScrollButtonUp
+      }, _react["default"].createElement("i", {
+        className: "icon icon-caret-left fas"
+      })), _react["default"].createElement("div", {
+        className: "edge-scroll-button right-edge" + (typeof edges.right !== 'number' || edges.right === 0 ? " faded-out" : ""),
+        onMouseDown: this.handleRightScrollButtonMouseDown,
+        onMouseUp: this.handleScrollButtonUp,
+        onMouseOut: this.handleScrollButtonUp
+      }, _react["default"].createElement("i", {
+        className: "icon icon-caret-right fas"
+      })));
     }
   }]);
 
@@ -1023,8 +921,6 @@ var DimensioningContainer =
 /*#__PURE__*/
 function (_React$PureComponent4) {
   _inherits(DimensioningContainer, _React$PureComponent4);
-
-  var _super5 = _createSuper(DimensioningContainer);
 
   _createClass(DimensioningContainer, null, [{
     key: "setDetailPanesLeftOffset",
@@ -1112,7 +1008,7 @@ function (_React$PureComponent4) {
 
     _classCallCheck(this, DimensioningContainer);
 
-    _this8 = _super5.call(this, props);
+    _this8 = _possibleConstructorReturn(this, _getPrototypeOf(DimensioningContainer).call(this, props));
     _this8.getScrollContainer = _this8.getScrollContainer.bind(_assertThisInitialized(_this8));
     _this8.getScrollableElement = _this8.getScrollableElement.bind(_assertThisInitialized(_this8));
     _this8.throttledUpdate = _underscore["default"].debounce(_this8.forceUpdate.bind(_assertThisInitialized(_this8)), 500);
@@ -1384,7 +1280,7 @@ function (_React$PureComponent4) {
       var canLoadMore = this.canLoadMore();
       var anyResults = results.length > 0;
 
-      var headerRowCommonProps = _objectSpread(_objectSpread({}, _underscore["default"].pick(this.props, 'columnDefinitions', 'sortBy', 'sortColumn', 'sortReverse', 'defaultMinColumnWidth', 'renderDetailPane', 'windowWidth')), {}, {
+      var headerRowCommonProps = _objectSpread({}, _underscore["default"].pick(this.props, 'columnDefinitions', 'sortBy', 'sortColumn', 'sortReverse', 'defaultMinColumnWidth', 'renderDetailPane', 'windowWidth'), {
         mounted: mounted,
         results: results,
         rowHeight: rowHeight,
@@ -1409,7 +1305,7 @@ function (_React$PureComponent4) {
         'setDetailHeight': this.setDetailHeight
       });
 
-      var loadMoreAsYouScrollProps = _objectSpread(_objectSpread({}, _underscore["default"].pick(this.props, 'href', 'onDuplicateResultsFoundCallback', 'schemas', 'navigate')), {}, {
+      var loadMoreAsYouScrollProps = _objectSpread({}, _underscore["default"].pick(this.props, 'href', 'onDuplicateResultsFoundCallback', 'schemas', 'navigate'), {
         context: context,
         rowHeight: rowHeight,
         openRowHeight: openRowHeight,
@@ -1431,12 +1327,8 @@ function (_React$PureComponent4) {
       var shadowBorderLayer = null;
 
       if (anyResults) {
-        headersRow =
-        /*#__PURE__*/
-        _react["default"].createElement(_HeadersRow.HeadersRow, headerRowCommonProps);
-        shadowBorderLayer =
-        /*#__PURE__*/
-        _react["default"].createElement(ShadowBorderLayer, _extends({
+        headersRow = _react["default"].createElement(_HeadersRow.HeadersRow, headerRowCommonProps);
+        shadowBorderLayer = _react["default"].createElement(ShadowBorderLayer, _extends({
           tableContainerScrollLeft: tableContainerScrollLeft,
           tableContainerWidth: tableContainerWidth,
           fullRowWidth: fullRowWidth
@@ -1447,13 +1339,9 @@ function (_React$PureComponent4) {
         }));
       }
 
-      var renderChildren = !anyResults ?
-      /*#__PURE__*/
-      _react["default"].createElement("div", {
+      var renderChildren = !anyResults ? _react["default"].createElement("div", {
         className: "text-center py-5"
-      },
-      /*#__PURE__*/
-      _react["default"].createElement("h3", {
+      }, _react["default"].createElement("h3", {
         className: "text-300"
       }, "No Results")) : results.map(function (result, idx) {
         var id = _object.itemUtil.atId(result);
@@ -1462,24 +1350,19 @@ function (_React$PureComponent4) {
         // else all rows get re-rendered (in virtual DOM atleast) on horizontal scroll due to prop value
         // changing. Alternatively could've made a shouldComponentUpdate in ResultRow (but need to keep track of more).
 
-        return (
-          /*#__PURE__*/
-          _react["default"].createElement(ResultRow, _extends({}, resultRowCommonProps, {
-            result: result,
-            id: id,
-            detailOpen: detailOpen
-          }, {
-            rowNumber: idx,
-            key: id,
-            tableContainerScrollLeft: detailOpen ? tableContainerScrollLeft : 0
-          }))
-        );
+        return _react["default"].createElement(ResultRow, _extends({}, resultRowCommonProps, {
+          result: result,
+          id: id,
+          detailOpen: detailOpen
+        }, {
+          rowNumber: idx,
+          key: id,
+          tableContainerScrollLeft: detailOpen ? tableContainerScrollLeft : 0
+        }));
       });
 
       if (anyResults && !canLoadMore) {
-        renderChildren.push(
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
+        renderChildren.push(_react["default"].createElement("div", {
           className: "fin search-result-row",
           key: "fin-last-item",
           style: {
@@ -1487,29 +1370,18 @@ function (_React$PureComponent4) {
             width: tableContainerWidth - (isOwnPage ? 0 : 30),
             transform: _utilities.style.translate3d(tableContainerScrollLeft)
           }
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
+        }, _react["default"].createElement("div", {
           className: "inner"
-        }, "- ",
-        /*#__PURE__*/
-        _react["default"].createElement("span", null, "fin"), " -")));
+        }, "- ", _react["default"].createElement("span", null, "fin"), " -")));
       }
 
-      return (
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: "search-results-outer-container" + (isOwnPage ? " is-own-page" : " is-within-page"),
-          ref: this.outerRef,
-          "data-context-loading": isContextLoading
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: "search-results-container" + (canLoadMore === false ? ' fully-loaded' : '')
-        }, headersRow,
-        /*#__PURE__*/
-        _react["default"].createElement(LoadMoreAsYouScroll, loadMoreAsYouScrollProps, renderChildren), shadowBorderLayer))
-      );
+      return _react["default"].createElement("div", {
+        className: "search-results-outer-container" + (isOwnPage ? " is-own-page" : " is-within-page"),
+        ref: this.outerRef,
+        "data-context-loading": isContextLoading
+      }, _react["default"].createElement("div", {
+        className: "search-results-container" + (canLoadMore === false ? ' fully-loaded' : '')
+      }, headersRow, _react["default"].createElement(LoadMoreAsYouScroll, loadMoreAsYouScrollProps, renderChildren), shadowBorderLayer));
     }
   }]);
 
@@ -1538,8 +1410,6 @@ var SearchResultTable =
 function (_React$PureComponent5) {
   _inherits(SearchResultTable, _React$PureComponent5);
 
-  var _super6 = _createSuper(SearchResultTable);
-
   _createClass(SearchResultTable, null, [{
     key: "isDesktopClientside",
     value: function isDesktopClientside(windowWidth) {
@@ -1552,7 +1422,7 @@ function (_React$PureComponent5) {
 
     _classCallCheck(this, SearchResultTable);
 
-    _this11 = _super6.call(this, props);
+    _this11 = _possibleConstructorReturn(this, _getPrototypeOf(SearchResultTable).call(this, props));
     _this11.memoized = {
       filterOutHiddenCols: (0, _memoizeOne["default"])(_CustomColumnController.filterOutHiddenCols)
     };
@@ -1573,31 +1443,21 @@ function (_React$PureComponent5) {
       if (isContextLoading && !context) {
         // Initial context (pre-sort, filter, etc) loading.
         // Only applicable for EmbeddedSearchView
-        return (
-          /*#__PURE__*/
-          _react["default"].createElement("div", {
-            className: "search-results-outer-container text-center" + (isOwnPage ? " is-own-page" : " is-within-page")
-          },
-          /*#__PURE__*/
-          _react["default"].createElement("div", {
-            className: "search-results-container text-center py-5"
-          },
-          /*#__PURE__*/
-          _react["default"].createElement("i", {
-            className: "icon icon-fw icon-spin icon-circle-notch fas icon-2x text-secondary"
-          })))
-        );
+        return _react["default"].createElement("div", {
+          className: "search-results-outer-container text-center" + (isOwnPage ? " is-own-page" : " is-within-page")
+        }, _react["default"].createElement("div", {
+          className: "search-results-container text-center py-5"
+        }, _react["default"].createElement("i", {
+          className: "icon icon-fw icon-spin icon-circle-notch fas icon-2x text-secondary"
+        })));
       } // We filter down the columnDefinitions here (rather than in CustomColumnController)
       // because they are still necessary for UI for selection of visible/invisible columns
       // in SearchView/ControlsAndResults/AboveSearchViewTableControls/....
 
 
-      return (
-        /*#__PURE__*/
-        _react["default"].createElement(DimensioningContainer, _extends({}, _underscore["default"].omit(this.props, 'hiddenColumns', 'columnDefinitionOverrideMap', 'defaultWidthMap'), {
-          columnDefinitions: visibleColumnDefinitions || columnDefinitions
-        }))
-      );
+      return _react["default"].createElement(DimensioningContainer, _extends({}, _underscore["default"].omit(this.props, 'hiddenColumns', 'columnDefinitionOverrideMap', 'defaultWidthMap'), {
+        columnDefinitions: visibleColumnDefinitions || columnDefinitions
+      }));
     }
   }]);
 
@@ -1650,14 +1510,11 @@ _defineProperty(SearchResultTable, "defaultProps", {
   }, _basicColumnExtensionMap.basicColumnExtensionMap),
   // Fallback - just title column.
   'renderDetailPane': function renderDetailPane(result, rowNumber, width, props) {
-    return (
-      /*#__PURE__*/
-      _react["default"].createElement(DefaultDetailPane, _extends({}, props, {
-        result: result,
-        rowNumber: rowNumber,
-        width: width
-      }))
-    );
+    return _react["default"].createElement(DefaultDetailPane, _extends({}, props, {
+      result: result,
+      rowNumber: rowNumber,
+      width: width
+    }));
   },
   'defaultMinColumnWidth': 55,
   'hiddenColumns': null,

--- a/es/components/browse/components/SelectedItemsController.js
+++ b/es/components/browse/components/SelectedItemsController.js
@@ -57,45 +57,15 @@ function _defineProperties(target, props) { for (var i = 0; i < props.length; i+
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
-
-function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function (o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
-
-function _createSuper(Derived) {
-  function isNativeReflectConstruct() {
-    if (typeof Reflect === "undefined" || !Reflect.construct) return false;
-    if (Reflect.construct.sham) return false;
-    if (typeof Proxy === "function") return true;
-
-    try {
-      Date.prototype.toString.call(Reflect.construct(Date, [], function () {}));
-      return true;
-    } catch (e) {
-      return false;
-    }
-  }
-
-  return function () {
-    var Super = _getPrototypeOf(Derived),
-        result;
-
-    if (isNativeReflectConstruct()) {
-      var NewTarget = _getPrototypeOf(this).constructor;
-
-      result = Reflect.construct(Super, arguments, NewTarget);
-    } else {
-      result = Super.apply(this, arguments);
-    }
-
-    return _possibleConstructorReturn(this, result);
-  };
-}
-
 function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function (o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
-function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function (o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function (o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
 /**
  * Utility function to post message to parent window
@@ -137,14 +107,12 @@ var SelectedItemsController =
 function (_React$PureComponent) {
   _inherits(SelectedItemsController, _React$PureComponent);
 
-  var _super = _createSuper(SelectedItemsController);
-
   function SelectedItemsController(props) {
     var _this;
 
     _classCallCheck(this, SelectedItemsController);
 
-    _this = _super.call(this, props);
+    _this = _possibleConstructorReturn(this, _getPrototypeOf(SelectedItemsController).call(this, props));
     _this.handleSelectItem = _this.handleSelectItem.bind(_assertThisInitialized(_this));
     _this.handleSelectItemCompleteClick = _this.handleSelectItemCompleteClick.bind(_assertThisInitialized(_this));
     _this.handleSelectCancelClick = _this.handleSelectCancelClick.bind(_assertThisInitialized(_this));
@@ -284,7 +252,7 @@ function (_React$PureComponent) {
         // Remove lab.display_title and type columns on selection
         var newColumnExtensionMap = _underscore["default"].clone(originalColumnExtensionMap);
 
-        newColumnExtensionMap.display_title = _objectSpread(_objectSpread({}, newColumnExtensionMap.display_title), {}, {
+        newColumnExtensionMap.display_title = _objectSpread({}, newColumnExtensionMap.display_title, {
           'minColumnWidth': (originalColumnExtensionMap.display_title.minColumnWidth || 100) + 20,
           'render': function render(result, parentProps) {
             var selectedItems = _this2.state.selectedItems;
@@ -293,26 +261,19 @@ function (_React$PureComponent) {
                 toggleDetailOpen = parentProps.toggleDetailOpen,
                 href = parentProps.href,
                 context = parentProps.context;
-            return (
-              /*#__PURE__*/
-              _react["default"].createElement(_basicColumnExtensionMap.DisplayTitleColumnWrapper, {
-                result: result,
-                href: href,
-                context: context,
-                rowNumber: rowNumber,
-                detailOpen: detailOpen,
-                toggleDetailOpen: toggleDetailOpen
-              },
-              /*#__PURE__*/
-              _react["default"].createElement(SelectionItemCheckbox, _extends({
-                selectedItems: selectedItems,
-                isMultiSelect: currentAction === 'multiselect'
-              }, {
-                handleSelectItem: _this2.handleSelectItem
-              })),
-              /*#__PURE__*/
-              _react["default"].createElement(_basicColumnExtensionMap.DisplayTitleColumnDefault, null))
-            );
+            return _react["default"].createElement(_basicColumnExtensionMap.DisplayTitleColumnWrapper, {
+              result: result,
+              href: href,
+              context: context,
+              rowNumber: rowNumber,
+              detailOpen: detailOpen,
+              toggleDetailOpen: toggleDetailOpen
+            }, _react["default"].createElement(SelectionItemCheckbox, _extends({
+              selectedItems: selectedItems,
+              isMultiSelect: currentAction === 'multiselect'
+            }, {
+              handleSelectItem: _this2.handleSelectItem
+            })), _react["default"].createElement(_basicColumnExtensionMap.DisplayTitleColumnDefault, null));
           }
         });
         return newColumnExtensionMap;
@@ -361,15 +322,12 @@ var SelectionItemCheckbox = _react["default"].memo(function (props) {
   var onChange = (0, _react.useMemo)(function () {
     return handleSelectItem.bind(handleSelectItem, result, isMultiSelect);
   }, [handleSelectItem, result, isMultiSelect]);
-  return (
-    /*#__PURE__*/
-    _react["default"].createElement("input", {
-      type: "checkbox",
-      checked: isChecked,
-      onChange: onChange,
-      className: "mr-2"
-    })
-  );
+  return _react["default"].createElement("input", {
+    type: "checkbox",
+    checked: isChecked,
+    onChange: onChange,
+    className: "mr-2"
+  });
 });
 /** Move to own file later maybe. Especially if functionality expands. */
 
@@ -383,69 +341,40 @@ var SelectStickyFooter = _react["default"].memo(function (props) {
       currentAction = props.currentAction;
   var itemTypeFriendlyName = (0, _schemaTransforms.getTitleForType)((0, _schemaTransforms.getSchemaTypeFromSearchContext)(context), schemas);
   var selectedItemDisplayTitle = currentAction === 'selection' && selectedItems.size === 1 ? selectedItems.entries().next().value[1].display_title : "Nothing";
-  return (
-    /*#__PURE__*/
-    _react["default"].createElement(StickyFooter, null,
-    /*#__PURE__*/
-    _react["default"].createElement("div", {
-      className: "row selection-controls-footer"
-    },
-    /*#__PURE__*/
-    _react["default"].createElement("div", {
-      className: "col mb-05 mt-05"
-    }, currentAction === 'multiselect' ?
-    /*#__PURE__*/
-    _react["default"].createElement("div", {
-      className: "row"
-    },
-    /*#__PURE__*/
-    _react["default"].createElement("h3", {
-      className: "mt-0 mb-0 col-auto text-600"
-    }, selectedItems.size),
-    /*#__PURE__*/
-    _react["default"].createElement("h4", {
-      className: "mt-0 mb-0 text-muted col-auto text-400 px-0"
-    }, itemTypeFriendlyName + (selectedItems.size === 1 ? '' : 's'), " selected")) :
-    /*#__PURE__*/
-    _react["default"].createElement("div", {
-      className: "row"
-    },
-    /*#__PURE__*/
-    _react["default"].createElement("h4", {
-      className: "mt-0 mb-0 col-auto text-400"
-    }, selectedItemDisplayTitle),
-    /*#__PURE__*/
-    _react["default"].createElement("h4", {
-      className: "mt-0 mb-0 text-muted col-auto text-400 px-0"
-    }, "selected"))),
-    /*#__PURE__*/
-    _react["default"].createElement("div", {
-      className: "col-12 col-md-auto"
-    },
-    /*#__PURE__*/
-    _react["default"].createElement("button", {
-      type: "button",
-      className: "btn btn-success",
-      onClick: onComplete,
-      disabled: selectedItems.size === 0,
-      "data-tip": "Select checked items and close window"
-    },
-    /*#__PURE__*/
-    _react["default"].createElement("i", {
-      className: "icon icon-fw fas icon-check"
-    }), "\xA0 Apply"),
-    /*#__PURE__*/
-    _react["default"].createElement("button", {
-      type: "button",
-      className: "btn btn-outline-warning ml-1",
-      onClick: onCancel,
-      "data-tip": "Cancel selection and close window"
-    },
-    /*#__PURE__*/
-    _react["default"].createElement("i", {
-      className: "icon icon-fw fas icon-times"
-    }), "\xA0 Cancel"))))
-  );
+  return _react["default"].createElement(StickyFooter, null, _react["default"].createElement("div", {
+    className: "row selection-controls-footer"
+  }, _react["default"].createElement("div", {
+    className: "col mb-05 mt-05"
+  }, currentAction === 'multiselect' ? _react["default"].createElement("div", {
+    className: "row"
+  }, _react["default"].createElement("h3", {
+    className: "mt-0 mb-0 col-auto text-600"
+  }, selectedItems.size), _react["default"].createElement("h4", {
+    className: "mt-0 mb-0 text-muted col-auto text-400 px-0"
+  }, itemTypeFriendlyName + (selectedItems.size === 1 ? '' : 's'), " selected")) : _react["default"].createElement("div", {
+    className: "row"
+  }, _react["default"].createElement("h4", {
+    className: "mt-0 mb-0 col-auto text-400"
+  }, selectedItemDisplayTitle), _react["default"].createElement("h4", {
+    className: "mt-0 mb-0 text-muted col-auto text-400 px-0"
+  }, "selected"))), _react["default"].createElement("div", {
+    className: "col-12 col-md-auto"
+  }, _react["default"].createElement("button", {
+    type: "button",
+    className: "btn btn-success",
+    onClick: onComplete,
+    disabled: selectedItems.size === 0,
+    "data-tip": "Select checked items and close window"
+  }, _react["default"].createElement("i", {
+    className: "icon icon-fw fas icon-check"
+  }), "\xA0 Apply"), _react["default"].createElement("button", {
+    type: "button",
+    className: "btn btn-outline-warning ml-1",
+    onClick: onCancel,
+    "data-tip": "Cancel selection and close window"
+  }, _react["default"].createElement("i", {
+    className: "icon icon-fw fas icon-times"
+  }), "\xA0 Cancel"))));
 });
 /**
  * General purpose sticky footer component
@@ -459,14 +388,9 @@ function StickyFooter(_ref2) {
   var children = _ref2.children,
       passProps = _objectWithoutProperties(_ref2, ["children"]);
 
-  return (
-    /*#__PURE__*/
-    _react["default"].createElement("div", _extends({
-      className: "sticky-page-footer"
-    }, passProps),
-    /*#__PURE__*/
-    _react["default"].createElement("div", {
-      className: "container"
-    }, children))
-  );
+  return _react["default"].createElement("div", _extends({
+    className: "sticky-page-footer"
+  }, passProps), _react["default"].createElement("div", {
+    className: "container"
+  }, children));
 }

--- a/es/components/browse/components/above-table-controls/AboveSearchViewTableControls.js
+++ b/es/components/browse/components/above-table-controls/AboveSearchViewTableControls.js
@@ -25,16 +25,12 @@ var AboveSearchViewTableControls = _react["default"].memo(function (props) {
   var total = null;
 
   if (showTotalResults) {
-    total =
-    /*#__PURE__*/
-    _react["default"].createElement("div", {
+    total = _react["default"].createElement("div", {
       style: {
         'verticalAlign': 'bottom'
       },
       className: "inline-block"
-    },
-    /*#__PURE__*/
-    _react["default"].createElement("span", {
+    }, _react["default"].createElement("span", {
       className: "text-500",
       id: "results-count"
     }, typeof showTotalResults === 'number' ? showTotalResults : context && typeof context.total === 'number' ? context.total : null), " Results");
@@ -49,32 +45,23 @@ var AboveSearchViewTableControls = _react["default"].memo(function (props) {
     });
 
     if (addAction && typeof addAction.href === 'string') {
-      addButton =
-      /*#__PURE__*/
-      _react["default"].createElement("a", {
+      addButton = _react["default"].createElement("a", {
         className: "btn btn-primary btn-xs" + (total ? " ml-1" : ""),
         href: addAction.href,
         "data-skiprequest": "true"
-      },
-      /*#__PURE__*/
-      _react["default"].createElement("i", {
+      }, _react["default"].createElement("i", {
         className: "icon icon-fw icon-plus fas mr-03 fas"
       }), "Create New \xA0");
     }
   }
 
-  return (
-    /*#__PURE__*/
-    _react["default"].createElement(_AboveTableControlsBase.AboveTableControlsBase, _extends({
-      panelMap: _AboveTableControlsBase.AboveTableControlsBase.getCustomColumnSelectorPanelMapDefinition(props)
-    }, _underscore["default"].pick(props, 'isFullscreen', 'windowWidth', 'toggleFullScreen')),
-    /*#__PURE__*/
-    _react["default"].createElement(LeftSectionControls, {
-      total: total,
-      addButton: addButton,
-      topLeftChildren: topLeftChildren
-    }))
-  );
+  return _react["default"].createElement(_AboveTableControlsBase.AboveTableControlsBase, _extends({
+    panelMap: _AboveTableControlsBase.AboveTableControlsBase.getCustomColumnSelectorPanelMapDefinition(props)
+  }, _underscore["default"].pick(props, 'isFullscreen', 'windowWidth', 'toggleFullScreen')), _react["default"].createElement(LeftSectionControls, {
+    total: total,
+    addButton: addButton,
+    topLeftChildren: topLeftChildren
+  }));
 });
 
 exports.AboveSearchViewTableControls = AboveSearchViewTableControls;
@@ -87,11 +74,8 @@ function LeftSectionControls(_ref) {
       onClosePanel = _ref.onClosePanel,
       currentOpenPanel = _ref.currentOpenPanel;
   if (!total && !addButton && !topLeftChildren) return null;
-  return (
-    /*#__PURE__*/
-    _react["default"].createElement("div", {
-      key: "total-count",
-      className: "pull-left pt-11 box results-count"
-    }, total, topLeftChildren || addButton)
-  );
+  return _react["default"].createElement("div", {
+    key: "total-count",
+    className: "pull-left pt-11 box results-count"
+  }, total, topLeftChildren || addButton);
 }

--- a/es/components/browse/components/table-commons/ColumnCombiner.js
+++ b/es/components/browse/components/table-commons/ColumnCombiner.js
@@ -50,6 +50,12 @@ function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterat
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function (o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
 function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
@@ -57,42 +63,6 @@ function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _d
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
 
 function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function (o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
-
-function _createSuper(Derived) {
-  function isNativeReflectConstruct() {
-    if (typeof Reflect === "undefined" || !Reflect.construct) return false;
-    if (Reflect.construct.sham) return false;
-    if (typeof Proxy === "function") return true;
-
-    try {
-      Date.prototype.toString.call(Reflect.construct(Date, [], function () {}));
-      return true;
-    } catch (e) {
-      return false;
-    }
-  }
-
-  return function () {
-    var Super = _getPrototypeOf(Derived),
-        result;
-
-    if (isNativeReflectConstruct()) {
-      var NewTarget = _getPrototypeOf(this).constructor;
-
-      result = Reflect.construct(Super, arguments, NewTarget);
-    } else {
-      result = Super.apply(this, arguments);
-    }
-
-    return _possibleConstructorReturn(this, result);
-  };
-}
-
-function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
-
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
-
-function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function (o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
@@ -111,8 +81,6 @@ var ColumnCombiner =
 /*#__PURE__*/
 function (_React$PureComponent) {
   _inherits(ColumnCombiner, _React$PureComponent);
-
-  var _super = _createSuper(ColumnCombiner);
 
   _createClass(ColumnCombiner, null, [{
     key: "getDefinitions",
@@ -158,7 +126,7 @@ function (_React$PureComponent) {
 
     _classCallCheck(this, ColumnCombiner);
 
-    _this = _super.call(this, props);
+    _this = _possibleConstructorReturn(this, _getPrototypeOf(ColumnCombiner).call(this, props));
     _this.memoized = {
       haveContextColumnsChanged: (0, _memoizeOne["default"])(haveContextColumnsChanged),
       // We want `defaultHiddenColumns` memoized separately from `columnDefinitions`
@@ -229,7 +197,7 @@ function (_React$PureComponent) {
         console.error("No columns available in context nor props. Please provide columns. Ok if resorting to back-end provided columns and waiting for first response to load.");
       }
 
-      var propsToPass = _objectSpread(_objectSpread({}, passProps), {}, {
+      var propsToPass = _objectSpread({}, passProps, {
         /** Final form of all columns to show in table */
         columnDefinitions: this.memoized.getDefinitions(columns, columnExtensionMap),
 
@@ -275,7 +243,7 @@ function columnsToColumnDefinitions(columns, columnDefinitionMap) {
         field = _ref6[0],
         columnProperties = _ref6[1];
 
-    return _objectSpread(_objectSpread({}, columnProperties), {}, {
+    return _objectSpread({}, columnProperties, {
       field: field
     });
   });

--- a/es/components/browse/components/table-commons/HeadersRow.js
+++ b/es/components/browse/components/table-commons/HeadersRow.js
@@ -39,6 +39,12 @@ function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { va
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function (o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
 function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
@@ -46,42 +52,6 @@ function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _d
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
 
 function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function (o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
-
-function _createSuper(Derived) {
-  function isNativeReflectConstruct() {
-    if (typeof Reflect === "undefined" || !Reflect.construct) return false;
-    if (Reflect.construct.sham) return false;
-    if (typeof Proxy === "function") return true;
-
-    try {
-      Date.prototype.toString.call(Reflect.construct(Date, [], function () {}));
-      return true;
-    } catch (e) {
-      return false;
-    }
-  }
-
-  return function () {
-    var Super = _getPrototypeOf(Derived),
-        result;
-
-    if (isNativeReflectConstruct()) {
-      var NewTarget = _getPrototypeOf(this).constructor;
-
-      result = Reflect.construct(Super, arguments, NewTarget);
-    } else {
-      result = Super.apply(this, arguments);
-    }
-
-    return _possibleConstructorReturn(this, result);
-  };
-}
-
-function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
-
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
-
-function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function (o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
@@ -95,8 +65,6 @@ var HeadersRow =
 /*#__PURE__*/
 function (_React$PureComponent) {
   _inherits(HeadersRow, _React$PureComponent);
-
-  var _super = _createSuper(HeadersRow);
 
   _createClass(HeadersRow, null, [{
     key: "alignedWidths",
@@ -170,7 +138,7 @@ function (_React$PureComponent) {
 
     _classCallCheck(this, HeadersRow);
 
-    _this = _super.call(this, props);
+    _this = _possibleConstructorReturn(this, _getPrototypeOf(HeadersRow).call(this, props));
     _this.onWindowClick = _this.onWindowClick.bind(_assertThisInitialized(_this));
     _this.setShowingSortFieldsFor = _this.setShowingSortFieldsFor.bind(_assertThisInitialized(_this));
     _this.sortByField = _this.sortByField.bind(_assertThisInitialized(_this));
@@ -296,7 +264,7 @@ function (_React$PureComponent) {
           throw new Error('props.setHeaderWidths not a function');
         }
 
-        setColumnWidths(_objectSpread(_objectSpread({}, columnWidths), widths));
+        setColumnWidths(_objectSpread({}, columnWidths, {}, widths));
       });
     }
   }, {
@@ -307,7 +275,7 @@ function (_React$PureComponent) {
         var widths = _ref3.widths;
         var defaultMinColumnWidth = _ref4.defaultMinColumnWidth;
         return {
-          'widths': _objectSpread(_objectSpread({}, widths), {}, _defineProperty({}, field, Math.max(columnDefinition.minColumnWidth || defaultMinColumnWidth || 55, r.x)))
+          'widths': _objectSpread({}, widths, _defineProperty({}, field, Math.max(columnDefinition.minColumnWidth || defaultMinColumnWidth || 55, r.x)))
         };
       });
     }
@@ -348,56 +316,45 @@ function (_React$PureComponent) {
       };
       var alignedWidths = this.memoized.alignedWidths(columnDefinitions, columnWidths, widths, windowWidth);
       var rootLoadingField = this.memoized.getRootLoadingField(columnDefinitions, loadingField);
-      return (
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: outerClassName,
-          style: {
-            'width': width || null // Only passed in from ItemPage
+      return _react["default"].createElement("div", {
+        className: outerClassName,
+        style: {
+          'width': width || null // Only passed in from ItemPage
 
-          },
-          "data-showing-sort-fields-for": showingSortFieldsForColumn
         },
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: "headers-columns-overflow-container"
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: "columns clearfix",
-          style: {
-            left: leftOffset //transform: "translate3d(" + leftOffset + "px, 0px, 0px)"
+        "data-showing-sort-fields-for": showingSortFieldsForColumn
+      }, _react["default"].createElement("div", {
+        className: "headers-columns-overflow-container"
+      }, _react["default"].createElement("div", {
+        className: "columns clearfix",
+        style: {
+          left: leftOffset //transform: "translate3d(" + leftOffset + "px, 0px, 0px)"
 
-          }
-        }, columnDefinitions.map(function (columnDefinition, index) {
-          var field = columnDefinition.field;
-          return (
-            /*#__PURE__*/
-            // `props.active` may be undefined, object with more fields, or array where first item is `descending` flag (bool).
-            _react["default"].createElement(HeadersRowColumn, _extends({}, commonProps, {
-              columnDefinition: columnDefinition,
-              index: index,
-              showingSortOptionsMenu: showingSortFieldsForColumn && showingSortFieldsForColumn === field,
-              isLoading: rootLoadingField && rootLoadingField === field
-            }, {
-              width: alignedWidths[index],
-              active: activeColumnMap[field],
-              key: field
-            }))
-          );
-        }))), showingSortFieldsForColumn !== null ?
-        /*#__PURE__*/
-        _react["default"].createElement(SortOptionsMenuContainer, _extends({
-          showingSortFieldsForColumn: showingSortFieldsForColumn,
-          columnDefinitions: columnDefinitions,
-          sortColumn: sortColumn,
-          sortReverse: sortReverse,
-          alignedWidths: alignedWidths,
-          leftOffset: leftOffset
-        }, {
-          sortByField: this.sortByField
-        })) : null)
-      );
+        }
+      }, columnDefinitions.map(function (columnDefinition, index) {
+        var field = columnDefinition.field;
+        return (// `props.active` may be undefined, object with more fields, or array where first item is `descending` flag (bool).
+          _react["default"].createElement(HeadersRowColumn, _extends({}, commonProps, {
+            columnDefinition: columnDefinition,
+            index: index,
+            showingSortOptionsMenu: showingSortFieldsForColumn && showingSortFieldsForColumn === field,
+            isLoading: rootLoadingField && rootLoadingField === field
+          }, {
+            width: alignedWidths[index],
+            active: activeColumnMap[field],
+            key: field
+          }))
+        );
+      }))), showingSortFieldsForColumn !== null ? _react["default"].createElement(SortOptionsMenuContainer, _extends({
+        showingSortFieldsForColumn: showingSortFieldsForColumn,
+        columnDefinitions: columnDefinitions,
+        sortColumn: sortColumn,
+        sortReverse: sortReverse,
+        alignedWidths: alignedWidths,
+        leftOffset: leftOffset
+      }, {
+        sortByField: this.sortByField
+      })) : null);
     }
   }]);
 
@@ -446,14 +403,12 @@ var HeadersRowColumn =
 function (_React$PureComponent2) {
   _inherits(HeadersRowColumn, _React$PureComponent2);
 
-  var _super2 = _createSuper(HeadersRowColumn);
-
   function HeadersRowColumn(props) {
     var _this4;
 
     _classCallCheck(this, HeadersRowColumn);
 
-    _this4 = _super2.call(this, props);
+    _this4 = _possibleConstructorReturn(this, _getPrototypeOf(HeadersRowColumn).call(this, props));
     _this4.onDrag = _this4.onDrag.bind(_assertThisInitialized(_this4));
     _this4.onStop = _this4.onStop.bind(_assertThisInitialized(_this4));
     _this4.memoized = {
@@ -506,9 +461,7 @@ function (_React$PureComponent2) {
       var sorterIcon;
 
       if (!noSort && typeof sortByField === 'function' && width >= 50) {
-        sorterIcon =
-        /*#__PURE__*/
-        _react["default"].createElement(ColumnSorterIcon, {
+        sorterIcon = _react["default"].createElement(ColumnSorterIcon, {
           columnDefinition: columnDefinition,
           sortByField: sortByField,
           showingSortOptionsMenu: showingSortOptionsMenu,
@@ -519,45 +472,32 @@ function (_React$PureComponent2) {
       }
 
       var cls = "search-headers-column-block" + (noSort ? " no-sort" : '') + (showingSortOptionsMenu ? " showing-sort-field-options" : "");
-      return (
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          "data-field": field,
-          "data-column-key": field,
-          key: field,
-          className: cls,
-          style: {
-            width: width
-          }
+      return _react["default"].createElement("div", {
+        "data-field": field,
+        "data-column-key": field,
+        key: field,
+        className: cls,
+        style: {
+          width: width
+        }
+      }, _react["default"].createElement("div", {
+        className: "inner"
+      }, _react["default"].createElement("div", {
+        className: "column-title"
+      }, _react["default"].createElement("span", {
+        "data-tip": tooltip,
+        "data-html": true
+      }, colTitle || title)), sorterIcon), typeof onAdjusterDrag === "function" ? _react["default"].createElement(_reactDraggable["default"], {
+        position: {
+          x: width,
+          y: 0
         },
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: "inner"
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: "column-title"
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("span", {
-          "data-tip": tooltip,
-          "data-html": true
-        }, colTitle || title)), sorterIcon), typeof onAdjusterDrag === "function" ?
-        /*#__PURE__*/
-        _react["default"].createElement(_reactDraggable["default"], {
-          position: {
-            x: width,
-            y: 0
-          },
-          axis: "x",
-          onDrag: this.onDrag,
-          onStop: this.onStop
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: "width-adjuster"
-        })) : null)
-      );
+        axis: "x",
+        onDrag: this.onDrag,
+        onStop: this.onStop
+      }, _react["default"].createElement("div", {
+        className: "width-adjuster"
+      })) : null);
     }
   }]);
 
@@ -568,8 +508,6 @@ var ColumnSorterIcon =
 /*#__PURE__*/
 function (_React$PureComponent3) {
   _inherits(ColumnSorterIcon, _React$PureComponent3);
-
-  var _super3 = _createSuper(ColumnSorterIcon);
 
   _createClass(ColumnSorterIcon, null, [{
     key: "getDescend",
@@ -588,7 +526,7 @@ function (_React$PureComponent3) {
 
     _classCallCheck(this, ColumnSorterIcon);
 
-    _this5 = _super3.call(this, props);
+    _this5 = _possibleConstructorReturn(this, _getPrototypeOf(ColumnSorterIcon).call(this, props));
     _this5.onIconClick = _this5.onIconClick.bind(_assertThisInitialized(_this5));
     _this5.memoized = {
       isActive: (0, _memoizeOne["default"])(ColumnSorterIcon.isActive)
@@ -674,23 +612,18 @@ function (_React$PureComponent3) {
         tooltip = "" + sort_fields.length + " sort options";
       }
 
-      return (
-        /*#__PURE__*/
-        _react["default"].createElement("span", {
-          className: cls,
-          onClick: this.onIconClick,
-          "data-tip": tooltip,
-          "data-html": true
-        },
-        /*#__PURE__*/
-        _react["default"].createElement(ColumnSorterIconElement, _extends({
-          showingSortOptionsMenu: showingSortOptionsMenu,
-          hasMultipleSortOptions: hasMultipleSortOptions,
-          isLoading: isLoading
-        }, {
-          descend: !active || descend
-        })))
-      );
+      return _react["default"].createElement("span", {
+        className: cls,
+        onClick: this.onIconClick,
+        "data-tip": tooltip,
+        "data-html": true
+      }, _react["default"].createElement(ColumnSorterIconElement, _extends({
+        showingSortOptionsMenu: showingSortOptionsMenu,
+        hasMultipleSortOptions: hasMultipleSortOptions,
+        isLoading: isLoading
+      }, {
+        descend: !active || descend
+      })));
     }
   }]);
 
@@ -751,27 +684,20 @@ var SortOptionsMenuContainer = _react["default"].memo(function (props) {
   var style = {
     left: Math.max(200, widthUntilActiveColumnEnd + leftOffset)
   };
-  return (
-    /*#__PURE__*/
-    _react["default"].createElement("div", {
-      className: "headers-columns-dropdown-menu-container"
-    },
-    /*#__PURE__*/
-    _react["default"].createElement(SortOptionsMenu, {
-      currentSortColumn: currentSortColumn,
-      descend: descend,
-      sort_fields: sort_fields,
-      sortByField: sortByField,
-      style: style
-    }))
-  );
+  return _react["default"].createElement("div", {
+    className: "headers-columns-dropdown-menu-container"
+  }, _react["default"].createElement(SortOptionsMenu, {
+    currentSortColumn: currentSortColumn,
+    descend: descend,
+    sort_fields: sort_fields,
+    sortByField: sortByField,
+    style: style
+  }));
 });
 
 var SortOptionsMenu = _react["default"].memo(function (_ref7) {
   var _ref7$header = _ref7.header,
-      header = _ref7$header === void 0 ?
-  /*#__PURE__*/
-  _react["default"].createElement("h5", {
+      header = _ref7$header === void 0 ? _react["default"].createElement("h5", {
     className: "dropdown-header mt-0 px-3 pt-03 text-600"
   }, "Sort by") : _ref7$header,
       currentSortColumn = _ref7.currentSortColumn,
@@ -789,26 +715,18 @@ var SortOptionsMenu = _react["default"].memo(function (_ref7) {
     var isActive = currentSortColumn === field;
     var cls = "dropdown-item" + " clickable no-highlight no-user-select" + " d-flex align-items-center justify-content-between" + (isActive ? " active" : "");
     var onClick = sortByField.bind(sortByField, field);
-    return (
-      /*#__PURE__*/
-      _react["default"].createElement("div", {
-        className: cls,
-        key: field,
-        onClick: onClick
-      }, title || field, !isActive ? null :
-      /*#__PURE__*/
-      _react["default"].createElement("i", {
-        className: "small icon fas ml-12 icon-arrow-".concat(descend ? "down" : "up")
-      }))
-    );
+    return _react["default"].createElement("div", {
+      className: cls,
+      key: field,
+      onClick: onClick
+    }, title || field, !isActive ? null : _react["default"].createElement("i", {
+      className: "small icon fas ml-12 icon-arrow-".concat(descend ? "down" : "up")
+    }));
   });
-  return (
-    /*#__PURE__*/
-    _react["default"].createElement("div", {
-      className: "dropdown-menu show",
-      style: style
-    }, header, options)
-  );
+  return _react["default"].createElement("div", {
+    className: "dropdown-menu show",
+    style: style
+  }, header, options);
 });
 
 var ColumnSorterIconElement = _react["default"].memo(function (_ref9) {
@@ -818,36 +736,24 @@ var ColumnSorterIconElement = _react["default"].memo(function (_ref9) {
       isLoading = _ref9$isLoading === void 0 ? false : _ref9$isLoading;
 
   if (isLoading) {
-    return (
-      /*#__PURE__*/
-      _react["default"].createElement("i", {
-        className: "icon icon-fw icon-circle-notch icon-spin fas"
-      })
-    );
+    return _react["default"].createElement("i", {
+      className: "icon icon-fw icon-circle-notch icon-spin fas"
+    });
   }
 
   if (showingSortOptionsMenu) {
-    return (
-      /*#__PURE__*/
-      _react["default"].createElement("i", {
-        className: "icon icon-fw icon-times fas"
-      })
-    );
+    return _react["default"].createElement("i", {
+      className: "icon icon-fw icon-times fas"
+    });
   }
 
   if (descend) {
-    return (
-      /*#__PURE__*/
-      _react["default"].createElement("i", {
-        className: "sort-icon icon icon-fw icon-sort-down fas align-top"
-      })
-    );
+    return _react["default"].createElement("i", {
+      className: "sort-icon icon icon-fw icon-sort-down fas align-top"
+    });
   } else {
-    return (
-      /*#__PURE__*/
-      _react["default"].createElement("i", {
-        className: "sort-icon icon icon-fw icon-sort-up fas align-bottom"
-      })
-    );
+    return _react["default"].createElement("i", {
+      className: "sort-icon icon icon-fw icon-sort-up fas align-bottom"
+    });
   }
 });

--- a/es/components/browse/components/table-commons/ResultRowColumnBlockValue.js
+++ b/es/components/browse/components/table-commons/ResultRowColumnBlockValue.js
@@ -28,12 +28,6 @@ function _arrayWithoutHoles(arr) { if (Array.isArray(arr)) { for (var i = 0, arr
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
-
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
-
-function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function (o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
-
 function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
@@ -41,6 +35,42 @@ function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _d
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
 
 function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function (o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
+function _createSuper(Derived) {
+  function isNativeReflectConstruct() {
+    if (typeof Reflect === "undefined" || !Reflect.construct) return false;
+    if (Reflect.construct.sham) return false;
+    if (typeof Proxy === "function") return true;
+
+    try {
+      Date.prototype.toString.call(Reflect.construct(Date, [], function () {}));
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  return function () {
+    var Super = _getPrototypeOf(Derived),
+        result;
+
+    if (isNativeReflectConstruct()) {
+      var NewTarget = _getPrototypeOf(this).constructor;
+
+      result = Reflect.construct(Super, arguments, NewTarget);
+    } else {
+      result = Super.apply(this, arguments);
+    }
+
+    return _possibleConstructorReturn(this, result);
+  };
+}
+
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function (o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
@@ -53,6 +83,8 @@ var ResultRowColumnBlockValue =
 /*#__PURE__*/
 function (_React$Component) {
   _inherits(ResultRowColumnBlockValue, _React$Component);
+
+  var _super = _createSuper(ResultRowColumnBlockValue);
 
   _createClass(ResultRowColumnBlockValue, null, [{
     key: "transformIfNeeded",
@@ -113,7 +145,7 @@ function (_React$Component) {
 
     _classCallCheck(this, ResultRowColumnBlockValue);
 
-    _this = _possibleConstructorReturn(this, _getPrototypeOf(ResultRowColumnBlockValue).call(this, props));
+    _this = _super.call(this, props);
     _this.memoized = {
       transformIfNeeded: (0, _memoizeOne["default"])(ResultRowColumnBlockValue.transformIfNeeded)
     };
@@ -155,30 +187,42 @@ function (_React$Component) {
       var tooltip;
 
       if (typeof value === 'number') {
-        value = _react["default"].createElement("span", {
+        value =
+        /*#__PURE__*/
+        _react["default"].createElement("span", {
           className: "value"
         }, value);
       } else if (typeof value === 'string') {
         if (propTooltip === true && value.length > 25) tooltip = value;
-        value = _react["default"].createElement("span", {
+        value =
+        /*#__PURE__*/
+        _react["default"].createElement("span", {
           className: "value text-center"
         }, value);
       } else if (value === null) {
-        value = _react["default"].createElement("small", {
+        value =
+        /*#__PURE__*/
+        _react["default"].createElement("small", {
           className: "value text-center"
         }, "-");
       } else if (_react["default"].isValidElement(value) && value.type === "a") {
         // We let other columnRender funcs define their `value` container (if any)
         // But if is link, e.g. from termTransformFxn, then wrap it to center it.
-        value = _react["default"].createElement("span", {
+        value =
+        /*#__PURE__*/
+        _react["default"].createElement("span", {
           className: "value text-center"
         }, value);
       } else if (typeof value === "boolean") {
-        value = _react["default"].createElement("span", {
+        value =
+        /*#__PURE__*/
+        _react["default"].createElement("span", {
           className: "value text-center"
         }, value);
       } else if (!renderFxn) {
-        value = _react["default"].createElement("span", {
+        value =
+        /*#__PURE__*/
+        _react["default"].createElement("span", {
           className: "value"
         }, value); // JSX from termTransformFxn - assume doesn't take table cell layouting into account.
       } // else is likely JSX from custom render function -- leave as-is
@@ -190,10 +234,13 @@ function (_React$Component) {
         cls += ' ' + className;
       }
 
-      return _react["default"].createElement("div", {
-        className: cls,
-        "data-tip": tooltip
-      }, value);
+      return (
+        /*#__PURE__*/
+        _react["default"].createElement("div", {
+          className: cls,
+          "data-tip": tooltip
+        }, value)
+      );
     }
   }]);
 
@@ -228,9 +275,12 @@ function sanitizeOutputValue(value) {
         var atId = _object.itemUtil.atId(value);
 
         if (atId) {
-          return _react["default"].createElement("a", {
-            href: atId
-          }, value.display_title);
+          return (
+            /*#__PURE__*/
+            _react["default"].createElement("a", {
+              href: atId
+            }, value.display_title)
+          );
         } else {
           return value.display_title;
         }

--- a/es/components/browse/components/table-commons/ResultRowColumnBlockValue.js
+++ b/es/components/browse/components/table-commons/ResultRowColumnBlockValue.js
@@ -28,6 +28,12 @@ function _arrayWithoutHoles(arr) { if (Array.isArray(arr)) { for (var i = 0, arr
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function (o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
 function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
@@ -35,42 +41,6 @@ function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _d
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
 
 function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function (o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
-
-function _createSuper(Derived) {
-  function isNativeReflectConstruct() {
-    if (typeof Reflect === "undefined" || !Reflect.construct) return false;
-    if (Reflect.construct.sham) return false;
-    if (typeof Proxy === "function") return true;
-
-    try {
-      Date.prototype.toString.call(Reflect.construct(Date, [], function () {}));
-      return true;
-    } catch (e) {
-      return false;
-    }
-  }
-
-  return function () {
-    var Super = _getPrototypeOf(Derived),
-        result;
-
-    if (isNativeReflectConstruct()) {
-      var NewTarget = _getPrototypeOf(this).constructor;
-
-      result = Reflect.construct(Super, arguments, NewTarget);
-    } else {
-      result = Super.apply(this, arguments);
-    }
-
-    return _possibleConstructorReturn(this, result);
-  };
-}
-
-function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
-
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
-
-function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function (o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
@@ -83,8 +53,6 @@ var ResultRowColumnBlockValue =
 /*#__PURE__*/
 function (_React$Component) {
   _inherits(ResultRowColumnBlockValue, _React$Component);
-
-  var _super = _createSuper(ResultRowColumnBlockValue);
 
   _createClass(ResultRowColumnBlockValue, null, [{
     key: "transformIfNeeded",
@@ -145,7 +113,7 @@ function (_React$Component) {
 
     _classCallCheck(this, ResultRowColumnBlockValue);
 
-    _this = _super.call(this, props);
+    _this = _possibleConstructorReturn(this, _getPrototypeOf(ResultRowColumnBlockValue).call(this, props));
     _this.memoized = {
       transformIfNeeded: (0, _memoizeOne["default"])(ResultRowColumnBlockValue.transformIfNeeded)
     };
@@ -187,42 +155,30 @@ function (_React$Component) {
       var tooltip;
 
       if (typeof value === 'number') {
-        value =
-        /*#__PURE__*/
-        _react["default"].createElement("span", {
+        value = _react["default"].createElement("span", {
           className: "value"
         }, value);
       } else if (typeof value === 'string') {
         if (propTooltip === true && value.length > 25) tooltip = value;
-        value =
-        /*#__PURE__*/
-        _react["default"].createElement("span", {
+        value = _react["default"].createElement("span", {
           className: "value text-center"
         }, value);
       } else if (value === null) {
-        value =
-        /*#__PURE__*/
-        _react["default"].createElement("small", {
+        value = _react["default"].createElement("small", {
           className: "value text-center"
         }, "-");
       } else if (_react["default"].isValidElement(value) && value.type === "a") {
         // We let other columnRender funcs define their `value` container (if any)
         // But if is link, e.g. from termTransformFxn, then wrap it to center it.
-        value =
-        /*#__PURE__*/
-        _react["default"].createElement("span", {
+        value = _react["default"].createElement("span", {
           className: "value text-center"
         }, value);
       } else if (typeof value === "boolean") {
-        value =
-        /*#__PURE__*/
-        _react["default"].createElement("span", {
+        value = _react["default"].createElement("span", {
           className: "value text-center"
         }, value);
       } else if (!renderFxn) {
-        value =
-        /*#__PURE__*/
-        _react["default"].createElement("span", {
+        value = _react["default"].createElement("span", {
           className: "value"
         }, value); // JSX from termTransformFxn - assume doesn't take table cell layouting into account.
       } // else is likely JSX from custom render function -- leave as-is
@@ -234,13 +190,10 @@ function (_React$Component) {
         cls += ' ' + className;
       }
 
-      return (
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: cls,
-          "data-tip": tooltip
-        }, value)
-      );
+      return _react["default"].createElement("div", {
+        className: cls,
+        "data-tip": tooltip
+      }, value);
     }
   }]);
 
@@ -275,12 +228,9 @@ function sanitizeOutputValue(value) {
         var atId = _object.itemUtil.atId(value);
 
         if (atId) {
-          return (
-            /*#__PURE__*/
-            _react["default"].createElement("a", {
-              href: atId
-            }, value.display_title)
-          );
+          return _react["default"].createElement("a", {
+            href: atId
+          }, value.display_title);
         } else {
           return value.display_title;
         }

--- a/es/components/browse/components/table-commons/basicColumnExtensionMap.js
+++ b/es/components/browse/components/table-commons/basicColumnExtensionMap.js
@@ -61,30 +61,23 @@ var basicColumnExtensionMap = {
       var renderElem;
 
       if (itemTypeList[0] === "User") {
-        renderElem =
-        /*#__PURE__*/
-        _react["default"].createElement(DisplayTitleColumnUser, {
+        renderElem = _react["default"].createElement(DisplayTitleColumnUser, {
           result: result
         });
       } else {
-        renderElem =
-        /*#__PURE__*/
-        _react["default"].createElement(DisplayTitleColumnDefault, {
+        renderElem = _react["default"].createElement(DisplayTitleColumnDefault, {
           result: result
         });
       }
 
-      return (
-        /*#__PURE__*/
-        _react["default"].createElement(DisplayTitleColumnWrapper, {
-          result: result,
-          href: href,
-          context: context,
-          rowNumber: rowNumber,
-          detailOpen: detailOpen,
-          toggleDetailOpen: toggleDetailOpen
-        }, renderElem)
-      );
+      return _react["default"].createElement(DisplayTitleColumnWrapper, {
+        result: result,
+        href: href,
+        context: context,
+        rowNumber: rowNumber,
+        detailOpen: detailOpen,
+        toggleDetailOpen: toggleDetailOpen
+      }, renderElem);
     }
   },
   '@type': {
@@ -100,43 +93,34 @@ var basicColumnExtensionMap = {
           propNavigate = _props$navigate === void 0 ? null : _props$navigate;
       var leafItemType = (0, _schemaTransforms.getItemType)(result);
       var itemTypeTitle = (0, _schemaTransforms.getTitleForType)(leafItemType, schemas);
-      return (
-        /*#__PURE__*/
-        _react["default"].createElement(_react["default"].Fragment, null,
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: "icon-container"
+      return _react["default"].createElement(_react["default"].Fragment, null, _react["default"].createElement("div", {
+        className: "icon-container"
+      }, _react["default"].createElement("i", {
+        className: "icon icon-fw fas icon-filter clickable mr-08",
+        onClick: function onClick(e) {
+          // Preserve search query, if any, but remove filters (which are usually per-type).
+          if (!href || href.indexOf('/search/') === -1) return;
+          e.preventDefault();
+          e.stopPropagation();
+
+          var urlParts = _url["default"].parse(href, true);
+
+          var query = _objectSpread({}, urlParts.query, {
+            'type': leafItemType
+          });
+
+          if (urlParts.query.q) query.q = urlParts.query.q;
+
+          var nextHref = '/search/?' + _querystring["default"].stringify(query); // We use props.navigate here first which may refer to VirtualHrefController.virtualNavigate
+          // since we're navigating to a search href here.
+
+
+          (propNavigate || _navigate.navigate)(nextHref);
         },
-        /*#__PURE__*/
-        _react["default"].createElement("i", {
-          className: "icon icon-fw fas icon-filter clickable mr-08",
-          onClick: function onClick(e) {
-            // Preserve search query, if any, but remove filters (which are usually per-type).
-            if (!href || href.indexOf('/search/') === -1) return;
-            e.preventDefault();
-            e.stopPropagation();
-
-            var urlParts = _url["default"].parse(href, true);
-
-            var query = _objectSpread(_objectSpread({}, urlParts.query), {}, {
-              'type': leafItemType
-            });
-
-            if (urlParts.query.q) query.q = urlParts.query.q;
-
-            var nextHref = '/search/?' + _querystring["default"].stringify(query); // We use props.navigate here first which may refer to VirtualHrefController.virtualNavigate
-            // since we're navigating to a search href here.
-
-
-            (propNavigate || _navigate.navigate)(nextHref);
-          },
-          "data-tip": "Filter down to only " + itemTypeTitle
-        })),
-        /*#__PURE__*/
-        _react["default"].createElement("span", {
-          className: "item-type-title value"
-        }, itemTypeTitle))
-      );
+        "data-tip": "Filter down to only " + itemTypeTitle
+      })), _react["default"].createElement("span", {
+        className: "item-type-title value"
+      }, itemTypeTitle));
     }
   },
   'date_created': {
@@ -149,17 +133,12 @@ var basicColumnExtensionMap = {
     },
     'render': function (result) {
       if (!result.date_created) return null;
-      return (
-        /*#__PURE__*/
-        _react["default"].createElement("span", {
-          className: "value"
-        },
-        /*#__PURE__*/
-        _react["default"].createElement(_LocalizedTime.LocalizedTime, {
-          timestamp: result.date_created,
-          formatType: "date-sm"
-        }))
-      );
+      return _react["default"].createElement("span", {
+        className: "value"
+      }, _react["default"].createElement(_LocalizedTime.LocalizedTime, {
+        timestamp: result.date_created,
+        formatType: "date-sm"
+      }));
     },
     'order': 510
   },
@@ -176,17 +155,12 @@ var basicColumnExtensionMap = {
       var _result$last_modified2 = _result$last_modified.date_modified,
           date_modified = _result$last_modified2 === void 0 ? null : _result$last_modified2;
       if (!date_modified) return null;
-      return (
-        /*#__PURE__*/
-        _react["default"].createElement("span", {
-          className: "value"
-        },
-        /*#__PURE__*/
-        _react["default"].createElement(_LocalizedTime.LocalizedTime, {
-          timestamp: date_modified,
-          formatType: "date-sm"
-        }))
-      );
+      return _react["default"].createElement("span", {
+        className: "value"
+      }, _react["default"].createElement(_LocalizedTime.LocalizedTime, {
+        timestamp: date_modified,
+        formatType: "date-sm"
+      }));
     },
     'order': 515
   }
@@ -208,9 +182,7 @@ var DisplayTitleColumnUser = _react["default"].memo(function (_ref) {
 
   if (link) {
     // This should be the case always
-    title =
-    /*#__PURE__*/
-    _react["default"].createElement("a", {
+    title = _react["default"].createElement("a", {
       key: "title",
       href: link || '#',
       onClick: onClick
@@ -219,9 +191,7 @@ var DisplayTitleColumnUser = _react["default"].memo(function (_ref) {
     if (typeof email === 'string' && email.indexOf('@') > -1) {
       // Specific case for User items. May be removed or more cases added, if needed.
       hasPhoto = true;
-      title =
-      /*#__PURE__*/
-      _react["default"].createElement(_react["default"].Fragment, null, _object.itemUtil.User.gravatar(email, 32, {
+      title = _react["default"].createElement(_react["default"].Fragment, null, _object.itemUtil.User.gravatar(email, 32, {
         'className': 'in-search-table-title-image',
         'data-tip': email
       }, 'mm'), title);
@@ -229,15 +199,12 @@ var DisplayTitleColumnUser = _react["default"].memo(function (_ref) {
   }
 
   var cls = "title-block" + (hasPhoto ? " has-photo d-flex align-items-center" : " text-ellipsis-container");
-  return (
-    /*#__PURE__*/
-    _react["default"].createElement("div", {
-      key: "title-container",
-      className: cls,
-      "data-tip": tooltip,
-      "data-delay-show": 750
-    }, title)
-  );
+  return _react["default"].createElement("div", {
+    key: "title-container",
+    className: cls,
+    "data-tip": tooltip,
+    "data-delay-show": 750
+  }, title);
 });
 /**
  * @todo
@@ -266,9 +233,7 @@ var DisplayTitleColumnDefault = _react["default"].memo(function (props) {
 
   if (link) {
     // This should be the case always
-    title =
-    /*#__PURE__*/
-    _react["default"].createElement("a", {
+    title = _react["default"].createElement("a", {
       key: "title",
       href: link || '#',
       onClick: onClick
@@ -276,15 +241,12 @@ var DisplayTitleColumnDefault = _react["default"].memo(function (props) {
   }
 
   var cls = "title-block text-ellipsis-container" + (shouldMonospace ? " text-monospace text-small" : "") + (className ? " " + className : "");
-  return (
-    /*#__PURE__*/
-    _react["default"].createElement("div", {
-      key: "title-container",
-      className: cls,
-      "data-tip": tooltip,
-      "data-delay-show": 750
-    }, title)
-  );
+  return _react["default"].createElement("div", {
+    key: "title-container",
+    className: cls,
+    "data-tip": tooltip,
+    "data-delay-show": 750
+  }, title);
 });
 
 exports.DisplayTitleColumnDefault = DisplayTitleColumnDefault;
@@ -328,15 +290,10 @@ var DisplayTitleColumnWrapper = _react["default"].memo(function (props) {
     });
   });
 
-  return (
-    /*#__PURE__*/
-    _react["default"].createElement(_react["default"].Fragment, null,
-    /*#__PURE__*/
-    _react["default"].createElement(TableRowToggleOpenButton, {
-      open: detailOpen,
-      onClick: toggleDetailOpen
-    }), renderChildren)
-  );
+  return _react["default"].createElement(_react["default"].Fragment, null, _react["default"].createElement(TableRowToggleOpenButton, {
+    open: detailOpen,
+    onClick: toggleDetailOpen
+  }), renderChildren);
 });
 /** Button shown in first column (display_title) to open/close detail pane. */
 
@@ -347,26 +304,17 @@ var TableRowToggleOpenButton = _react["default"].memo(function (_ref2) {
   var onClick = _ref2.onClick,
       toggleDetailOpen = _ref2.toggleDetailOpen,
       open = _ref2.open;
-  return (
-    /*#__PURE__*/
-    _react["default"].createElement("div", {
-      className: "toggle-detail-button-container"
-    },
-    /*#__PURE__*/
-    _react["default"].createElement("button", {
-      type: "button",
-      className: "toggle-detail-button",
-      onClick: onClick || toggleDetailOpen
-    },
-    /*#__PURE__*/
-    _react["default"].createElement("div", {
-      className: "icon-container"
-    },
-    /*#__PURE__*/
-    _react["default"].createElement("i", {
-      className: "icon icon-fw fas icon-" + (open ? 'minus' : 'plus')
-    }))))
-  );
+  return _react["default"].createElement("div", {
+    className: "toggle-detail-button-container"
+  }, _react["default"].createElement("button", {
+    type: "button",
+    className: "toggle-detail-button",
+    onClick: onClick || toggleDetailOpen
+  }, _react["default"].createElement("div", {
+    className: "icon-container"
+  }, _react["default"].createElement("i", {
+    className: "icon icon-fw fas icon-" + (open ? 'minus' : 'plus')
+  }))));
 });
 
 exports.TableRowToggleOpenButton = TableRowToggleOpenButton;

--- a/es/components/forms/SubmissionView.js
+++ b/es/components/forms/SubmissionView.js
@@ -129,7 +129,7 @@ function (_React$PureComponent) {
      *
      * @todo maybe memoize this and replace usage of state.keyValid w/ it.
      */
-    value: function findValidationState(keyIdx, prevKeyHierarchy, keyContext, keyComplete) {
+    value: function findValidationState(keyIdx, prevKeyHierarchy) {
       var hierarchy = _util.object.deepClone(prevKeyHierarchy);
 
       var keyHierarchy = (0, _submissionView.searchHierarchy)(hierarchy, keyIdx);
@@ -137,10 +137,10 @@ function (_React$PureComponent) {
       var validationReturn = 1;
 
       _underscore["default"].keys(keyHierarchy).forEach(function (key) {
+        // If key is a number, item has not been submitted yet... see note below
         if (!isNaN(key)) {
-          if (!keyComplete[key] && keyContext[key]) {
-            validationReturn = 0;
-          }
+          // NOTE: as of SAYTAJAX, ONLY unsubmitted items are stored with numeric keys
+          validationReturn = 0;
         }
       });
 
@@ -1713,11 +1713,18 @@ function (_React$PureComponent) {
                   _this6.setState(stateToSet);
                 }
               } else {
+                // Check if parent validation state will change based on current submission... update that alongside rest of state, if so
+                var newParentValidState = SubmissionView.findValidationState(parentKey, stateToSet.keyHierarchy, stateToSet.keyContext, stateToSet.keyComplete);
+
+                if (newParentValidState !== stateToSet.keyValid[parentKey]) {
+                  stateToSet.keyValid[parentKey] = newParentValidState;
+                }
+
                 _util.console.log("updating state with stateToSet: ", stateToSet);
 
                 _util.console.log("keyDisplay, ", keyDisplay);
 
-                _util.console.log("inKey: , ", inKey);
+                _util.console.log("inKey: ", inKey);
 
                 alert(keyDisplay[inKey] + ' was successfully submitted.');
 
@@ -2810,8 +2817,7 @@ function (_React$Component2) {
       //     atIds=${atIds},
       //     customSelectField=${customSelectField},
       //     customSelectType=${customSelectType},
-      //     customArrayIdx=${customArrayIdx},
-      //     valueToReplace=${valueToReplace}`);
+      //     customArrayIdx=${customArrayIdx}`);
       var currContext = this.props.currContext;
       var _this$state7 = this.state,
           stateSelectField = _this$state7.selectField,

--- a/es/components/forms/SubmissionView.js
+++ b/es/components/forms/SubmissionView.js
@@ -542,9 +542,7 @@ function (_React$PureComponent) {
     value: function initCreateObj(ambiguousType, ambiguousIdx, creatingLink) {
       var init = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : false;
       var parentField = arguments.length > 4 && arguments[4] !== undefined ? arguments[4] : null;
-
-      _util.console.log.apply(_util.console, ["calling initCreateObj with:"].concat(Array.prototype.slice.call(arguments)));
-
+      // console.log("calling initCreateObj with:", ...arguments);
       var schemas = this.props.schemas;
 
       var itemTypeHierarchy = _util.schemaTransforms.schemasToItemTypeHierarchy(schemas); // check to see if we have an ambiguous linkTo type.
@@ -821,9 +819,7 @@ function (_React$PureComponent) {
     key: "createObj",
     value: function createObj(type, newIdx, newLink, alias) {
       var extraState = arguments.length > 4 && arguments[4] !== undefined ? arguments[4] : {};
-
-      _util.console.log.apply(_util.console, ["CREATEOBJ"].concat(Array.prototype.slice.call(arguments)));
-
+      // console.log("CREATEOBJ", ...arguments);
       var errorCount = this.state.errorCount; // get rid of any hanging errors
 
       for (var i = 0; i < errorCount; i++) {
@@ -926,8 +922,7 @@ function (_React$PureComponent) {
   }, {
     key: "removeObj",
     value: function removeObj(keyToRemove) {
-      _util.console.log("calling removeObj with keyToRemove=", keyToRemove);
-
+      // console.log("calling removeObj with keyToRemove=", keyToRemove);
       this.setState(function (_ref4) {
         var keyContext = _ref4.keyContext,
             keyValid = _ref4.keyValid,
@@ -1276,10 +1271,8 @@ function (_React$PureComponent) {
   }, {
     key: "realPostNewContext",
     value: function realPostNewContext(e) {
-      _util.console.log("real posting new context");
-
-      _util.console.log("submitting object with currkey: ", this.state.currKey);
-
+      // console.log("real posting new context");
+      // console.log("submitting object with currkey: ", this.state.currKey);
       e.preventDefault();
       this.submitObject(this.state.currKey);
     }
@@ -1698,9 +1691,8 @@ function (_React$PureComponent) {
               if (inKey !== 0) {
                 var _findFieldFromContext = (0, _submissionView.findFieldFromContext)(contextCopy[parentKey], typesCopy[parentKey], schemas, inKey, responseData['@type']),
                     splitField = _findFieldFromContext.splitField,
-                    arrayIdx = _findFieldFromContext.arrayIdx;
+                    arrayIdx = _findFieldFromContext.arrayIdx; // console.log('Results from findFieldFromContext', splitField, arrayIdx);
 
-                _util.console.log('Results from findFieldFromContext', splitField, arrayIdx);
 
                 (0, _submissionView.modifyContextInPlace)(splitField, contextCopy[parentKey], arrayIdx, "linked object", submitted_at_id);
                 (0, _submissionView.replaceInHierarchy)(hierCopy, inKey, submitted_at_id); // Modifies hierCopy in place.
@@ -1753,13 +1745,10 @@ function (_React$PureComponent) {
 
                 if (newParentValidState !== stateToSet.keyValid[parentKey]) {
                   stateToSet.keyValid[parentKey] = newParentValidState;
-                }
+                } // console.log("updating state with stateToSet: ", stateToSet);
+                // console.log("keyDisplay, ", keyDisplay);
+                // console.log("inKey: ", inKey);
 
-                _util.console.log("updating state with stateToSet: ", stateToSet);
-
-                _util.console.log("keyDisplay, ", keyDisplay);
-
-                _util.console.log("inKey: ", inKey);
 
                 alert(keyDisplay[inKey] + ' was successfully submitted.');
 
@@ -1780,8 +1769,7 @@ function (_React$PureComponent) {
           submitProcessContd(myLab, myAward);
         });
       } else {
-        _util.console.log("submitting process continued");
-
+        // console.log("submitting process continued");
         submitProcessContd();
       }
     }
@@ -2863,49 +2851,34 @@ function (_React$Component2) {
       }
 
       if (Array.isArray(pointer[splitFieldLeaf]) && fieldType !== 'array') {
-        _util.console.log("found an array, ", pointer[splitFieldLeaf]); // move pointer into array
+        // console.log("found an array, ", pointer[splitFieldLeaf]);
+        // move pointer into array
+        pointer = pointer[splitFieldLeaf]; // console.log("pointer is now: ", pointer);
 
-
-        pointer = pointer[splitFieldLeaf];
-
-        _util.console.log("pointer is now: ", pointer);
-
-        prevValue = pointer[arrayIdx[arrayIdxPointer]];
-
-        _util.console.log("prevValue is now:", prevValue);
+        prevValue = pointer[arrayIdx[arrayIdxPointer]]; // console.log("prevValue is now:", prevValue);
 
         if (value === null) {
           // delete this array itemfieldType
-          _util.console.log("what is value?", value);
-
-          _util.console.log("pointer presplice", pointer);
-
-          pointer.splice(arrayIdx[arrayIdxPointer], 1);
-
-          _util.console.log("pointer postsplice", pointer);
+          // console.log("what is value?", value);
+          // console.log("pointer presplice", pointer);
+          pointer.splice(arrayIdx[arrayIdxPointer], 1); // console.log("pointer postsplice", pointer);
         } else {
-          _util.console.log("arrayIdx for pointer", arrayIdx[arrayIdxPointer]);
-
+          // console.log("arrayIdx for pointer", arrayIdx[arrayIdxPointer]);
           pointer[arrayIdx[arrayIdxPointer]] = value;
         }
       } else {
         // value we're trying to set is not inside an array at this point
-        prevValue = pointer[splitFieldLeaf];
-
-        _util.console.log("prevValue is now:", prevValue);
+        prevValue = pointer[splitFieldLeaf]; // console.log("prevValue is now:", prevValue);
 
         pointer[splitFieldLeaf] = value;
       }
       /* modifyContextInPlace can replace everything up until this point... need to update var names, though */
+      // console.log("value and previousValue, ", value, prevValue);
+      // console.log("modifyNewContext II", value, currContext);
 
-
-      _util.console.log("value and previousValue, ", value, prevValue);
-
-      _util.console.log("modifyNewContext II", value, currContext);
 
       if ((value === null || prevValue !== null) && (fieldType === 'linked object' || fieldType === "existing linked object" || fieldType === 'new linked object')) {
-        _util.console.log("removing obj ", prevValue);
-
+        // console.log("removing obj ", prevValue);
         removeObj(prevValue);
       }
 
@@ -3118,18 +3091,6 @@ function (_React$Component2) {
       var _this$state8 = this.state,
           selectField = _this$state8.selectField,
           selectArrayIdx = _this$state8.selectArrayIdx;
-      var _this$props13 = this.props,
-          keyContext = _this$props13.keyContext,
-          currKey = _this$props13.currKey;
-
-      _util.console.log("previous value", previousValue);
-
-      _util.console.log("curr value", keyContext[currKey][selectField]);
-
-      _util.console.log("this.state", this.state);
-
-      _util.console.log("this.props", this.props);
-
       this.modifyNewContext(selectField, previousValue || null, 'existing linked object', null, selectArrayIdx);
       this.setState({
         'selectType': null,
@@ -3146,15 +3107,15 @@ function (_React$Component2) {
   }, {
     key: "initiateField",
     value: function initiateField(field) {
-      var _this$props14 = this.props,
-          schemas = _this$props14.schemas,
-          currType = _this$props14.currType,
-          currKey = _this$props14.currKey,
-          roundTwo = _this$props14.roundTwo,
-          currContext = _this$props14.currContext,
-          keyComplete = _this$props14.keyComplete,
-          keyContext = _this$props14.keyContext,
-          edit = _this$props14.edit;
+      var _this$props13 = this.props,
+          schemas = _this$props13.schemas,
+          currType = _this$props13.currType,
+          currKey = _this$props13.currKey,
+          roundTwo = _this$props13.roundTwo,
+          currContext = _this$props13.currContext,
+          keyComplete = _this$props13.keyComplete,
+          keyContext = _this$props13.keyContext,
+          edit = _this$props13.edit;
       var currSchema = schemas[currType]; // console.log("RENDER INDV OBJ VIEW", currSchema, field);
 
       var fieldSchema = _util.object.getNestedProperty(currSchema, ['properties', field], true);
@@ -3289,13 +3250,13 @@ function (_React$Component2) {
   }, {
     key: "render",
     value: function render() {
-      var _this$props15 = this.props,
-          currContext = _this$props15.currContext,
-          keyComplete = _this$props15.keyComplete,
-          keyContext = _this$props15.keyContext,
-          currKey = _this$props15.currKey,
-          schemas = _this$props15.schemas,
-          roundTwo = _this$props15.roundTwo;
+      var _this$props14 = this.props,
+          currContext = _this$props14.currContext,
+          keyComplete = _this$props14.keyComplete,
+          keyContext = _this$props14.keyContext,
+          currKey = _this$props14.currKey,
+          schemas = _this$props14.schemas,
+          roundTwo = _this$props14.roundTwo;
       var fields = currContext ? _underscore["default"].keys(currContext) : [];
       var fieldJSXComponents = (0, _submissionView.sortPropFields)(_underscore["default"].filter( // Sort fields first by requirement and secondly alphabetically. These are JSX BuildField components.
       _underscore["default"].map(fields, this.initiateField), function (f) {
@@ -3386,9 +3347,9 @@ function (_React$PureComponent3) {
   }, {
     key: "render",
     value: function render() {
-      var _this$props16 = this.props,
-          context = _this$props16.context,
-          schemas = _this$props16.schemas;
+      var _this$props15 = this.props,
+          context = _this$props15.context,
+          schemas = _this$props15.schemas;
       var open = this.state.open;
       return (
         /*#__PURE__*/

--- a/es/components/forms/SubmissionView.js
+++ b/es/components/forms/SubmissionView.js
@@ -2652,23 +2652,43 @@ function (_React$Component2) {
       }
 
       if (Array.isArray(pointer[splitFieldLeaf]) && fieldType !== 'array') {
-        // move pointer into array
+        _util.console.log("found an array, ", pointer[splitFieldLeaf]); // move pointer into array
+
+
         pointer = pointer[splitFieldLeaf];
+
+        _util.console.log("pointer is now: ", pointer);
+
         prevValue = pointer[arrayIdx[arrayIdxPointer]];
+
+        _util.console.log("prevValue is now:", prevValue);
 
         if (value === null) {
           // delete this array itemfieldType
+          _util.console.log("what is value?", value);
+
+          _util.console.log("pointer presplice", pointer);
+
           pointer.splice(arrayIdx[arrayIdxPointer], 1);
+
+          _util.console.log("pointer postsplice", pointer);
         } else {
+          _util.console.log("arrayIdx for pointer", arrayIdx[arrayIdxPointer]);
+
           pointer[arrayIdx[arrayIdxPointer]] = value;
         }
       } else {
         // value we're trying to set is not inside an array at this point
         prevValue = pointer[splitFieldLeaf];
+
+        _util.console.log("prevValue is now:", prevValue);
+
         pointer[splitFieldLeaf] = value;
       }
       /* modifyContextInPlace can replace everything up until this point... need to update var names, though */
 
+
+      _util.console.log("value and previousValue, ", value, prevValue);
 
       _util.console.log("modifyNewContext II", value, currContext);
 
@@ -2883,11 +2903,23 @@ function (_React$Component2) {
 
   }, {
     key: "selectCancel",
-    value: function selectCancel() {
+    value: function selectCancel(previousValue) {
       var _this$state8 = this.state,
           selectField = _this$state8.selectField,
           selectArrayIdx = _this$state8.selectArrayIdx;
-      this.modifyNewContext(selectField, null, 'existing linked object', null, selectArrayIdx);
+      var _this$props13 = this.props,
+          keyContext = _this$props13.keyContext,
+          currKey = _this$props13.currKey;
+
+      _util.console.log("previous value", previousValue);
+
+      _util.console.log("curr value", keyContext[currKey][selectField]);
+
+      _util.console.log("this.state", this.state);
+
+      _util.console.log("this.props", this.props);
+
+      this.modifyNewContext(selectField, previousValue || null, 'existing linked object', null, selectArrayIdx);
       this.setState({
         'selectType': null,
         'selectField': null,
@@ -2903,15 +2935,15 @@ function (_React$Component2) {
   }, {
     key: "initiateField",
     value: function initiateField(field) {
-      var _this$props13 = this.props,
-          schemas = _this$props13.schemas,
-          currType = _this$props13.currType,
-          currKey = _this$props13.currKey,
-          roundTwo = _this$props13.roundTwo,
-          currContext = _this$props13.currContext,
-          keyComplete = _this$props13.keyComplete,
-          keyContext = _this$props13.keyContext,
-          edit = _this$props13.edit;
+      var _this$props14 = this.props,
+          schemas = _this$props14.schemas,
+          currType = _this$props14.currType,
+          currKey = _this$props14.currKey,
+          roundTwo = _this$props14.roundTwo,
+          currContext = _this$props14.currContext,
+          keyComplete = _this$props14.keyComplete,
+          keyContext = _this$props14.keyContext,
+          edit = _this$props14.edit;
       var currSchema = schemas[currType]; // console.log("RENDER INDV OBJ VIEW", currSchema, field);
 
       var fieldSchema = _util.object.getNestedProperty(currSchema, ['properties', field], true);
@@ -3030,13 +3062,13 @@ function (_React$Component2) {
   }, {
     key: "render",
     value: function render() {
-      var _this$props14 = this.props,
-          currContext = _this$props14.currContext,
-          keyComplete = _this$props14.keyComplete,
-          keyContext = _this$props14.keyContext,
-          currKey = _this$props14.currKey,
-          schemas = _this$props14.schemas,
-          roundTwo = _this$props14.roundTwo;
+      var _this$props15 = this.props,
+          currContext = _this$props15.currContext,
+          keyComplete = _this$props15.keyComplete,
+          keyContext = _this$props15.keyContext,
+          currKey = _this$props15.currKey,
+          schemas = _this$props15.schemas,
+          roundTwo = _this$props15.roundTwo;
       var fields = currContext ? _underscore["default"].keys(currContext) : [];
       var fieldJSXComponents = (0, _submissionView.sortPropFields)(_underscore["default"].filter( // Sort fields first by requirement and secondly alphabetically. These are JSX BuildField components.
       _underscore["default"].map(fields, this.initiateField), function (f) {
@@ -3111,9 +3143,9 @@ function (_React$PureComponent3) {
   }, {
     key: "render",
     value: function render() {
-      var _this$props15 = this.props,
-          context = _this$props15.context,
-          schemas = _this$props15.schemas;
+      var _this$props16 = this.props,
+          context = _this$props16.context,
+          schemas = _this$props16.schemas;
       var open = this.state.open;
       return _react["default"].createElement("div", {
         className: "current-item-properties round-two-panel"

--- a/es/components/forms/components/LinkToSelector.js
+++ b/es/components/forms/components/LinkToSelector.js
@@ -77,6 +77,9 @@ function (_React$PureComponent) {
     _this2.setChildWindowMessageHandler = _this2.setChildWindowMessageHandler.bind(_assertThisInitialized(_this2));
     _this2.handleChildWindowMessage = _this2.handleChildWindowMessage.bind(_assertThisInitialized(_this2));
     _this2.receiveData = _this2.receiveData.bind(_assertThisInitialized(_this2));
+
+    _patchedConsole.patchedConsoleInstance.log("LinkToSelector value", props.value);
+
     return _this2;
   }
 
@@ -116,6 +119,7 @@ function (_React$PureComponent) {
 
       var _this$props = this.props,
           searchURL = _this$props.searchURL,
+          value = _this$props.value,
           onCloseChildWindow = _this$props.onCloseChildWindow;
       var pastInSelection = pastProps.isSelecting;
       var nowInSelection = nextProps.isSelecting;
@@ -164,7 +168,7 @@ function (_React$PureComponent) {
 
             if (_this3 && _this3.windowObjectReference && _this3.windowObjectReference.closed) {
               if (typeof onCloseChildWindow === 'function') {
-                onCloseChildWindow();
+                onCloseChildWindow(value);
               }
             }
 
@@ -196,6 +200,9 @@ function (_React$PureComponent) {
   }, {
     key: "handleChildWindowMessage",
     value: function handleChildWindowMessage(evt) {
+      var _this$props2 = this.props,
+          value = _this$props2.value,
+          onCloseChildWindow = _this$props2.onCloseChildWindow;
       var eventType = evt && evt.data && evt.data.eventType;
 
       if (!eventType) {
@@ -235,7 +242,10 @@ function (_React$PureComponent) {
 
       if (eventType === 'fourfrontcancelclick') {
         this.cleanChildWindow();
-        this.props.onCloseChildWindow();
+
+        _patchedConsole.patchedConsoleInstance.log("cancel click occurred... value:", value);
+
+        onCloseChildWindow(value);
       } // If we have a `props.childWindowAlert`, show it once child window lets us know it has initialized it JS environment.
 
 
@@ -338,6 +348,7 @@ _defineProperty(LinkToSelector, "propTypes", {
 
   /** Optional callback called with no params when child window is closed. Could/should unset `props.isSelecting`. */
   'onCloseChildWindow': _propTypes["default"].func,
+  // When used with SV, will generally be the IndvObject.selectCancel method
 
   /** If true, then allows to drag & drop Item to window */
   'enableWindowDrop': _propTypes["default"].bool.isRequired,

--- a/es/components/forms/components/LinkToSelector.js
+++ b/es/components/forms/components/LinkToSelector.js
@@ -109,9 +109,6 @@ function (_React$PureComponent) {
     _this2.setChildWindowMessageHandler = _this2.setChildWindowMessageHandler.bind(_assertThisInitialized(_this2));
     _this2.handleChildWindowMessage = _this2.handleChildWindowMessage.bind(_assertThisInitialized(_this2));
     _this2.receiveData = _this2.receiveData.bind(_assertThisInitialized(_this2));
-
-    _patchedConsole.patchedConsoleInstance.log("LinkToSelector value", props.value);
-
     return _this2;
   }
 
@@ -274,9 +271,6 @@ function (_React$PureComponent) {
 
       if (eventType === 'fourfrontcancelclick') {
         this.cleanChildWindow();
-
-        _patchedConsole.patchedConsoleInstance.log("cancel click occurred... value:", value);
-
         onCloseChildWindow(value);
       } // If we have a `props.childWindowAlert`, show it once child window lets us know it has initialized it JS environment.
 
@@ -322,8 +316,6 @@ function (_React$PureComponent) {
   }, {
     key: "receiveData",
     value: function receiveData(items) {
-      _patchedConsole.patchedConsoleInstance.log("items, ", items);
-
       this.cleanChildWindow();
       this.props.onSelect(items, true);
     }

--- a/es/components/forms/components/SearchAsYouTypeAjax.js
+++ b/es/components/forms/components/SearchAsYouTypeAjax.js
@@ -58,27 +58,59 @@ function _defineProperties(target, props) { for (var i = 0; i < props.length; i+
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
 
-function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
-
-function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function (o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
-
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
-
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
 
 function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function (o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
+function _createSuper(Derived) {
+  function isNativeReflectConstruct() {
+    if (typeof Reflect === "undefined" || !Reflect.construct) return false;
+    if (Reflect.construct.sham) return false;
+    if (typeof Proxy === "function") return true;
+
+    try {
+      Date.prototype.toString.call(Reflect.construct(Date, [], function () {}));
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  return function () {
+    var Super = _getPrototypeOf(Derived),
+        result;
+
+    if (isNativeReflectConstruct()) {
+      var NewTarget = _getPrototypeOf(this).constructor;
+
+      result = Reflect.construct(Super, arguments, NewTarget);
+    } else {
+      result = Super.apply(this, arguments);
+    }
+
+    return _possibleConstructorReturn(this, result);
+  };
+}
+
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function (o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
 var SearchAsYouTypeAjax =
 /*#__PURE__*/
 function (_React$PureComponent) {
   _inherits(SearchAsYouTypeAjax, _React$PureComponent);
 
+  var _super = _createSuper(SearchAsYouTypeAjax);
+
   function SearchAsYouTypeAjax(props) {
     var _this;
 
     _classCallCheck(this, SearchAsYouTypeAjax);
 
-    _this = _possibleConstructorReturn(this, _getPrototypeOf(SearchAsYouTypeAjax).call(this, props));
+    _this = _super.call(this, props);
     _this.state = {
       results: [],
       currentTextValue: props.value || "",
@@ -256,27 +288,41 @@ function (_React$PureComponent) {
           error = _this$state.error;
       var optionsHeader = propOptionsHeader;
 
-      var passProps = _objectSpread({}, leftoverProps, {
+      var passProps = _objectSpread(_objectSpread({}, leftoverProps), {}, {
         keyComplete: keyComplete,
         value: value
       });
 
       if (loading && !error) {
-        optionsHeader = _react["default"].createElement("div", {
+        optionsHeader =
+        /*#__PURE__*/
+        _react["default"].createElement("div", {
           className: "text-center py-3"
-        }, _react["default"].createElement("i", {
+        },
+        /*#__PURE__*/
+        _react["default"].createElement("i", {
           className: "icon icon-spin icon-circle-notch fas"
         }));
       } else {
         if (results.length === 0 && !error) {
           var queryLen = currentTextValue.length;
-          optionsHeader = _react["default"].createElement(_react["default"].Fragment, null, _react["default"].createElement("em", {
+          optionsHeader =
+          /*#__PURE__*/
+          _react["default"].createElement(_react["default"].Fragment, null,
+          /*#__PURE__*/
+          _react["default"].createElement("em", {
             className: "d-block text-center px-4 py-3"
           }, queryLen == 1 ? "Minimum search length is 2 characters" : "No results found"), optionsHeader);
         } else if (error) {
-          optionsHeader = _react["default"].createElement(_react["default"].Fragment, null, _react["default"].createElement("em", {
+          optionsHeader =
+          /*#__PURE__*/
+          _react["default"].createElement(_react["default"].Fragment, null,
+          /*#__PURE__*/
+          _react["default"].createElement("em", {
             className: "d-block text-center px-4 py-3"
-          }, _react["default"].createElement("i", {
+          },
+          /*#__PURE__*/
+          _react["default"].createElement("i", {
             className: "fas icon-warning icon"
           }), " ", error), optionsHeader);
         }
@@ -285,7 +331,9 @@ function (_React$PureComponent) {
       var intKey = parseInt(value); // if in the middle of editing a custom linked object for this field
 
       var hideButton = value && !isNaN(value) && !keyComplete[intKey];
-      return hideButton ? null : _react["default"].createElement(_SearchSelectionMenu.SearchSelectionMenu, _extends({}, passProps, {
+      return hideButton ? null :
+      /*#__PURE__*/
+      _react["default"].createElement(_SearchSelectionMenu.SearchSelectionMenu, _extends({}, passProps, {
         optionsHeader: optionsHeader,
         currentTextValue: currentTextValue
       }, {
@@ -318,14 +366,21 @@ SearchAsYouTypeAjax.defaultProps = {
     var title = result.display_title,
         atID = result["@id"],
         description = result.description;
-    return _react["default"].createElement("div", {
-      "data-tip": description,
-      key: atID
-    }, _react["default"].createElement("h5", {
-      className: "text-300 text-ellipsis-container"
-    }, title), _react["default"].createElement("h6", {
-      className: "text-mono text-400 text-ellipsis-container"
-    }, atID));
+    return (
+      /*#__PURE__*/
+      _react["default"].createElement("div", {
+        "data-tip": description,
+        key: atID
+      },
+      /*#__PURE__*/
+      _react["default"].createElement("h5", {
+        className: "text-300 text-ellipsis-container"
+      }, title),
+      /*#__PURE__*/
+      _react["default"].createElement("h6", {
+        className: "text-mono text-400 text-ellipsis-container"
+      }, atID))
+    );
   },
   "titleRenderFunction": function titleRenderFunction(result) {
     return result.display_title;
@@ -371,24 +426,31 @@ function SubmissionViewSearchAsYouTypeAjax(props) {
       return idToTitleMap[resultAtID] || resultAtID;
     };
   }, [idToTitleMap]);
-  return _react["default"].createElement("div", {
-    className: "d-flex flex-wrap"
-  }, _react["default"].createElement(SearchAsYouTypeAjax, _extends({
-    showTips: true
-  }, {
-    value: value,
-    onChange: onChange,
-    baseHref: baseHref,
-    optionRenderFunction: optionRenderFunction,
-    fieldsToRequest: fieldsToRequest,
-    titleRenderFunction: titleRenderFunction,
-    selectComplete: selectComplete
-  }, props)), _react["default"].createElement(LinkedObj, _extends({
-    key: "linked-item"
-  }, props, {
-    value: value,
-    baseHref: baseHref
-  })));
+  return (
+    /*#__PURE__*/
+    _react["default"].createElement("div", {
+      className: "d-flex flex-wrap"
+    },
+    /*#__PURE__*/
+    _react["default"].createElement(SearchAsYouTypeAjax, _extends({
+      showTips: true
+    }, {
+      value: value,
+      onChange: onChange,
+      baseHref: baseHref,
+      optionRenderFunction: optionRenderFunction,
+      fieldsToRequest: fieldsToRequest,
+      titleRenderFunction: titleRenderFunction,
+      selectComplete: selectComplete
+    }, props)),
+    /*#__PURE__*/
+    _react["default"].createElement(LinkedObj, _extends({
+      key: "linked-item"
+    }, props, {
+      value: value,
+      baseHref: baseHref
+    })))
+  );
 }
 
 function sexToIcon(sex, showTip) {
@@ -396,22 +458,30 @@ function sexToIcon(sex, showTip) {
 
   if (sex && typeof sex === "string") {
     if (sex === "f") {
-      sex = _react["default"].createElement("i", {
+      sex =
+      /*#__PURE__*/
+      _react["default"].createElement("i", {
         className: "icon icon-fw icon-venus fas",
         "data-tip": showTip ? "Sex: Female" : ""
       });
     } else if (sex === "m") {
-      sex = _react["default"].createElement("i", {
+      sex =
+      /*#__PURE__*/
+      _react["default"].createElement("i", {
         className: "icon icon-fw icon-mars fas",
         "data-tip": showTip ? "Sex: Male" : ""
       });
     } else if (sex === "u") {
-      sex = _react["default"].createElement("i", {
+      sex =
+      /*#__PURE__*/
+      _react["default"].createElement("i", {
         className: "icon icon-fw icon-genderless fas",
         "data-tip": showTip ? "Sex: Unknown" : ""
       });
     } else {
-      sex = _react["default"].createElement("i", {
+      sex =
+      /*#__PURE__*/
+      _react["default"].createElement("i", {
         className: "icon icon-fw icon-question fas",
         "data-tip": showTip ? "Sex: N/A" : ""
       });
@@ -437,22 +507,36 @@ var optionCustomizationsByType = {
           age = _result$age === void 0 ? null : _result$age,
           _result$aliases = result.aliases,
           aliases = _result$aliases === void 0 ? [] : _result$aliases;
-      return (// need to better align right col, and adjust relative widths
+      return (
+        /*#__PURE__*/
+        // need to better align right col, and adjust relative widths
         _react["default"].createElement("div", {
           "data-tip": description,
           key: atID,
           className: "d-flex"
-        }, _react["default"].createElement("div", {
+        },
+        /*#__PURE__*/
+        _react["default"].createElement("div", {
           className: "col"
-        }, _react["default"].createElement("h5", {
+        },
+        /*#__PURE__*/
+        _react["default"].createElement("h5", {
           className: "text-300"
-        }, title), _react["default"].createElement("h6", {
+        }, title),
+        /*#__PURE__*/
+        _react["default"].createElement("h6", {
           className: "text-mono text-400"
-        }, aliases)), _react["default"].createElement("div", {
+        }, aliases)),
+        /*#__PURE__*/
+        _react["default"].createElement("div", {
           className: "col"
-        }, _react["default"].createElement("h5", {
+        },
+        /*#__PURE__*/
+        _react["default"].createElement("h5", {
           className: "text-300"
-        }, "Age: ", age || "N/A"), _react["default"].createElement("h6", {
+        }, "Age: ", age || "N/A"),
+        /*#__PURE__*/
+        _react["default"].createElement("h6", {
           className: "text-mono text-400"
         }, " Sex: ", sexToIcon(sex, false), " ")))
       );
@@ -465,14 +549,21 @@ var optionCustomizationsByType = {
           atID = result["@id"],
           description = result.description,
           accession = result.accession;
-      return _react["default"].createElement("div", {
-        "data-tip": description,
-        key: atID
-      }, _react["default"].createElement("h5", {
-        className: "text-300 text-ellipsis-container"
-      }, title), _react["default"].createElement("h6", {
-        className: "text-mono text-400 text-ellipsis-container"
-      }, accession));
+      return (
+        /*#__PURE__*/
+        _react["default"].createElement("div", {
+          "data-tip": description,
+          key: atID
+        },
+        /*#__PURE__*/
+        _react["default"].createElement("h5", {
+          className: "text-300 text-ellipsis-container"
+        }, title),
+        /*#__PURE__*/
+        _react["default"].createElement("h6", {
+          className: "text-mono text-400 text-ellipsis-container"
+        }, accession))
+      );
     },
     "fieldsToRequest": ['accession', 'status', 'date_created']
   },
@@ -485,14 +576,21 @@ var optionCustomizationsByType = {
           role = result.role,
           first_name = result.first_name,
           last_name = result.last_name;
-      return _react["default"].createElement("div", {
-        "data-tip": description,
-        key: atID
-      }, _react["default"].createElement("h5", {
-        className: "text-300 w-100"
-      }, title, " (", first_name, " ", last_name, ")"), _react["default"].createElement("h6", {
-        className: "text-mono text-400"
-      }, email));
+      return (
+        /*#__PURE__*/
+        _react["default"].createElement("div", {
+          "data-tip": description,
+          key: atID
+        },
+        /*#__PURE__*/
+        _react["default"].createElement("h5", {
+          className: "text-300 w-100"
+        }, title, " (", first_name, " ", last_name, ")"),
+        /*#__PURE__*/
+        _react["default"].createElement("h6", {
+          className: "text-mono text-400"
+        }, email))
+      );
     },
     "fieldsToRequest": ['email', 'role', 'first_name', 'last_name', 'submits_for']
   },
@@ -504,14 +602,21 @@ var optionCustomizationsByType = {
           status = result.status,
           date_created = result.date_created,
           submitted_by = result.submitted_by;
-      return _react["default"].createElement("div", {
-        "data-tip": description,
-        key: atID
-      }, _react["default"].createElement("h5", {
-        className: "text-300 text-ellipsis-container"
-      }, title), _react["default"].createElement("h6", {
-        className: "text-mono text-400 text-ellipsis-container"
-      }, atID));
+      return (
+        /*#__PURE__*/
+        _react["default"].createElement("div", {
+          "data-tip": description,
+          key: atID
+        },
+        /*#__PURE__*/
+        _react["default"].createElement("h5", {
+          className: "text-300 text-ellipsis-container"
+        }, title),
+        /*#__PURE__*/
+        _react["default"].createElement("h6", {
+          className: "text-mono text-400 text-ellipsis-container"
+        }, atID))
+      );
     },
     "fieldsToRequest": ['status', 'description', 'date_created', 'submitted_by']
   },
@@ -523,14 +628,21 @@ var optionCustomizationsByType = {
           status = result.status,
           date_created = result.date_created,
           submitted_by = result.submitted_by;
-      return _react["default"].createElement("div", {
-        "data-tip": description,
-        key: atID
-      }, _react["default"].createElement("h5", {
-        className: "text-300 text-ellipsis-container"
-      }, title), _react["default"].createElement("h6", {
-        className: "text-mono text-400 text-ellipsis-container"
-      }, atID));
+      return (
+        /*#__PURE__*/
+        _react["default"].createElement("div", {
+          "data-tip": description,
+          key: atID
+        },
+        /*#__PURE__*/
+        _react["default"].createElement("h5", {
+          className: "text-300 text-ellipsis-container"
+        }, title),
+        /*#__PURE__*/
+        _react["default"].createElement("h6", {
+          className: "text-mono text-400 text-ellipsis-container"
+        }, atID))
+      );
     },
     "fieldsToRequest": ['status', 'description', 'date_created', 'submitted_by']
   },
@@ -540,14 +652,21 @@ var optionCustomizationsByType = {
           atID = result["@id"],
           description = result.description,
           hpo_id = result.hpo_id;
-      return _react["default"].createElement("div", {
-        "data-tip": description,
-        key: atID
-      }, _react["default"].createElement("h5", {
-        className: "text-300 text-ellipsis-container"
-      }, title), _react["default"].createElement("h6", {
-        className: "text-mono text-400"
-      }, hpo_id));
+      return (
+        /*#__PURE__*/
+        _react["default"].createElement("div", {
+          "data-tip": description,
+          key: atID
+        },
+        /*#__PURE__*/
+        _react["default"].createElement("h5", {
+          className: "text-300 text-ellipsis-container"
+        }, title),
+        /*#__PURE__*/
+        _react["default"].createElement("h6", {
+          className: "text-mono text-400"
+        }, hpo_id))
+      );
     },
     "fieldsToRequest": ["hpo_id"]
   }
@@ -560,6 +679,8 @@ var LinkedObj =
 /*#__PURE__*/
 function (_React$PureComponent2) {
   _inherits(LinkedObj, _React$PureComponent2);
+
+  var _super2 = _createSuper(LinkedObj);
 
   _createClass(LinkedObj, null, [{
     key: "isInSelectionField",
@@ -595,7 +716,7 @@ function (_React$PureComponent2) {
 
     _classCallCheck(this, LinkedObj);
 
-    _this3 = _possibleConstructorReturn(this, _getPrototypeOf(LinkedObj).call(this, props));
+    _this3 = _super2.call(this, props);
     _this3.setSubmissionStateToLinkedToItem = _this3.setSubmissionStateToLinkedToItem.bind(_assertThisInitialized(_this3));
     _this3.handleStartSelectItem = _this3.handleStartSelectItem.bind(_assertThisInitialized(_this3));
     _this3.handleFinishSelectItem = _this3.handleFinishSelectItem.bind(_assertThisInitialized(_this3));
@@ -745,11 +866,25 @@ function (_React$PureComponent2) {
       var itemType = schema && schema.linkTo;
       var prettyTitle = schema && (schema.parentSchema && schema.parentSchema.title || schema.title);
 
-      var message = _react["default"].createElement("div", null, !isMultiSelect ? _react["default"].createElement("p", {
+      var message =
+      /*#__PURE__*/
+      _react["default"].createElement("div", null, !isMultiSelect ?
+      /*#__PURE__*/
+      _react["default"].createElement("p", {
         className: "mb-0"
-      }, "Please either select an Item below and click ", _react["default"].createElement("em", null, "Apply"), " or ", _react["default"].createElement("em", null, "drag and drop"), " an Item (row) from this window into the submissions window.") : _react["default"].createElement("p", {
+      }, "Please either select an Item below and click ",
+      /*#__PURE__*/
+      _react["default"].createElement("em", null, "Apply"), " or ",
+      /*#__PURE__*/
+      _react["default"].createElement("em", null, "drag and drop"), " an Item (row) from this window into the submissions window.") :
+      /*#__PURE__*/
+      _react["default"].createElement("p", {
         className: "mb-0"
-      }, "Please select the Item(s) you would like and then press ", _react["default"].createElement("em", null, "Apply"), " below."), _react["default"].createElement("p", {
+      }, "Please select the Item(s) you would like and then press ",
+      /*#__PURE__*/
+      _react["default"].createElement("em", null, "Apply"), " below."),
+      /*#__PURE__*/
+      _react["default"].createElement("p", {
         className: "mb-0"
       }, "You may use facets on the left-hand side to narrow down results."));
 
@@ -781,37 +916,51 @@ function (_React$PureComponent2) {
         }
       }
 
-      return _react["default"].createElement(_LinkToSelector.LinkToSelector, _extends({
-        isSelecting: true,
-        onSelect: this.handleFinishSelectItem,
-        onCloseChildWindow: selectCancel,
-        childWindowAlert: this.childWindowAlert
-      }, {
-        value: value,
-        dropMessage: "Drop " + (itemType || "Item") + " for field '" + (prettyTitle || nestedField) + "'",
-        searchURL: searchURL
-      }));
+      return (
+        /*#__PURE__*/
+        _react["default"].createElement(_LinkToSelector.LinkToSelector, _extends({
+          isSelecting: true,
+          onSelect: this.handleFinishSelectItem,
+          onCloseChildWindow: selectCancel,
+          childWindowAlert: this.childWindowAlert
+        }, {
+          value: value,
+          dropMessage: "Drop " + (itemType || "Item") + " for field '" + (prettyTitle || nestedField) + "'",
+          searchURL: searchURL
+        }))
+      );
     }
   }, {
     key: "renderButtons",
     value: function renderButtons() {
-      return _react["default"].createElement("div", {
-        className: "linked-object-buttons-container"
-      }, _react["default"].createElement("button", {
-        type: "button",
-        className: "btn btn-outline-secondary adv-search",
-        "data-tip": "Advanced Search",
-        onClick: this.handleStartSelectItem
-      }, _react["default"].createElement("i", {
-        className: "icon icon-fw icon-search fas"
-      })), _react["default"].createElement("button", {
-        type: "button",
-        className: "btn btn-outline-secondary create-new-obj",
-        "data-tip": "Create New",
-        onClick: this.handleCreateNewItemClick
-      }, _react["default"].createElement("i", {
-        className: "icon icon-fw icon-file-medical fas"
-      })));
+      return (
+        /*#__PURE__*/
+        _react["default"].createElement("div", {
+          className: "linked-object-buttons-container"
+        },
+        /*#__PURE__*/
+        _react["default"].createElement("button", {
+          type: "button",
+          className: "btn btn-outline-secondary adv-search",
+          "data-tip": "Advanced Search",
+          onClick: this.handleStartSelectItem
+        },
+        /*#__PURE__*/
+        _react["default"].createElement("i", {
+          className: "icon icon-fw icon-search fas"
+        })),
+        /*#__PURE__*/
+        _react["default"].createElement("button", {
+          type: "button",
+          className: "btn btn-outline-secondary create-new-obj",
+          "data-tip": "Create New",
+          onClick: this.handleCreateNewItemClick
+        },
+        /*#__PURE__*/
+        _react["default"].createElement("i", {
+          className: "icon icon-fw icon-file-medical fas"
+        })))
+      );
     }
   }, {
     key: "render",
@@ -833,7 +982,13 @@ function (_React$PureComponent2) {
 
 
       if (value) {
-        var thisDisplay = keyDisplay[value] ? _react["default"].createElement(_react["default"].Fragment, null, keyDisplay[value], _react["default"].createElement("code", null, value)) : _react["default"].createElement("code", null, value);
+        var thisDisplay = keyDisplay[value] ?
+        /*#__PURE__*/
+        _react["default"].createElement(_react["default"].Fragment, null, keyDisplay[value],
+        /*#__PURE__*/
+        _react["default"].createElement("code", null, value)) :
+        /*#__PURE__*/
+        _react["default"].createElement("code", null, value);
 
         if (isNaN(value)) {
           return this.renderButtons();
@@ -844,23 +999,37 @@ function (_React$PureComponent2) {
           // string once the obj is successfully submitted
 
           if (keyComplete[intKey]) {
-            return _react["default"].createElement("div", null, _react["default"].createElement("a", {
-              href: keyComplete[intKey],
-              target: "_blank",
-              rel: "noopener noreferrer"
-            }, thisDisplay), _react["default"].createElement("i", {
-              className: "icon icon-fw icon-external-link-alt ml-05 fas"
-            }));
+            return (
+              /*#__PURE__*/
+              _react["default"].createElement("div", null,
+              /*#__PURE__*/
+              _react["default"].createElement("a", {
+                href: keyComplete[intKey],
+                target: "_blank",
+                rel: "noopener noreferrer"
+              }, thisDisplay),
+              /*#__PURE__*/
+              _react["default"].createElement("i", {
+                className: "icon icon-fw icon-external-link-alt ml-05 fas"
+              }))
+            );
           } else {
-            return _react["default"].createElement("div", {
-              className: "incomplete-linked-object-display-container text-ellipsis-container"
-            }, _react["default"].createElement("i", {
-              className: "icon icon-fw icon-edit far"
-            }), "\xA0\xA0", _react["default"].createElement("a", {
-              href: "#",
-              onClick: this.setSubmissionStateToLinkedToItem,
-              "data-tip": "Continue editing/submitting"
-            }, thisDisplay), "\xA0");
+            return (
+              /*#__PURE__*/
+              _react["default"].createElement("div", {
+                className: "incomplete-linked-object-display-container text-ellipsis-container"
+              },
+              /*#__PURE__*/
+              _react["default"].createElement("i", {
+                className: "icon icon-fw icon-edit far"
+              }), "\xA0\xA0",
+              /*#__PURE__*/
+              _react["default"].createElement("a", {
+                href: "#",
+                onClick: this.setSubmissionStateToLinkedToItem,
+                "data-tip": "Continue editing/submitting"
+              }, thisDisplay), "\xA0")
+            );
           }
         }
       } else {
@@ -892,23 +1061,34 @@ var SquareButton = _react["default"].memo(function (props) {
     btnCls += " btn-" + bsStyle;
   }
 
-  return _react["default"].createElement("div", {
-    className: "remove-button-column" + (!show ? ' hidden' : ''),
-    style: style
-  }, _react["default"].createElement(_Fade.Fade, {
-    "in": show
-  }, _react["default"].createElement("div", {
-    className: outerCls
-  }, _react["default"].createElement("button", {
-    type: "button",
-    disabled: disabled || !show,
-    onClick: onClick,
-    "data-tip": tip,
-    tabIndex: 2,
-    className: btnCls
-  }, _react["default"].createElement("i", {
-    className: "icon icon-fw icon-" + icon
-  })))));
+  return (
+    /*#__PURE__*/
+    _react["default"].createElement("div", {
+      className: "remove-button-column" + (!show ? ' hidden' : ''),
+      style: style
+    },
+    /*#__PURE__*/
+    _react["default"].createElement(_Fade.Fade, {
+      "in": show
+    },
+    /*#__PURE__*/
+    _react["default"].createElement("div", {
+      className: outerCls
+    },
+    /*#__PURE__*/
+    _react["default"].createElement("button", {
+      type: "button",
+      disabled: disabled || !show,
+      onClick: onClick,
+      "data-tip": tip,
+      tabIndex: 2,
+      className: btnCls
+    },
+    /*#__PURE__*/
+    _react["default"].createElement("i", {
+      className: "icon icon-fw icon-" + icon
+    })))))
+  );
 });
 
 exports.SquareButton = SquareButton;

--- a/es/components/forms/components/SearchAsYouTypeAjax.js
+++ b/es/components/forms/components/SearchAsYouTypeAjax.js
@@ -386,6 +386,7 @@ function SubmissionViewSearchAsYouTypeAjax(props) {
   }, props)), _react["default"].createElement(LinkedObj, _extends({
     key: "linked-item"
   }, props, {
+    value: value,
     baseHref: baseHref
   })));
 }
@@ -767,7 +768,8 @@ function (_React$PureComponent2) {
           currType = _this$props9.currType,
           nestedField = _this$props9.nestedField,
           isMultiSelect = _this$props9.isMultiSelect,
-          baseHref = _this$props9.baseHref;
+          baseHref = _this$props9.baseHref,
+          value = _this$props9.value;
       var itemType = schema.linkTo;
       var prettyTitle = schema && (schema.parentSchema && schema.parentSchema.title || schema.title);
       var searchURL = baseHref + "&currentAction=" + (isMultiSelect ? 'multiselect' : 'selection') + '&type=' + itemType; // check if we have any schema flags that will affect the searchUrl
@@ -779,14 +781,16 @@ function (_React$PureComponent2) {
         }
       }
 
-      return _react["default"].createElement(_LinkToSelector.LinkToSelector, {
+      return _react["default"].createElement(_LinkToSelector.LinkToSelector, _extends({
         isSelecting: true,
         onSelect: this.handleFinishSelectItem,
         onCloseChildWindow: selectCancel,
-        childWindowAlert: this.childWindowAlert,
+        childWindowAlert: this.childWindowAlert
+      }, {
+        value: value,
         dropMessage: "Drop " + (itemType || "Item") + " for field '" + (prettyTitle || nestedField) + "'",
         searchURL: searchURL
-      });
+      }));
     }
   }, {
     key: "renderButtons",

--- a/es/components/forms/components/submission-fields.js
+++ b/es/components/forms/components/submission-fields.js
@@ -48,6 +48,12 @@ function _extends() { _extends = Object.assign || function (target) { for (var i
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function (o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
 function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
@@ -55,42 +61,6 @@ function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _d
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
 
 function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function (o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
-
-function _createSuper(Derived) {
-  function isNativeReflectConstruct() {
-    if (typeof Reflect === "undefined" || !Reflect.construct) return false;
-    if (Reflect.construct.sham) return false;
-    if (typeof Proxy === "function") return true;
-
-    try {
-      Date.prototype.toString.call(Reflect.construct(Date, [], function () {}));
-      return true;
-    } catch (e) {
-      return false;
-    }
-  }
-
-  return function () {
-    var Super = _getPrototypeOf(Derived),
-        result;
-
-    if (isNativeReflectConstruct()) {
-      var NewTarget = _getPrototypeOf(this).constructor;
-
-      result = Reflect.construct(Super, arguments, NewTarget);
-    } else {
-      result = Super.apply(this, arguments);
-    }
-
-    return _possibleConstructorReturn(this, result);
-  };
-}
-
-function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
-
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
-
-function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function (o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
 /**
  * Individual component for each type of field. Contains the appropriate input
@@ -104,8 +74,6 @@ var BuildField =
 /*#__PURE__*/
 function (_React$PureComponent) {
   _inherits(BuildField, _React$PureComponent);
-
-  var _super = _createSuper(BuildField);
 
   _createClass(BuildField, null, [{
     key: "fieldTypeFromFieldSchema",
@@ -158,7 +126,7 @@ function (_React$PureComponent) {
 
     _classCallCheck(this, BuildField);
 
-    _this = _super.call(this, props);
+    _this = _possibleConstructorReturn(this, _getPrototypeOf(BuildField).call(this, props));
 
     _underscore["default"].bindAll(_assertThisInitialized(_this), 'displayField', 'handleDropdownButtonToggle', 'handleAliasChange', 'handleEnumChange', 'buildSuggestedEnumEntry', 'submitSuggestedEnumVal', 'handleChange', 'handleAliasChange', 'deleteField', 'pushArrayValue', 'commonRowProps', 'labelTypeDescriptor', 'wrapWithLabel', 'wrapWithNoLabel');
 
@@ -225,15 +193,12 @@ function (_React$PureComponent) {
         var filetype = currContext && currContext.options && currContext.options.filetype;
 
         if (filetype === 'md' || filetype === 'html') {
-          return (
-            /*#__PURE__*/
-            _react["default"].createElement(PreviewField, _extends({}, this.props, {
-              filetype: filetype,
-              fieldType: fieldType
-            }, {
-              onChange: this.handleChange
-            }))
-          );
+          return _react["default"].createElement(PreviewField, _extends({}, this.props, {
+            filetype: filetype,
+            fieldType: fieldType
+          }, {
+            onChange: this.handleChange
+          }));
         }
       } // Common field types
 
@@ -241,191 +206,131 @@ function (_React$PureComponent) {
       switch (fieldType) {
         case 'text':
           if (field === 'aliases') {
-            return (
-              /*#__PURE__*/
-              _react["default"].createElement("div", {
-                className: "input-wrapper"
-              },
-              /*#__PURE__*/
-              _react["default"].createElement(AliasInputField, _extends({}, inputProps, {
-                onAliasChange: this.handleAliasChange,
-                currentSubmittingUser: currentSubmittingUser
-              })))
-            );
+            return _react["default"].createElement("div", {
+              className: "input-wrapper"
+            }, _react["default"].createElement(AliasInputField, _extends({}, inputProps, {
+              onAliasChange: this.handleAliasChange,
+              currentSubmittingUser: currentSubmittingUser
+            })));
           }
 
-          return (
-            /*#__PURE__*/
-            _react["default"].createElement("input", _extends({}, inputProps, {
-              type: "text",
-              className: "form-control",
-              inputMode: "latin"
-            }))
-          );
+          return _react["default"].createElement("input", _extends({}, inputProps, {
+            type: "text",
+            className: "form-control",
+            inputMode: "latin"
+          }));
 
         case 'textarea':
-          return (
-            /*#__PURE__*/
-            _react["default"].createElement("textarea", _extends({}, inputProps, {
-              type: "text",
-              inputMode: "latin",
-              rows: 4,
-              className: "form-control mb-08 mt-08"
-            }))
-          );
+          return _react["default"].createElement("textarea", _extends({}, inputProps, {
+            type: "text",
+            inputMode: "latin",
+            rows: 4,
+            className: "form-control mb-08 mt-08"
+          }));
 
         case 'html':
         case 'code':
-          return (
-            /*#__PURE__*/
-            _react["default"].createElement("textarea", _extends({}, inputProps, {
-              type: "text",
-              inputMode: "latin",
-              rows: 8,
-              wrap: "off",
-              className: "form-control text-small mb-08 mt-08",
-              style: {
-                'fontFamily': "Source Code Pro, monospace",
-                'fontSize': 'small'
-              }
-            }))
-          );
+          return _react["default"].createElement("textarea", _extends({}, inputProps, {
+            type: "text",
+            inputMode: "latin",
+            rows: 8,
+            wrap: "off",
+            className: "form-control text-small mb-08 mt-08",
+            style: {
+              'fontFamily': "Source Code Pro, monospace",
+              'fontSize': 'small'
+            }
+          }));
 
         case 'integer':
-          return (
-            /*#__PURE__*/
-            _react["default"].createElement(_reactBootstrap.FormControl, _extends({
-              type: "number"
-            }, inputProps, {
-              step: 1
-            }))
-          );
+          return _react["default"].createElement(_reactBootstrap.FormControl, _extends({
+            type: "number"
+          }, inputProps, {
+            step: 1
+          }));
 
         case 'number':
-          return (
-            /*#__PURE__*/
-            _react["default"].createElement(_reactBootstrap.FormControl, _extends({
-              type: "number"
-            }, inputProps))
-          );
+          return _react["default"].createElement(_reactBootstrap.FormControl, _extends({
+            type: "number"
+          }, inputProps));
 
         case 'boolean':
-          return (
-            /*#__PURE__*/
-            _react["default"].createElement(_Checkbox.Checkbox, _extends({}, _underscore["default"].omit(inputProps, 'value', 'placeholder'), {
-              checked: !!value
-            }),
-            /*#__PURE__*/
-            _react["default"].createElement("span", {
-              style: {
-                'verticalAlign': 'middle',
-                'textTransform': 'capitalize'
-              }
-            }, typeof value === 'boolean' ? value + '' : null))
-          );
+          return _react["default"].createElement(_Checkbox.Checkbox, _extends({}, _underscore["default"].omit(inputProps, 'value', 'placeholder'), {
+            checked: !!value
+          }), _react["default"].createElement("span", {
+            style: {
+              'verticalAlign': 'middle',
+              'textTransform': 'capitalize'
+            }
+          }, typeof value === 'boolean' ? value + '' : null));
 
         case 'enum':
-          return (
-            /*#__PURE__*/
-            _react["default"].createElement("span", {
-              className: "input-wrapper"
-            },
-            /*#__PURE__*/
-            _react["default"].createElement(_SearchAsYouTypeLocal.SearchAsYouTypeLocal, {
-              searchList: enumValues,
-              value: value,
-              allowCustomValue: false,
-              filterMethod: "includes",
-              onChange: this.handleEnumChange,
-              maxResults: 3
-            }))
-          );
+          return _react["default"].createElement("span", {
+            className: "input-wrapper"
+          }, _react["default"].createElement(_SearchAsYouTypeLocal.SearchAsYouTypeLocal, {
+            searchList: enumValues,
+            value: value,
+            allowCustomValue: false,
+            filterMethod: "includes",
+            onChange: this.handleEnumChange,
+            maxResults: 3
+          }));
 
         case 'suggested_enum':
-          return (
-            /*#__PURE__*/
-            _react["default"].createElement("span", {
-              className: "input-wrapper"
-            },
-            /*#__PURE__*/
-            _react["default"].createElement(_SearchAsYouTypeLocal.SearchAsYouTypeLocal, {
-              searchList: enumValues,
-              value: value,
-              allowCustomValue: true,
-              filterMethod: "includes",
-              onChange: this.handleEnumChange,
-              maxResults: 3
-            }))
-          );
+          return _react["default"].createElement("span", {
+            className: "input-wrapper"
+          }, _react["default"].createElement(_SearchAsYouTypeLocal.SearchAsYouTypeLocal, {
+            searchList: enumValues,
+            value: value,
+            allowCustomValue: true,
+            filterMethod: "includes",
+            onChange: this.handleEnumChange,
+            maxResults: 3
+          }));
 
         case 'linked object':
-          return (
-            /*#__PURE__*/
-            _react["default"].createElement("div", {
-              className: "input-wrapper"
-            },
-            /*#__PURE__*/
-            _react["default"].createElement(_SearchAsYouTypeAjax.SubmissionViewSearchAsYouTypeAjax, _extends({
-              value: value,
-              allowCustomValue: false
-            }, this.props, {
-              idToTitleMap: keyDisplay
-            })))
-          );
+          return _react["default"].createElement("div", {
+            className: "input-wrapper"
+          }, _react["default"].createElement(_SearchAsYouTypeAjax.SubmissionViewSearchAsYouTypeAjax, _extends({
+            value: value,
+            allowCustomValue: false
+          }, this.props, {
+            idToTitleMap: keyDisplay
+          })));
 
         case 'array':
-          return (
-            /*#__PURE__*/
-            _react["default"].createElement(ArrayField, _extends({}, this.props, {
-              pushArrayValue: this.pushArrayValue,
-              value: value || null,
-              roundTwo: roundTwo
-            }))
-          );
+          return _react["default"].createElement(ArrayField, _extends({}, this.props, {
+            pushArrayValue: this.pushArrayValue,
+            value: value || null,
+            roundTwo: roundTwo
+          }));
 
         case 'object':
-          return (
-            /*#__PURE__*/
-            _react["default"].createElement(ObjectField, this.props)
-          );
+          return _react["default"].createElement(ObjectField, this.props);
 
         case 'attachment':
-          return (
-            /*#__PURE__*/
-            _react["default"].createElement("div", {
-              style: {
-                'display': 'inline'
-              }
-            },
-            /*#__PURE__*/
-            _react["default"].createElement(AttachmentInput, this.props))
-          );
+          return _react["default"].createElement("div", {
+            style: {
+              'display': 'inline'
+            }
+          }, _react["default"].createElement(AttachmentInput, this.props));
 
         case 'file upload':
-          return (
-            /*#__PURE__*/
-            _react["default"].createElement(S3FileInput, this.props)
-          );
+          return _react["default"].createElement(S3FileInput, this.props);
       } // Fallback
 
 
-      return (
-        /*#__PURE__*/
-        _react["default"].createElement("div", null, "No field for this case yet.")
-      );
+      return _react["default"].createElement("div", null, "No field for this case yet.");
     }
   }, {
     key: "buildSuggestedEnumEntry",
     value: function buildSuggestedEnumEntry(val) {
-      return (
-        /*#__PURE__*/
-        _react["default"].createElement(_reactBootstrap.DropdownItem, {
-          key: val,
-          title: val || '',
-          eventKey: val,
-          onSelect: this.submitSuggestedEnumVal
-        }, val || '')
-      );
+      return _react["default"].createElement(_reactBootstrap.DropdownItem, {
+        key: val,
+        title: val || '',
+        eventKey: val,
+        onSelect: this.submitSuggestedEnumVal
+      }, val || '');
     }
   }, {
     key: "submitSuggestedEnumVal",
@@ -602,18 +507,13 @@ function (_React$PureComponent) {
     key: "labelTypeDescriptor",
     value: function labelTypeDescriptor() {
       var required = this.props.required;
-      return (
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: "field-descriptor"
-        }, required ?
-        /*#__PURE__*/
-        _react["default"].createElement("span", {
-          style: {
-            'color': '#a94442'
-          }
-        }, " Required") : null)
-      );
+      return _react["default"].createElement("div", {
+        className: "field-descriptor"
+      }, required ? _react["default"].createElement("span", {
+        style: {
+          'color': '#a94442'
+        }
+      }, " Required") : null);
     }
     /** @ignore */
 
@@ -625,49 +525,29 @@ function (_React$PureComponent) {
           title = _this$props9.title,
           fieldType = _this$props9.fieldType,
           schema = _this$props9.schema;
-      return (
-        /*#__PURE__*/
-        _react["default"].createElement("div", this.commonRowProps(),
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: "row"
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: "col-12 col-md-4"
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("h5", {
-          className: "submission-field-title text-ellipsis-container"
-        }, this.labelTypeDescriptor(), fieldTip ?
-        /*#__PURE__*/
-        _react["default"].createElement(InfoIcon, {
-          className: "mr-07",
-          title: title,
-          fieldType: fieldType,
-          schema: schema
-        }, fieldTip) : null,
-        /*#__PURE__*/
-        _react["default"].createElement("span", null, title))),
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: "col-12 col-md-8"
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: "row field-container"
-        }, Array.prototype.slice.call(arguments)))))
-      );
+      return _react["default"].createElement("div", this.commonRowProps(), _react["default"].createElement("div", {
+        className: "row"
+      }, _react["default"].createElement("div", {
+        className: "col-12 col-md-4"
+      }, _react["default"].createElement("h5", {
+        className: "submission-field-title text-ellipsis-container"
+      }, this.labelTypeDescriptor(), fieldTip ? _react["default"].createElement(InfoIcon, {
+        className: "mr-07",
+        title: title,
+        fieldType: fieldType,
+        schema: schema
+      }, fieldTip) : null, _react["default"].createElement("span", null, title))), _react["default"].createElement("div", {
+        className: "col-12 col-md-8"
+      }, _react["default"].createElement("div", {
+        className: "row field-container"
+      }, Array.prototype.slice.call(arguments)))));
     }
     /** @ignore */
 
   }, {
     key: "wrapWithNoLabel",
     value: function wrapWithNoLabel() {
-      return (
-        /*#__PURE__*/
-        _react["default"].createElement("div", this.commonRowProps(), Array.prototype.slice.call(arguments))
-      );
+      return _react["default"].createElement("div", this.commonRowProps(), Array.prototype.slice.call(arguments));
     }
     /**
      * Renders out input for this field. Performs this recursively (through adding own component down in render tree)
@@ -741,15 +621,9 @@ function (_React$PureComponent) {
         extClass += ' in-selection-field';
       }
 
-      return wrapFunc(
-      /*#__PURE__*/
-      _react["default"].createElement(_react["default"].Fragment, null,
-      /*#__PURE__*/
-      _react["default"].createElement("div", {
+      return wrapFunc(_react["default"].createElement(_react["default"].Fragment, null, _react["default"].createElement("div", {
         className: 'field-column col' + extClass
-      }, fieldToDisplay), fieldType === 'array' || fieldType === 'file upload' ? null :
-      /*#__PURE__*/
-      _react["default"].createElement(_SearchAsYouTypeAjax.SquareButton, {
+      }, fieldToDisplay), fieldType === 'array' || fieldType === 'file upload' ? null : _react["default"].createElement(_SearchAsYouTypeAjax.SquareButton, {
         show: showDelete,
         disabled: disableDelete,
         tip: isArray ? 'Remove Item' : 'Clear Value',
@@ -770,45 +644,32 @@ var PreviewField = _react["default"].memo(function (props) {
       field = props.field,
       onChange = props.onChange;
 
-  var preview = value &&
-  /*#__PURE__*/
-  _react["default"].createElement(_react["default"].Fragment, null,
-  /*#__PURE__*/
-  _react["default"].createElement("h6", {
+  var preview = value && _react["default"].createElement(_react["default"].Fragment, null, _react["default"].createElement("h6", {
     className: "mt-1 text-600"
-  }, "Preview:"),
-  /*#__PURE__*/
-  _react["default"].createElement("hr", {
+  }, "Preview:"), _react["default"].createElement("hr", {
     className: "mb-1 mt-05"
-  }),
-  /*#__PURE__*/
-  _react["default"].createElement(_BasicStaticSectionBody.BasicStaticSectionBody, {
+  }), _react["default"].createElement(_BasicStaticSectionBody.BasicStaticSectionBody, {
     content: value || '',
     filetype: filetype
   }));
 
-  return (
-    /*#__PURE__*/
-    _react["default"].createElement("div", {
-      className: "preview-field-container mt-08 mb-08"
-    },
-    /*#__PURE__*/
-    _react["default"].createElement(_reactBootstrap.FormControl, {
-      onChange: onChange,
-      id: "field_for_" + field,
-      name: field,
-      value: value,
-      type: "text",
-      inputMode: "latin",
-      as: "textarea",
-      rows: 8,
-      wrap: "off",
-      style: {
-        'fontFamily': "Source Code Pro, monospace",
-        'fontSize': 'small'
-      }
-    }), preview)
-  );
+  return _react["default"].createElement("div", {
+    className: "preview-field-container mt-08 mb-08"
+  }, _react["default"].createElement(_reactBootstrap.FormControl, {
+    onChange: onChange,
+    id: "field_for_" + field,
+    name: field,
+    value: value,
+    type: "text",
+    inputMode: "latin",
+    as: "textarea",
+    rows: 8,
+    wrap: "off",
+    style: {
+      'fontFamily': "Source Code Pro, monospace",
+      'fontSize': 'small'
+    }
+  }), preview);
 });
 /**
  * Display fields that are arrays. To do this, make a BuildField for each
@@ -821,8 +682,6 @@ var ArrayField =
 /*#__PURE__*/
 function (_React$Component) {
   _inherits(ArrayField, _React$Component);
-
-  var _super2 = _createSuper(ArrayField);
 
   _createClass(ArrayField, null, [{
     key: "typeOfItems",
@@ -867,7 +726,7 @@ function (_React$Component) {
 
     _classCallCheck(this, ArrayField);
 
-    _this2 = _super2.call(this, props);
+    _this2 = _possibleConstructorReturn(this, _getPrototypeOf(ArrayField).call(this, props));
 
     _underscore["default"].bindAll(_assertThisInitialized(_this2), 'initiateArrayField', 'generateAddButton');
 
@@ -949,31 +808,26 @@ function (_React$Component) {
         'parentSchema': schema
       });
 
-      return (
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          key: arrayIdx,
-          className: "array-field-container " + (arrayIdx % 2 === 0 ? 'even' : 'odd'),
-          "data-field-type": fieldType
-        },
-        /*#__PURE__*/
-        _react["default"].createElement(BuildField, _extends({
-          value: inArrValue || null,
-          fieldTip: fieldTip,
-          fieldType: fieldType,
-          title: title,
-          enumValues: enumValues
-        }, _underscore["default"].pick(this.props, 'field', 'modifyNewContext', 'linkType', 'selectObj', 'selectComplete', 'selectCancel', 'nestedField', 'keyDisplay', 'keyComplete', 'setSubmissionState', 'fieldBeingSelected', 'fieldBeingSelectedArrayIdx', 'updateUpload', 'upload', 'uploadStatus', 'md5Progress', 'currentSubmittingUser', 'roundTwo', 'currType'), {
-          isArray: true,
-          isLastItemInArray: allItems.length - 1 === index,
-          arrayIdx: arrayIdxList,
-          schema: childFieldSchema,
-          disabled: false,
-          required: false,
-          key: arrayIdx,
-          isMultiSelect: true
-        })))
-      );
+      return _react["default"].createElement("div", {
+        key: arrayIdx,
+        className: "array-field-container " + (arrayIdx % 2 === 0 ? 'even' : 'odd'),
+        "data-field-type": fieldType
+      }, _react["default"].createElement(BuildField, _extends({
+        value: inArrValue || null,
+        fieldTip: fieldTip,
+        fieldType: fieldType,
+        title: title,
+        enumValues: enumValues
+      }, _underscore["default"].pick(this.props, 'field', 'modifyNewContext', 'linkType', 'selectObj', 'selectComplete', 'selectCancel', 'nestedField', 'keyDisplay', 'keyComplete', 'setSubmissionState', 'fieldBeingSelected', 'fieldBeingSelectedArrayIdx', 'updateUpload', 'upload', 'uploadStatus', 'md5Progress', 'currentSubmittingUser', 'roundTwo', 'currType'), {
+        isArray: true,
+        isLastItemInArray: allItems.length - 1 === index,
+        arrayIdx: arrayIdxList,
+        schema: childFieldSchema,
+        disabled: false,
+        required: false,
+        key: arrayIdx,
+        isMultiSelect: true
+      })));
     }
   }, {
     key: "generateAddButton",
@@ -982,22 +836,15 @@ function (_React$Component) {
           _this$props14$value = _this$props14.value,
           values = _this$props14$value === void 0 ? [] : _this$props14$value,
           pushArrayValue = _this$props14.pushArrayValue;
-      return (
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: "add-array-item-button-container"
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("button", {
-          type: "button",
-          className: "btn btn-outline-dark btn-" + (values.length > 0 ? "sm" : "md"),
-          onClick: pushArrayValue
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("i", {
-          className: "icon icon-fw fas icon-plus"
-        }), " Add"))
-      );
+      return _react["default"].createElement("div", {
+        className: "add-array-item-button-container"
+      }, _react["default"].createElement("button", {
+        type: "button",
+        className: "btn btn-outline-dark btn-" + (values.length > 0 ? "sm" : "md"),
+        onClick: pushArrayValue
+      }, _react["default"].createElement("i", {
+        className: "icon icon-fw fas icon-plus"
+      }), " Add"));
     }
   }, {
     key: "render",
@@ -1013,12 +860,9 @@ function (_React$Component) {
       });
 
       var showAddButton = !isValueNull(values[valuesToRender.length - 1]);
-      return (
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: "list-of-array-items"
-        }, valuesToRender.map(this.initiateArrayField), showAddButton ? this.generateAddButton() : null)
-      );
+      return _react["default"].createElement("div", {
+        className: "list-of-array-items"
+      }, valuesToRender.map(this.initiateArrayField), showAddButton ? this.generateAddButton() : null);
     }
   }]);
 
@@ -1035,9 +879,9 @@ var ObjectField =
 function (_React$PureComponent2) {
   _inherits(ObjectField, _React$PureComponent2);
 
-  var _super3 = _createSuper(ObjectField);
-
   function ObjectField() {
+    var _getPrototypeOf2;
+
     var _this3;
 
     _classCallCheck(this, ObjectField);
@@ -1046,7 +890,7 @@ function (_React$PureComponent2) {
       args[_key] = arguments[_key];
     }
 
-    _this3 = _super3.call.apply(_super3, [this].concat(args));
+    _this3 = _possibleConstructorReturn(this, (_getPrototypeOf2 = _getPrototypeOf(ObjectField)).call.apply(_getPrototypeOf2, [this].concat(args)));
 
     _defineProperty(_assertThisInitialized(_this3), "includeField", function (schema, field) {
       if (!schema) return null;
@@ -1152,32 +996,26 @@ function (_React$PureComponent2) {
         // happens correctly
 
 
-        return (
-          /*#__PURE__*/
-          _react["default"].createElement(BuildField, _extends({}, passProps, {
-            field: field,
-            fieldType: fieldType,
-            fieldTip: fieldTip,
-            enumValues: enumValues,
-            nestedField: propNestedField + '.' + field,
-            title: title
-          }, {
-            value: fieldValue,
-            key: field,
-            schema: fieldSchema,
-            disabled: false,
-            required: false,
-            isArray: false,
-            isMultiSelect: isMultiSelect || false
-          }))
-        );
+        return _react["default"].createElement(BuildField, _extends({}, passProps, {
+          field: field,
+          fieldType: fieldType,
+          fieldTip: fieldTip,
+          enumValues: enumValues,
+          nestedField: propNestedField + '.' + field,
+          title: title
+        }, {
+          value: fieldValue,
+          key: field,
+          schema: fieldSchema,
+          disabled: false,
+          required: false,
+          isArray: false,
+          isMultiSelect: isMultiSelect || false
+        }));
       });
-      return (
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: "object-field-container"
-        }, builtFields)
-      );
+      return _react["default"].createElement("div", {
+        className: "object-field-container"
+      }, builtFields);
     }
   }]);
 
@@ -1195,14 +1033,12 @@ var AttachmentInput =
 function (_React$Component2) {
   _inherits(AttachmentInput, _React$Component2);
 
-  var _super4 = _createSuper(AttachmentInput);
-
   function AttachmentInput(props) {
     var _this5;
 
     _classCallCheck(this, AttachmentInput);
 
-    _this5 = _super4.call(this, props);
+    _this5 = _possibleConstructorReturn(this, _getPrototypeOf(AttachmentInput).call(this, props));
     _this5.handleChange = _this5.handleChange.bind(_assertThisInitialized(_this5));
     return _this5;
   }
@@ -1270,38 +1106,29 @@ function (_React$Component2) {
       }
 
       // Is type=submit below correct?
-      return (
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          style: {
-            'display': 'inherit'
-          }
+      return _react["default"].createElement("div", {
+        style: {
+          'display': 'inherit'
+        }
+      }, _react["default"].createElement("input", {
+        id: "field_for_" + field,
+        type: "file",
+        onChange: this.handleChange,
+        style: {
+          'display': 'none'
         },
-        /*#__PURE__*/
-        _react["default"].createElement("input", {
-          id: "field_for_" + field,
-          type: "file",
-          onChange: this.handleChange,
-          style: {
-            'display': 'none'
-          },
-          accept: this.acceptedTypes()
-        }),
-        /*#__PURE__*/
-        _react["default"].createElement("button", {
-          type: "submit",
-          className: "btn btn-outline-dark"
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("label", {
-          className: "text-400 mb-0",
-          htmlFor: "field_for_" + field,
-          style: {
-            'paddingRight': '5px',
-            'paddingLeft': '5px'
-          }
-        }, attach_title)))
-      );
+        accept: this.acceptedTypes()
+      }), _react["default"].createElement("button", {
+        type: "submit",
+        className: "btn btn-outline-dark"
+      }, _react["default"].createElement("label", {
+        className: "text-400 mb-0",
+        htmlFor: "field_for_" + field,
+        style: {
+          'paddingRight': '5px',
+          'paddingLeft': '5px'
+        }
+      }, attach_title)));
     }
   }]);
 
@@ -1319,14 +1146,12 @@ var S3FileInput =
 function (_React$Component3) {
   _inherits(S3FileInput, _React$Component3);
 
-  var _super5 = _createSuper(S3FileInput);
-
   function S3FileInput(props) {
     var _this6;
 
     _classCallCheck(this, S3FileInput);
 
-    _this6 = _super5.call(this, props);
+    _this6 = _possibleConstructorReturn(this, _getPrototypeOf(S3FileInput).call(this, props));
 
     _underscore["default"].bindAll(_assertThisInitialized(_this6), 'modifyFile', 'handleChange', 'handleAsyncUpload', 'modifyRunningUploads', 'cancelUpload', 'deleteField');
 
@@ -1522,130 +1347,87 @@ function (_React$Component3) {
       }
 
       var disableFile = md5Progress !== null || upload !== null;
-      return (
-        /*#__PURE__*/
-        _react["default"].createElement("div", null,
-        /*#__PURE__*/
-        _react["default"].createElement("div", null,
-        /*#__PURE__*/
-        _react["default"].createElement("input", {
-          id: "field_for_" + field,
-          type: "file",
-          onChange: this.handleChange,
-          disabled: disableFile,
-          style: {
-            'display': 'none'
-          }
-        }),
-        /*#__PURE__*/
-        _react["default"].createElement("button", {
-          type: "submit",
-          disabled: disableFile,
-          style: {
-            'padding': '0px'
-          },
-          className: "btn btn-outline-dark"
+      return _react["default"].createElement("div", null, _react["default"].createElement("div", null, _react["default"].createElement("input", {
+        id: "field_for_" + field,
+        type: "file",
+        onChange: this.handleChange,
+        disabled: disableFile,
+        style: {
+          'display': 'none'
+        }
+      }), _react["default"].createElement("button", {
+        type: "submit",
+        disabled: disableFile,
+        style: {
+          'padding': '0px'
         },
-        /*#__PURE__*/
-        _react["default"].createElement("label", {
-          className: "text-400",
-          htmlFor: "field_for_" + field,
-          style: {
-            'paddingRight': '12px',
-            'paddingTop': '6px',
-            'paddingBottom': '6px',
-            'paddingLeft': '12px',
-            'marginBottom': '0px'
-          }
-        }, filename_text)),
-        /*#__PURE__*/
-        _react["default"].createElement(_Fade.Fade, {
-          "in": showDelete
+        className: "btn btn-outline-dark"
+      }, _react["default"].createElement("label", {
+        className: "text-400",
+        htmlFor: "field_for_" + field,
+        style: {
+          'paddingRight': '12px',
+          'paddingTop': '6px',
+          'paddingBottom': '6px',
+          'paddingLeft': '12px',
+          'marginBottom': '0px'
+        }
+      }, filename_text)), _react["default"].createElement(_Fade.Fade, {
+        "in": showDelete
+      }, _react["default"].createElement("div", {
+        className: "pull-right"
+      }, _react["default"].createElement("button", {
+        type: "button",
+        className: "btn btn-danger",
+        disabled: !showDelete,
+        onClick: this.deleteField,
+        tabIndex: 2
+      }, _react["default"].createElement("i", {
+        className: "icon icon-fw icon-times fas"
+      }))))), statusTip ? _react["default"].createElement("div", {
+        style: {
+          'color': '#a94442',
+          'paddingTop': '10px'
+        }
+      }, statusTip) : null, md5Progress ? _react["default"].createElement("div", {
+        style: {
+          'paddingTop': '10px'
+        }
+      }, _react["default"].createElement("i", {
+        className: "icon icon-spin icon-circle-notch",
+        style: {
+          'opacity': '0.5'
+        }
+      }), _react["default"].createElement("span", {
+        style: {
+          'paddingLeft': '10px'
+        }
+      }, 'Calculating MD5... ' + md5Progress + '%')) : null, percentDone !== null ? _react["default"].createElement("div", {
+        className: "row",
+        style: {
+          'paddingTop': '10px'
+        }
+      }, _react["default"].createElement("div", {
+        className: "col-3 col-sm-3 pull-left"
+      }, _react["default"].createElement("a", {
+        href: "",
+        style: {
+          'color': '#a94442',
+          'paddingLeft': '10px'
         },
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: "pull-right"
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("button", {
-          type: "button",
-          className: "btn btn-danger",
-          disabled: !showDelete,
-          onClick: this.deleteField,
-          tabIndex: 2
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("i", {
-          className: "icon icon-fw icon-times fas"
-        }))))), statusTip ?
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          style: {
-            'color': '#a94442',
-            'paddingTop': '10px'
-          }
-        }, statusTip) : null, md5Progress ?
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          style: {
-            'paddingTop': '10px'
-          }
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("i", {
-          className: "icon icon-spin icon-circle-notch",
-          style: {
-            'opacity': '0.5'
-          }
-        }),
-        /*#__PURE__*/
-        _react["default"].createElement("span", {
-          style: {
-            'paddingLeft': '10px'
-          }
-        }, 'Calculating MD5... ' + md5Progress + '%')) : null, percentDone !== null ?
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: "row",
-          style: {
-            'paddingTop': '10px'
-          }
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: "col-3 col-sm-3 pull-left"
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("a", {
-          href: "",
-          style: {
-            'color': '#a94442',
-            'paddingLeft': '10px'
-          },
-          onClick: this.cancelUpload,
-          title: "Cancel"
-        }, 'Cancel upload')),
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: "col-9 col-sm-9 pull-right"
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("div", null,
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: "pull-left"
-        }, percentDone + "% complete"),
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: "pull-right"
-        }, "Total size: " + sizeUploaded)),
-        /*#__PURE__*/
-        _react["default"].createElement(_rcProgress.Line, {
-          percent: percentDone,
-          strokeWidth: "1",
-          strokeColor: "#388a92"
-        }))) : null)
-      );
+        onClick: this.cancelUpload,
+        title: "Cancel"
+      }, 'Cancel upload')), _react["default"].createElement("div", {
+        className: "col-9 col-sm-9 pull-right"
+      }, _react["default"].createElement("div", null, _react["default"].createElement("div", {
+        className: "pull-left"
+      }, percentDone + "% complete"), _react["default"].createElement("div", {
+        className: "pull-right"
+      }, "Total size: " + sizeUploaded)), _react["default"].createElement(_rcProgress.Line, {
+        percent: percentDone,
+        strokeWidth: "1",
+        strokeColor: "#388a92"
+      }))) : null);
     }
   }]);
 
@@ -1664,8 +1446,6 @@ var AliasInputField =
 /*#__PURE__*/
 function (_React$Component4) {
   _inherits(AliasInputField, _React$Component4);
-
-  var _super6 = _createSuper(AliasInputField);
 
   _createClass(AliasInputField, null, [{
     key: "emailToString",
@@ -1709,7 +1489,7 @@ function (_React$Component4) {
 
     _classCallCheck(this, AliasInputField);
 
-    _this9 = _super6.call(this, props);
+    _this9 = _possibleConstructorReturn(this, _getPrototypeOf(AliasInputField).call(this, props));
 
     _underscore["default"].bindAll(_assertThisInitialized(_this9), 'onAliasSecondPartChange', 'onAliasFirstPartChange', 'onAliasFirstPartChangeTyped', 'getInitialSubmitsForPart', 'finalizeAliasPartsChange');
 
@@ -1781,9 +1561,7 @@ function (_React$Component4) {
 
       if (currentSubmittingUser && Array.isArray(currentSubmittingUser.groups) && currentSubmittingUser.groups.indexOf('admin') > -1) {
         // Render an ordinary input box for admins (can specify any lab).
-        firstPartSelect =
-        /*#__PURE__*/
-        _react["default"].createElement("input", {
+        firstPartSelect = _react["default"].createElement("input", {
           type: "text",
           inputMode: "latin",
           id: "firstPartSelect",
@@ -1797,88 +1575,58 @@ function (_React$Component4) {
           className: "form-control" + (errorMessage ? " is-invalid" : isValid ? " is-valid" : "")
         });
       } else if (submits_for_list && submits_for_list.length > 1) {
-        firstPartSelect =
-        /*#__PURE__*/
-        _react["default"].createElement(_reactBootstrap.DropdownButton, {
+        firstPartSelect = _react["default"].createElement(_reactBootstrap.DropdownButton, {
           className: "alias-lab-select form-control alias-first-part-input" + (errorMessage ? " is-invalid" : ""),
           id: "firstPartSelect",
           variant: "light",
           onSelect: this.onAliasFirstPartChange,
           as: _reactBootstrap.InputGroup.Prepend,
-          title: parts.length > 1 &&
-          /*#__PURE__*/
-          _react["default"].createElement("span", {
+          title: parts.length > 1 && _react["default"].createElement("span", {
             className: "text-400 d-flex justify-content-between align-items-center"
-          },
-          /*#__PURE__*/
-          _react["default"].createElement("small", null, "Lab:\xA0"),
-          /*#__PURE__*/
-          _react["default"].createElement("span", {
+          }, _react["default"].createElement("small", null, "Lab:\xA0"), _react["default"].createElement("span", {
             className: "text-ellipsis-container",
             style: {
               maxWidth: '80%'
             }
           }, parts[0] !== '' && parts[0] || this.getInitialSubmitsForPart())) || 'Select a Lab'
         }, _underscore["default"].map(submits_for_list, function (lab) {
-          return (
-            /*#__PURE__*/
-            _react["default"].createElement(_reactBootstrap.DropdownItem, {
-              key: lab.name,
-              eventKey: lab.name
-            },
-            /*#__PURE__*/
-            _react["default"].createElement("span", {
-              className: "text-500"
-            }, lab.name), " (", lab.display_title, ")")
-          );
+          return _react["default"].createElement(_reactBootstrap.DropdownItem, {
+            key: lab.name,
+            eventKey: lab.name
+          }, _react["default"].createElement("span", {
+            className: "text-500"
+          }, lab.name), " (", lab.display_title, ")");
         }));
       } else {
         // Only 1 submits_for lab or 0 submits_for -- fallback to staticy thingy
-        firstPartSelect =
-        /*#__PURE__*/
-        _react["default"].createElement(_reactBootstrap.InputGroup.Prepend, {
+        firstPartSelect = _react["default"].createElement(_reactBootstrap.InputGroup.Prepend, {
           className: "alias-lab-single-option"
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("span", {
+        }, _react["default"].createElement("span", {
           className: "input-group-text"
         }, currFirstPartValue));
       }
 
       var outerClassName = "mb-0 alias-input-field form-group has-feedback" + (errorMessage ? " is-invalid has-error" : isValid ? " is-valid" : "");
-      return (
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: outerClassName
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: "input-group"
-        }, firstPartSelect,
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: "input-group-prepend input-group-append input-group-addon colon-separator"
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("span", {
-          className: "input-group-text"
-        }, ":")),
-        /*#__PURE__*/
-        _react["default"].createElement("input", {
-          type: "text",
-          id: "aliasInput",
-          inputMode: "latin",
-          value: parts[1] || '',
-          autoFocus: withinModal && !parts[1] ? true : false,
-          placeholder: "Type in a new identifier",
-          onChange: this.onAliasSecondPartChange,
-          className: "form-control" + (errorMessage ? " is-invalid" : isValid ? " is-valid" : "")
-        })), showErrorMsg && errorMessage ?
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: "invalid-feedback d-block text-right"
-        }, errorMessage) : null)
-      );
+      return _react["default"].createElement("div", {
+        className: outerClassName
+      }, _react["default"].createElement("div", {
+        className: "input-group"
+      }, firstPartSelect, _react["default"].createElement("div", {
+        className: "input-group-prepend input-group-append input-group-addon colon-separator"
+      }, _react["default"].createElement("span", {
+        className: "input-group-text"
+      }, ":")), _react["default"].createElement("input", {
+        type: "text",
+        id: "aliasInput",
+        inputMode: "latin",
+        value: parts[1] || '',
+        autoFocus: withinModal && !parts[1] ? true : false,
+        placeholder: "Type in a new identifier",
+        onChange: this.onAliasSecondPartChange,
+        className: "form-control" + (errorMessage ? " is-invalid" : isValid ? " is-valid" : "")
+      })), showErrorMsg && errorMessage ? _react["default"].createElement("div", {
+        className: "invalid-feedback d-block text-right"
+      }, errorMessage) : null);
     }
   }]);
 
@@ -1910,14 +1658,12 @@ var AliasInputFieldValidated =
 function (_React$PureComponent3) {
   _inherits(AliasInputFieldValidated, _React$PureComponent3);
 
-  var _super7 = _createSuper(AliasInputFieldValidated);
-
   function AliasInputFieldValidated(props) {
     var _this10;
 
     _classCallCheck(this, AliasInputFieldValidated);
 
-    _this10 = _super7.call(this, props);
+    _this10 = _possibleConstructorReturn(this, _getPrototypeOf(AliasInputFieldValidated).call(this, props));
     _this10.doValidateAlias = _this10.doValidateAlias.bind(_assertThisInitialized(_this10));
     _this10.onAliasChange = _this10.onAliasChange.bind(_assertThisInitialized(_this10));
     _this10.request = null;
@@ -2050,12 +1796,9 @@ function (_React$PureComponent3) {
   }, {
     key: "render",
     value: function render() {
-      return (
-        /*#__PURE__*/
-        _react["default"].createElement(AliasInputField, _extends({}, this.props, this.state, {
-          onAliasChange: this.onAliasChange
-        }))
-      );
+      return _react["default"].createElement(AliasInputField, _extends({}, this.props, this.state, {
+        onAliasChange: this.onAliasChange
+      }));
     }
   }]);
 
@@ -2075,12 +1818,10 @@ var InfoIcon =
 function (_React$PureComponent4) {
   _inherits(InfoIcon, _React$PureComponent4);
 
-  var _super8 = _createSuper(InfoIcon);
-
   function InfoIcon() {
     _classCallCheck(this, InfoIcon);
 
-    return _super8.apply(this, arguments);
+    return _possibleConstructorReturn(this, _getPrototypeOf(InfoIcon).apply(this, arguments));
   }
 
   _createClass(InfoIcon, [{
@@ -2118,14 +1859,11 @@ function (_React$PureComponent4) {
         tip += '<h6 class="mt-07 text-300">Field Type: <span class="text-400">' + this.fieldTypeDescriptor() + '</span></h6>';
       }
 
-      return (
-        /*#__PURE__*/
-        _react["default"].createElement("i", {
-          className: "icon icon-info-circle fas" + (className ? ' ' + className : ''),
-          "data-tip": tip,
-          "data-html": true
-        })
-      );
+      return _react["default"].createElement("i", {
+        className: "icon icon-info-circle fas" + (className ? ' ' + className : ''),
+        "data-tip": tip,
+        "data-html": true
+      });
     }
   }]);
 

--- a/es/components/static-pages/StaticPageBase.js
+++ b/es/components/static-pages/StaticPageBase.js
@@ -32,45 +32,15 @@ function _defineProperties(target, props) { for (var i = 0; i < props.length; i+
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
-
-function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function (o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
-
-function _createSuper(Derived) {
-  function isNativeReflectConstruct() {
-    if (typeof Reflect === "undefined" || !Reflect.construct) return false;
-    if (Reflect.construct.sham) return false;
-    if (typeof Proxy === "function") return true;
-
-    try {
-      Date.prototype.toString.call(Reflect.construct(Date, [], function () {}));
-      return true;
-    } catch (e) {
-      return false;
-    }
-  }
-
-  return function () {
-    var Super = _getPrototypeOf(Derived),
-        result;
-
-    if (isNativeReflectConstruct()) {
-      var NewTarget = _getPrototypeOf(this).constructor;
-
-      result = Reflect.construct(Super, arguments, NewTarget);
-    } else {
-      result = Super.apply(this, arguments);
-    }
-
-    return _possibleConstructorReturn(this, result);
-  };
-}
-
 function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function (o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
-function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function (o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function (o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
@@ -139,34 +109,23 @@ var Wrapper = _react["default"].memo(function (props) {
   var toc = context && context['table-of-contents'] || (tableOfContents && _typeof(tableOfContents) === 'object' ? tableOfContents : null);
   var pageTitle = title || context && context.title || null;
   var tocExists = toc && toc.enabled !== false;
-  return (
-    /*#__PURE__*/
-    _react["default"].createElement("div", {
-      className: "container",
-      id: "content"
-    },
-    /*#__PURE__*/
-    _react["default"].createElement("div", {
-      className: "static-page row",
-      key: "wrapper"
-    }, tocExists ?
-    /*#__PURE__*/
-    _react["default"].createElement("div", {
-      key: "toc-wrapper",
-      className: "col-12 col-xl-3 order-1 order-xl-3"
-    },
-    /*#__PURE__*/
-    _react["default"].createElement(_TableOfContents.TableOfContents, _extends({
-      pageTitle: pageTitle,
-      fixedGridWidth: 3,
-      maxHeaderDepth: toc['header-depth'] || 6
-    }, _underscore["default"].pick(props, 'navigate', 'windowWidth', 'windowHeight', 'context', 'href', 'registerWindowOnScrollHandler')))) : null,
-    /*#__PURE__*/
-    _react["default"].createElement("div", {
-      key: "main-column",
-      className: "order-2 col-12 col-xl-" + (tocExists ? '9' : '12')
-    }, children)))
-  );
+  return _react["default"].createElement("div", {
+    className: "container",
+    id: "content"
+  }, _react["default"].createElement("div", {
+    className: "static-page row",
+    key: "wrapper"
+  }, tocExists ? _react["default"].createElement("div", {
+    key: "toc-wrapper",
+    className: "col-12 col-xl-3 order-1 order-xl-3"
+  }, _react["default"].createElement(_TableOfContents.TableOfContents, _extends({
+    pageTitle: pageTitle,
+    fixedGridWidth: 3,
+    maxHeaderDepth: toc['header-depth'] || 6
+  }, _underscore["default"].pick(props, 'navigate', 'windowWidth', 'windowHeight', 'context', 'href', 'registerWindowOnScrollHandler')))) : null, _react["default"].createElement("div", {
+    key: "main-column",
+    className: "order-2 col-12 col-xl-" + (tocExists ? '9' : '12')
+  }, children)));
 });
 
 Wrapper.defaultProps = {
@@ -180,14 +139,12 @@ var StaticEntry =
 function (_React$PureComponent) {
   _inherits(StaticEntry, _React$PureComponent);
 
-  var _super = _createSuper(StaticEntry);
-
   function StaticEntry(props) {
     var _this;
 
     _classCallCheck(this, StaticEntry);
 
-    _this = _super.call(this, props);
+    _this = _possibleConstructorReturn(this, _getPrototypeOf(StaticEntry).call(this, props));
     _this.toggleOpen = _underscore["default"].throttle(_this.toggleOpen.bind(_assertThisInitialized(_this)), 1000);
     var options = props.section && props.section.options || {};
     _this.state = {
@@ -249,47 +206,31 @@ function (_React$PureComponent) {
 
       if (options.collapsible) {
         outerClassName += ' can-collapse ' + (open ? 'open' : 'closed');
-        return (
-          /*#__PURE__*/
-          _react["default"].createElement("div", {
-            className: outerClassName,
-            id: id
-          }, section && section.title ?
-          /*#__PURE__*/
-          _react["default"].createElement(_TableOfContents.HeaderWithLink, {
-            className: "section-title can-collapse " + (open ? 'open' : 'closed'),
-            link: id,
-            context: context,
-            onClick: this.toggleOpen
-          },
-          /*#__PURE__*/
-          _react["default"].createElement("i", {
-            className: "icon icon-fw fas icon-" + (open ? 'minus' : 'plus')
-          }), "\xA0\xA0", section.title) : null,
-          /*#__PURE__*/
-          _react["default"].createElement(_Collapse.Collapse, {
-            "in": open
-          },
-          /*#__PURE__*/
-          _react["default"].createElement("div", {
-            className: "inner"
-          }, open || closing ? renderedChildComponent : null)))
-        );
-      }
-
-      return (
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
+        return _react["default"].createElement("div", {
           className: outerClassName,
           id: id
-        }, section && section.title ?
-        /*#__PURE__*/
-        _react["default"].createElement(_TableOfContents.HeaderWithLink, {
-          className: "section-title",
+        }, section && section.title ? _react["default"].createElement(_TableOfContents.HeaderWithLink, {
+          className: "section-title can-collapse " + (open ? 'open' : 'closed'),
           link: id,
-          context: context
-        }, section.title) : null, renderedChildComponent)
-      );
+          context: context,
+          onClick: this.toggleOpen
+        }, _react["default"].createElement("i", {
+          className: "icon icon-fw fas icon-" + (open ? 'minus' : 'plus')
+        }), "\xA0\xA0", section.title) : null, _react["default"].createElement(_Collapse.Collapse, {
+          "in": open
+        }, _react["default"].createElement("div", {
+          className: "inner"
+        }, open || closing ? renderedChildComponent : null)));
+      }
+
+      return _react["default"].createElement("div", {
+        className: outerClassName,
+        id: id
+      }, section && section.title ? _react["default"].createElement(_TableOfContents.HeaderWithLink, {
+        className: "section-title",
+        link: id,
+        context: context
+      }, section.title) : null, renderedChildComponent);
     }
   }]);
 
@@ -320,12 +261,10 @@ var StaticPageBase =
 function (_React$PureComponent2) {
   _inherits(StaticPageBase, _React$PureComponent2);
 
-  var _super2 = _createSuper(StaticPageBase);
-
   function StaticPageBase() {
     _classCallCheck(this, StaticPageBase);
 
-    return _super2.apply(this, arguments);
+    return _possibleConstructorReturn(this, _getPrototypeOf(StaticPageBase).apply(this, arguments));
   }
 
   _createClass(StaticPageBase, [{
@@ -351,15 +290,12 @@ function (_React$PureComponent2) {
       }
 
       var tableOfContents = parsedContent && parsedContent['table-of-contents'] && parsedContent['table-of-contents'].enabled ? parsedContent['table-of-contents'] : false;
-      return (
-        /*#__PURE__*/
-        _react["default"].createElement(Wrapper, _extends({}, _underscore["default"].pick(this.props, 'navigate', 'windowWidth', 'windowHeight', 'registerWindowOnScrollHandler', 'href'), {
-          key: "page-wrapper",
-          title: parsedContent.title,
-          tableOfContents: tableOfContents,
-          context: parsedContent
-        }), StaticPageBase.renderSections(entryRenderFxn, parsedContent, this.props))
-      );
+      return _react["default"].createElement(Wrapper, _extends({}, _underscore["default"].pick(this.props, 'navigate', 'windowWidth', 'windowHeight', 'registerWindowOnScrollHandler', 'href'), {
+        key: "page-wrapper",
+        title: parsedContent.title,
+        tableOfContents: tableOfContents,
+        context: parsedContent
+      }), StaticPageBase.renderSections(entryRenderFxn, parsedContent, this.props));
     }
   }], [{
     key: "renderSections",
@@ -410,14 +346,11 @@ _defineProperty(StaticPageBase, "defaultProps", {
    * @param {Object} props - Collection of props passed down from BodyElement.
    */
   'entryRenderFxn': (0, _memoizeOne["default"])(function (sectionName, section, props) {
-    return (
-      /*#__PURE__*/
-      _react["default"].createElement(StaticEntry, _extends({}, props, {
-        key: sectionName,
-        sectionName: sectionName,
-        section: section
-      }))
-    );
+    return _react["default"].createElement(StaticEntry, _extends({}, props, {
+      key: sectionName,
+      sectionName: sectionName,
+      section: section
+    }));
   })
 });
 

--- a/es/components/ui/DropdownButton.js
+++ b/es/components/ui/DropdownButton.js
@@ -19,45 +19,15 @@ function _defineProperties(target, props) { for (var i = 0; i < props.length; i+
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
-
-function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function (o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
-
-function _createSuper(Derived) {
-  function isNativeReflectConstruct() {
-    if (typeof Reflect === "undefined" || !Reflect.construct) return false;
-    if (Reflect.construct.sham) return false;
-    if (typeof Proxy === "function") return true;
-
-    try {
-      Date.prototype.toString.call(Reflect.construct(Date, [], function () {}));
-      return true;
-    } catch (e) {
-      return false;
-    }
-  }
-
-  return function () {
-    var Super = _getPrototypeOf(Derived),
-        result;
-
-    if (isNativeReflectConstruct()) {
-      var NewTarget = _getPrototypeOf(this).constructor;
-
-      result = Reflect.construct(Super, arguments, NewTarget);
-    } else {
-      result = Super.apply(this, arguments);
-    }
-
-    return _possibleConstructorReturn(this, result);
-  };
-}
-
 function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function (o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
-function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function (o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function (o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
@@ -72,14 +42,12 @@ var DropdownButton =
 function (_React$PureComponent) {
   _inherits(DropdownButton, _React$PureComponent);
 
-  var _super = _createSuper(DropdownButton);
-
   function DropdownButton(props) {
     var _this;
 
     _classCallCheck(this, DropdownButton);
 
-    _this = _super.call(this, props);
+    _this = _possibleConstructorReturn(this, _getPrototypeOf(DropdownButton).call(this, props));
     _this.onWindowClick = _this.onWindowClick.bind(_assertThisInitialized(_this));
     _this.state = {
       'open': false
@@ -113,27 +81,20 @@ function (_React$PureComponent) {
           variant = _this$props.variant,
           size = _this$props.size;
       var open = this.state.open;
-      return (
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: "dropdown"
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("button", {
-          type: "button",
-          className: // TODO finish handling other props
-          "dropdown-toggle btn" + ("btn-" + (variant || "primary")) + ("btn-" + (size || "md")),
-          role: "button",
-          "data-toggle": "dropdown",
-          "aria-haspopup": "true",
-          "aria-expanded": "false"
-        }, title),
-        /*#__PURE__*/
-        _react["default"].createElement(DropdownMenu, {
-          children: children,
-          open: open
-        }))
-      );
+      return _react["default"].createElement("div", {
+        className: "dropdown"
+      }, _react["default"].createElement("button", {
+        type: "button",
+        className: // TODO finish handling other props
+        "dropdown-toggle btn" + ("btn-" + (variant || "primary")) + ("btn-" + (size || "md")),
+        role: "button",
+        "data-toggle": "dropdown",
+        "aria-haspopup": "true",
+        "aria-expanded": "false"
+      }, title), _react["default"].createElement(DropdownMenu, {
+        children: children,
+        open: open
+      }));
     }
   }]);
 
@@ -143,21 +104,15 @@ function (_React$PureComponent) {
 exports.DropdownButton = DropdownButton;
 
 _defineProperty(DropdownButton, "defaultProps", {
-  'children': [
-  /*#__PURE__*/
-  _react["default"].createElement("a", {
+  'children': [_react["default"].createElement("a", {
     className: "dropdown-item",
     href: "#",
     key: 1
-  }, "Action"),
-  /*#__PURE__*/
-  _react["default"].createElement("a", {
+  }, "Action"), _react["default"].createElement("a", {
     className: "dropdown-item",
     href: "#",
     key: 2
-  }, "Another action"),
-  /*#__PURE__*/
-  _react["default"].createElement("a", {
+  }, "Another action"), _react["default"].createElement("a", {
     className: "dropdown-item",
     href: "#",
     key: 3
@@ -169,12 +124,9 @@ var DropdownMenu = _react["default"].memo(function (props) {
   var children = props.children,
       open = props.open;
   if (!open) return null;
-  return (
-    /*#__PURE__*/
-    _react["default"].createElement("div", {
-      className: "dropdown-menu show"
-    }, children)
-  );
+  return _react["default"].createElement("div", {
+    className: "dropdown-menu show"
+  }, children);
 }); // TODO create plain Dropdown. Or not. Idk. Can easily create (more) custom Dropdown togglers and whatnot by emulating the above DropdownButton so not sure is worth adding more complexity...
 
 

--- a/es/components/ui/ItemDetailList.js
+++ b/es/components/ui/ItemDetailList.js
@@ -37,6 +37,12 @@ function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterat
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function (o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
 function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
@@ -44,42 +50,6 @@ function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _d
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
 
 function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function (o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
-
-function _createSuper(Derived) {
-  function isNativeReflectConstruct() {
-    if (typeof Reflect === "undefined" || !Reflect.construct) return false;
-    if (Reflect.construct.sham) return false;
-    if (typeof Proxy === "function") return true;
-
-    try {
-      Date.prototype.toString.call(Reflect.construct(Date, [], function () {}));
-      return true;
-    } catch (e) {
-      return false;
-    }
-  }
-
-  return function () {
-    var Super = _getPrototypeOf(Derived),
-        result;
-
-    if (isNativeReflectConstruct()) {
-      var NewTarget = _getPrototypeOf(this).constructor;
-
-      result = Reflect.construct(Super, arguments, NewTarget);
-    } else {
-      result = Super.apply(this, arguments);
-    }
-
-    return _possibleConstructorReturn(this, result);
-  };
-}
-
-function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
-
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
-
-function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function (o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
 /**
  * This file/component is kind of a mess.
@@ -109,35 +79,24 @@ var SubItemTitle = _react["default"].memo(function (_ref) {
   if (content && _underscore["default"].any([content.title, content.display_title, content.name], function (p) {
     return typeof p === 'string';
   })) {
-    subtitle =
-    /*#__PURE__*/
-    _react["default"].createElement("span", {
+    subtitle = _react["default"].createElement("span", {
       className: "text-600"
     }, typeof content.title === 'string' ? content.title : typeof content.display_title === 'string' ? content.display_title : content.name);
   }
 
-  return (
-    /*#__PURE__*/
-    _react["default"].createElement("span", {
-      className: "subitem-toggle"
+  return _react["default"].createElement("span", {
+    className: "subitem-toggle"
+  }, _react["default"].createElement("span", {
+    className: "link",
+    onClick: onToggle
+  }, _react["default"].createElement("i", {
+    style: {
+      'color': 'black',
+      'paddingRight': 10,
+      'paddingLeft': 5
     },
-    /*#__PURE__*/
-    _react["default"].createElement("span", {
-      className: "link",
-      onClick: onToggle
-    },
-    /*#__PURE__*/
-    _react["default"].createElement("i", {
-      style: {
-        'color': 'black',
-        'paddingRight': 10,
-        'paddingLeft': 5
-      },
-      className: "icon fas " + iconType
-    }), showTitle, " ", subtitle, " ", countProperties && !isOpen ?
-    /*#__PURE__*/
-    _react["default"].createElement("span", null, "(", countProperties, ")") : null))
-  );
+    className: "icon fas " + iconType
+  }), showTitle, " ", subtitle, " ", countProperties && !isOpen ? _react["default"].createElement("span", null, "(", countProperties, ")") : null));
 });
 
 SubItemTitle.propTypes = {
@@ -169,16 +128,11 @@ var SubItemListView = _react["default"].memo(function (props) {
     'showJSONButton': false,
     'hideButtons': true
   };
-  return (
-    /*#__PURE__*/
-    _react["default"].createElement("div", {
-      className: "sub-panel data-display panel-body-with-header"
-    },
-    /*#__PURE__*/
-    _react["default"].createElement("div", {
-      className: "key-value sub-descriptions"
-    }, _react["default"].createElement(typeof item.display_title === 'string' ? ItemDetailList : Detail, passProps)))
-  );
+  return _react["default"].createElement("div", {
+    className: "sub-panel data-display panel-body-with-header"
+  }, _react["default"].createElement("div", {
+    className: "key-value sub-descriptions"
+  }, _react["default"].createElement(typeof item.display_title === 'string' ? ItemDetailList : Detail, passProps)));
 });
 /**
  * Messiness.
@@ -192,8 +146,6 @@ var SubItemTable =
 /*#__PURE__*/
 function (_React$Component) {
   _inherits(SubItemTable, _React$Component);
-
-  var _super = _createSuper(SubItemTable);
 
   _createClass(SubItemTable, null, [{
     key: "shouldUseTable",
@@ -440,15 +392,11 @@ function (_React$Component) {
           _patchedConsole.patchedConsoleInstance.error("ERROR: Value for table cell is not a string, number, or JSX element.\nKey: " + key + '; Value: ' + newVal);
         }
 
-        newVal =
-        /*#__PURE__*/
-        _react["default"].createElement("code", null, newVal.length <= 25 ? newVal : newVal.slice(0, 25) + '...');
+        newVal = _react["default"].createElement("code", null, newVal.length <= 25 ? newVal : newVal.slice(0, 25) + '...');
       } catch (e) {
         _patchedConsole.patchedConsoleInstance.error(e, val);
 
-        newVal =
-        /*#__PURE__*/
-        _react["default"].createElement("em", null, '{obj}');
+        newVal = _react["default"].createElement("em", null, '{obj}');
       }
 
       return newVal;
@@ -460,7 +408,7 @@ function (_React$Component) {
 
     _classCallCheck(this, SubItemTable);
 
-    _this = _super.call(this, props);
+    _this = _possibleConstructorReturn(this, _getPrototypeOf(SubItemTable).call(this, props));
     _this.state = {
       'mounted': false
     };
@@ -559,53 +507,41 @@ function (_React$Component) {
 
               return {
                 'value': _underscore["default"].map(value, function (embeddedRow, i) {
-                  return (
-                    /*#__PURE__*/
-                    _react["default"].createElement("div", {
-                      style: {
-                        whiteSpace: "nowrap"
-                      },
-                      className: "text-left child-list-row",
-                      key: colKey + '--row-' + i
+                  return _react["default"].createElement("div", {
+                    style: {
+                      whiteSpace: "nowrap"
                     },
-                    /*#__PURE__*/
-                    _react["default"].createElement("div", {
-                      className: "inline-block child-list-row-number"
-                    }, i + 1, "."), allKeys.map(function (k) {
-                      var renderedSubVal; // = Schemas.Term.toName(k, embeddedRow[k]);
+                    className: "text-left child-list-row",
+                    key: colKey + '--row-' + i
+                  }, _react["default"].createElement("div", {
+                    className: "inline-block child-list-row-number"
+                  }, i + 1, "."), allKeys.map(function (k) {
+                    var renderedSubVal; // = Schemas.Term.toName(k, embeddedRow[k]);
 
-                      if (typeof columnDefinitions[parentKey + '.' + colKey + '.' + k] !== 'undefined') {
-                        if (typeof columnDefinitions[parentKey + '.' + colKey + '.' + k].render === 'function') {
-                          renderedSubVal = columnDefinitions[parentKey + '.' + colKey + '.' + k].render(embeddedRow[k], embeddedRow, colKeyIndex, value);
-                        }
+                    if (typeof columnDefinitions[parentKey + '.' + colKey + '.' + k] !== 'undefined') {
+                      if (typeof columnDefinitions[parentKey + '.' + colKey + '.' + k].render === 'function') {
+                        renderedSubVal = columnDefinitions[parentKey + '.' + colKey + '.' + k].render(embeddedRow[k], embeddedRow, colKeyIndex, value);
                       }
+                    }
 
-                      if (!renderedSubVal && embeddedRow[k] && _typeof(embeddedRow[k]) === 'object' && !(0, _object.isAnItem)(embeddedRow[k])) {
-                        renderedSubVal =
-                        /*#__PURE__*/
-                        _react["default"].createElement("code", null, JSON.stringify(embeddedRow[k]));
+                    if (!renderedSubVal && embeddedRow[k] && _typeof(embeddedRow[k]) === 'object' && !(0, _object.isAnItem)(embeddedRow[k])) {
+                      renderedSubVal = _react["default"].createElement("code", null, JSON.stringify(embeddedRow[k]));
+                    }
+
+                    if (!renderedSubVal) {
+                      renderedSubVal = (0, _object.isAnItem)(embeddedRow[k]) ? _react["default"].createElement("a", {
+                        href: _object.itemUtil.atId(embeddedRow[k])
+                      }, _object.itemUtil.getTitleStringFromContext(embeddedRow[k])) : termTransformFxn(k, embeddedRow[k]);
+                    }
+
+                    return _react["default"].createElement("div", {
+                      key: colKey + '.' + k + '--row-' + i,
+                      className: "inline-block child-column-" + colKey + '.' + k,
+                      style: {
+                        width: !subListKeyWidths ? null : (subListKeyWidths[colKey] || {})[k] || null
                       }
-
-                      if (!renderedSubVal) {
-                        renderedSubVal = (0, _object.isAnItem)(embeddedRow[k]) ?
-                        /*#__PURE__*/
-                        _react["default"].createElement("a", {
-                          href: _object.itemUtil.atId(embeddedRow[k])
-                        }, _object.itemUtil.getTitleStringFromContext(embeddedRow[k])) : termTransformFxn(k, embeddedRow[k]);
-                      }
-
-                      return (
-                        /*#__PURE__*/
-                        _react["default"].createElement("div", {
-                          key: colKey + '.' + k + '--row-' + i,
-                          className: "inline-block child-column-" + colKey + '.' + k,
-                          style: {
-                            width: !subListKeyWidths ? null : (subListKeyWidths[colKey] || {})[k] || null
-                          }
-                        }, renderedSubVal)
-                      );
-                    }))
-                  );
+                    }, renderedSubVal);
+                  }));
                 }),
                 'className': 'child-list-row-container',
                 'key': colKey
@@ -615,9 +551,7 @@ function (_React$Component) {
 
           if ((0, _object.isAnItem)(value)) {
             return {
-              'value':
-              /*#__PURE__*/
-              _react["default"].createElement("a", {
+              'value': _react["default"].createElement("a", {
                 href: _object.itemUtil.atId(value)
               }, value.display_title),
               'key': colKey
@@ -646,137 +580,97 @@ function (_React$Component) {
       (0, _schemaTransforms.flattenSchemaPropertyToColumnDefinition)(_object.tipsFromSchema || parentKeySchemaProperty, 0, schemas), columnDefinitions);
 
       var subListKeyRefs = this.subListKeyRefs = {};
-      return (
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: "detail-embedded-table-container"
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("table", {
-          className: "detail-embedded-table"
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("thead", null,
-        /*#__PURE__*/
-        _react["default"].createElement("tr", null, [
-        /*#__PURE__*/
-        _react["default"].createElement("th", {
-          key: "rowNumber",
-          style: {
-            minWidth: 36,
-            maxWidth: 36,
-            width: 36
-          }
-        }, "#")].concat(columnKeys.map(function (colKeyContainer) {
-          //var tips = tipsFromSchema(Schemas.get(), context) || {};
-          var colKey = colKeyContainer.key;
-          var title = keyTitleDescriptionMap[parentKey + '.' + colKey] && keyTitleDescriptionMap[parentKey + '.' + colKey].title || keyTitleDescriptionMap[colKey] && keyTitleDescriptionMap[colKey].title || colKey;
-          var tooltip = keyTitleDescriptionMap[parentKey + '.' + colKey] && keyTitleDescriptionMap[parentKey + '.' + colKey].description || keyTitleDescriptionMap[colKey] && keyTitleDescriptionMap[colKey].description || null;
-          var hasChildren = Array.isArray(colKeyContainer.childKeys) && colKeyContainer.childKeys.length > 0;
-          return (
-            /*#__PURE__*/
-            _react["default"].createElement("th", {
-              key: "header-for-" + colKey,
-              className: hasChildren ? 'has-children' : null
+      return _react["default"].createElement("div", {
+        className: "detail-embedded-table-container"
+      }, _react["default"].createElement("table", {
+        className: "detail-embedded-table"
+      }, _react["default"].createElement("thead", null, _react["default"].createElement("tr", null, [_react["default"].createElement("th", {
+        key: "rowNumber",
+        style: {
+          minWidth: 36,
+          maxWidth: 36,
+          width: 36
+        }
+      }, "#")].concat(columnKeys.map(function (colKeyContainer) {
+        //var tips = tipsFromSchema(Schemas.get(), context) || {};
+        var colKey = colKeyContainer.key;
+        var title = keyTitleDescriptionMap[parentKey + '.' + colKey] && keyTitleDescriptionMap[parentKey + '.' + colKey].title || keyTitleDescriptionMap[colKey] && keyTitleDescriptionMap[colKey].title || colKey;
+        var tooltip = keyTitleDescriptionMap[parentKey + '.' + colKey] && keyTitleDescriptionMap[parentKey + '.' + colKey].description || keyTitleDescriptionMap[colKey] && keyTitleDescriptionMap[colKey].description || null;
+        var hasChildren = Array.isArray(colKeyContainer.childKeys) && colKeyContainer.childKeys.length > 0;
+        return _react["default"].createElement("th", {
+          key: "header-for-" + colKey,
+          className: hasChildren ? 'has-children' : null
+        }, _react["default"].createElement(_object.TooltipInfoIconContainer, {
+          title: title,
+          tooltip: tooltip
+        }), hasChildren ? function () {
+          //var subKeyTitleDescriptionMap = (((this.props.keyTitleDescriptionMap || {})[this.props.parentKey] || {}).items || {}).properties || {};
+          //var subKeyTitleDescriptionMap = keyTitleDescriptionMap[this.props.parentKey + '.' + colKey] || keyTitleDescriptionMap[colKey] || {};
+          var subKeyTitleDescriptionMap = ((keyTitleDescriptionMap[parentKey + '.' + colKey] || keyTitleDescriptionMap[colKey] || {}).items || {}).properties || {};
+          subListKeyRefs[colKey] = {};
+          return _react["default"].createElement("div", {
+            style: {
+              whiteSpace: "nowrap"
             },
-            /*#__PURE__*/
-            _react["default"].createElement(_object.TooltipInfoIconContainer, {
-              title: title,
-              tooltip: tooltip
-            }), hasChildren ? function () {
-              //var subKeyTitleDescriptionMap = (((this.props.keyTitleDescriptionMap || {})[this.props.parentKey] || {}).items || {}).properties || {};
-              //var subKeyTitleDescriptionMap = keyTitleDescriptionMap[this.props.parentKey + '.' + colKey] || keyTitleDescriptionMap[colKey] || {};
-              var subKeyTitleDescriptionMap = ((keyTitleDescriptionMap[parentKey + '.' + colKey] || keyTitleDescriptionMap[colKey] || {}).items || {}).properties || {};
-              subListKeyRefs[colKey] = {};
-              return (
-                /*#__PURE__*/
-                _react["default"].createElement("div", {
-                  style: {
-                    whiteSpace: "nowrap"
-                  },
-                  className: "sub-list-keys-header"
-                }, [
-                /*#__PURE__*/
-                _react["default"].createElement("div", {
-                  key: "sub-header-rowNumber",
-                  className: "inline-block child-list-row-number"
-                }, "\xA0")].concat(colKeyContainer.childKeys.map(function (ck) {
-                  return (
-                    /*#__PURE__*/
-                    _react["default"].createElement("div", {
-                      key: "sub-header-for-" + colKey + '.' + ck,
-                      className: "inline-block",
-                      "data-key": colKey + '.' + ck,
-                      ref: function ref(r) {
-                        if (r) subListKeyRefs[colKey][ck] = r;
-                      },
-                      style: {
-                        'width': !subListKeyWidths ? null : (subListKeyWidths[colKey] || {})[ck] || null
-                      }
-                    },
-                    /*#__PURE__*/
-                    _react["default"].createElement(_object.TooltipInfoIconContainer, {
-                      title: (keyTitleDescriptionMap[parentKey + '.' + colKey + '.' + ck] || subKeyTitleDescriptionMap[ck] || {}).title || ck,
-                      tooltip: (keyTitleDescriptionMap[parentKey + '.' + colKey + '.' + ck] || subKeyTitleDescriptionMap[ck] || {}).description || null
-                    }))
-                  );
-                })))
-              );
-            }() : null)
-          );
-        })))),
-        /*#__PURE__*/
-        _react["default"].createElement("tbody", null, _underscore["default"].map(rowData, function (row, i) {
-          return (
-            /*#__PURE__*/
-            _react["default"].createElement("tr", {
-              key: "row-" + i
-            }, [
-            /*#__PURE__*/
-            _react["default"].createElement("td", {
-              key: "rowNumber"
-            }, i + 1, ".")].concat(row.map(function (colVal, j) {
-              var val = colVal.value;
-
-              if (typeof val === 'boolean') {
-                val =
-                /*#__PURE__*/
-                _react["default"].createElement("code", null, val ? 'True' : 'False');
+            className: "sub-list-keys-header"
+          }, [_react["default"].createElement("div", {
+            key: "sub-header-rowNumber",
+            className: "inline-block child-list-row-number"
+          }, "\xA0")].concat(colKeyContainer.childKeys.map(function (ck) {
+            return _react["default"].createElement("div", {
+              key: "sub-header-for-" + colKey + '.' + ck,
+              className: "inline-block",
+              "data-key": colKey + '.' + ck,
+              ref: function ref(r) {
+                if (r) subListKeyRefs[colKey][ck] = r;
+              },
+              style: {
+                'width': !subListKeyWidths ? null : (subListKeyWidths[colKey] || {})[ck] || null
               }
+            }, _react["default"].createElement(_object.TooltipInfoIconContainer, {
+              title: (keyTitleDescriptionMap[parentKey + '.' + colKey + '.' + ck] || subKeyTitleDescriptionMap[ck] || {}).title || ck,
+              tooltip: (keyTitleDescriptionMap[parentKey + '.' + colKey + '.' + ck] || subKeyTitleDescriptionMap[ck] || {}).description || null
+            }));
+          })));
+        }() : null);
+      })))), _react["default"].createElement("tbody", null, _underscore["default"].map(rowData, function (row, i) {
+        return _react["default"].createElement("tr", {
+          key: "row-" + i
+        }, [_react["default"].createElement("td", {
+          key: "rowNumber"
+        }, i + 1, ".")].concat(row.map(function (colVal, j) {
+          var val = colVal.value;
 
-              if (colVal.key === '@id' && val.slice(0, 1) === '/') {
-                val =
-                /*#__PURE__*/
-                _react["default"].createElement("a", {
-                  href: val
-                }, val);
-              }
+          if (typeof val === 'boolean') {
+            val = _react["default"].createElement("code", null, val ? 'True' : 'False');
+          }
 
-              if (typeof val === 'string' && val.length > 50) {
-                val = val.slice(0, 50) + '...';
-              }
+          if (colVal.key === '@id' && val.slice(0, 1) === '/') {
+            val = _react["default"].createElement("a", {
+              href: val
+            }, val);
+          }
 
-              if (val && _typeof(val) === 'object' && !_react["default"].isValidElement(val) && !Array.isArray(val)) {
-                val = SubItemTable.jsonify(val, columnKeys[j].key);
-              }
+          if (typeof val === 'string' && val.length > 50) {
+            val = val.slice(0, 50) + '...';
+          }
 
-              if (Array.isArray(val) && val.length > 0 && !_underscore["default"].all(val, _react["default"].isValidElement)) {
-                val = _underscore["default"].map(val, function (v, i) {
-                  return SubItemTable.jsonify(v, columnKeys[j].key + ':' + i);
-                });
-              }
+          if (val && _typeof(val) === 'object' && !_react["default"].isValidElement(val) && !Array.isArray(val)) {
+            val = SubItemTable.jsonify(val, columnKeys[j].key);
+          }
 
-              return (
-                /*#__PURE__*/
-                _react["default"].createElement("td", {
-                  key: "column-for-" + columnKeys[j].key,
-                  className: colVal.className || null
-                }, val)
-              );
-            })))
-          );
-        }))))
-      );
+          if (Array.isArray(val) && val.length > 0 && !_underscore["default"].all(val, _react["default"].isValidElement)) {
+            val = _underscore["default"].map(val, function (v, i) {
+              return SubItemTable.jsonify(v, columnKeys[j].key + ':' + i);
+            });
+          }
+
+          return _react["default"].createElement("td", {
+            key: "column-for-" + columnKeys[j].key,
+            className: colVal.className || null
+          }, val);
+        })));
+      }))));
     }
   }]);
 
@@ -788,14 +682,12 @@ var DetailRow =
 function (_React$PureComponent) {
   _inherits(DetailRow, _React$PureComponent);
 
-  var _super2 = _createSuper(DetailRow);
-
   function DetailRow(props) {
     var _this2;
 
     _classCallCheck(this, DetailRow);
 
-    _this2 = _super2.call(this, props);
+    _this2 = _possibleConstructorReturn(this, _getPrototypeOf(DetailRow).call(this, props));
     _this2.handleToggle = _this2.handleToggle.bind(_assertThisInitialized(_this2));
     _this2.state = {
       'isOpen': false
@@ -842,15 +734,9 @@ function (_React$PureComponent) {
       var labelToShow = label;
 
       if (labelNumber) {
-        labelToShow =
-        /*#__PURE__*/
-        _react["default"].createElement("span", null,
-        /*#__PURE__*/
-        _react["default"].createElement("span", {
+        labelToShow = _react["default"].createElement("span", null, _react["default"].createElement("span", {
           className: "label-number right inline-block" + (isOpen ? ' active' : '')
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("span", {
+        }, _react["default"].createElement("span", {
           className: "number-icon text-200"
         }, "#"), " ", labelNumber), label);
       }
@@ -861,63 +747,45 @@ function (_React$PureComponent) {
           'onToggle': this.handleToggle,
           'isOpen': isOpen
         });
-        return (
-          /*#__PURE__*/
-          _react["default"].createElement("div", null,
-          /*#__PURE__*/
-          _react["default"].createElement(_PartialList.PartialList.Row, {
-            field: key,
-            label: labelToShow,
-            className: (className || '') + (isOpen ? ' open' : '')
-          }, value),
-          /*#__PURE__*/
-          _react["default"].createElement(SubItemListView, _extends({
-            popLink: popLink,
-            schemas: schemas,
-            isOpen: isOpen,
-            termTransformFxn: termTransformFxn
-          }, {
-            content: item,
-            columnDefinitions: value.props.columnDefinitions || columnDefinitions // Recursively pass these down
+        return _react["default"].createElement("div", null, _react["default"].createElement(_PartialList.PartialList.Row, {
+          field: key,
+          label: labelToShow,
+          className: (className || '') + (isOpen ? ' open' : '')
+        }, value), _react["default"].createElement(SubItemListView, _extends({
+          popLink: popLink,
+          schemas: schemas,
+          isOpen: isOpen,
+          termTransformFxn: termTransformFxn
+        }, {
+          content: item,
+          columnDefinitions: value.props.columnDefinitions || columnDefinitions // Recursively pass these down
 
-          })))
-        );
+        })));
       }
 
       if (value.type === "ol" && value.props.children[0] && value.props.children[0].type === "li" && value.props.children[0].props.children && value.props.children[0].props.children.type === SubItemTitle) {
         // What we have here is a list of embedded objects. Render them out recursively and adjust some styles.
-        return (
-          /*#__PURE__*/
-          _react["default"].createElement("div", {
-            className: "array-group",
-            "data-length": item.length
-          }, _react["default"].Children.map(value.props.children, function (c, i) {
-            return (
-              /*#__PURE__*/
-              _react["default"].createElement(DetailRow, _extends({}, _this3.props, {
-                label: i === 0 ? labelToShow :
-                /*#__PURE__*/
-                _react["default"].createElement("span", {
-                  className: "dim-duplicate"
-                }, labelToShow),
-                labelNumber: i + 1,
-                item: item[i],
-                className: "array-group-row item-index-" + i + (i === item.length - 1 ? ' last-item' : '') + (i === 0 ? ' first-item' : '')
-              }))
-            );
-          }))
-        );
+        return _react["default"].createElement("div", {
+          className: "array-group",
+          "data-length": item.length
+        }, _react["default"].Children.map(value.props.children, function (c, i) {
+          return _react["default"].createElement(DetailRow, _extends({}, _this3.props, {
+            label: i === 0 ? labelToShow : _react["default"].createElement("span", {
+              className: "dim-duplicate"
+            }, labelToShow),
+            labelNumber: i + 1,
+            item: item[i],
+            className: "array-group-row item-index-" + i + (i === item.length - 1 ? ' last-item' : '') + (i === 0 ? ' first-item' : '')
+          }));
+        }));
       } // Default / Pass-Thru
 
 
-      return (
-        /*#__PURE__*/
-        _react["default"].createElement(_PartialList.PartialList.Row, {
-          label: labelToShow,
-          field: key,
-          className: (className || '') + (isOpen ? ' open' : '')
-        }, value)
-      );
+      return _react["default"].createElement(_PartialList.PartialList.Row, {
+        label: labelToShow,
+        field: key,
+        className: (className || '') + (isOpen ? ' open' : '')
+      }, value);
     }
   }]);
 
@@ -936,8 +804,6 @@ var Detail =
 /*#__PURE__*/
 function (_React$PureComponent2) {
   _inherits(Detail, _React$PureComponent2);
-
-  var _super3 = _createSuper(Detail);
 
   _createClass(Detail, null, [{
     key: "formKey",
@@ -962,13 +828,10 @@ function (_React$PureComponent2) {
         if (info.description) tooltip = info.description;
       }
 
-      return (
-        /*#__PURE__*/
-        _react["default"].createElement(_object.TooltipInfoIconContainer, {
-          title: title || key,
-          tooltip: tooltip
-        })
-      );
+      return _react["default"].createElement(_object.TooltipInfoIconContainer, {
+        title: title || key,
+        tooltip: tooltip
+      });
     }
     /**
     * Recursively render keys/values included in a provided item.
@@ -999,42 +862,26 @@ function (_React$PureComponent2) {
       };
 
       if (item === null) {
-        return (
-          /*#__PURE__*/
-          _react["default"].createElement("span", null, "No Value")
-        );
+        return _react["default"].createElement("span", null, "No Value");
       } else if (Array.isArray(item)) {
         if (SubItemTable.shouldUseTable(item, schemas)) {
-          return (
-            /*#__PURE__*/
-            _react["default"].createElement(SubItemTable, _extends({
-              popLink: popLink,
-              columnDefinitions: columnDefinitions,
-              schemas: schemas,
-              atType: atType,
-              termTransformFxn: termTransformFxn
-            }, {
-              items: item,
-              parentKey: keyPrefix
-            }))
-          );
+          return _react["default"].createElement(SubItemTable, _extends({
+            popLink: popLink,
+            columnDefinitions: columnDefinitions,
+            schemas: schemas,
+            atType: atType,
+            termTransformFxn: termTransformFxn
+          }, {
+            items: item,
+            parentKey: keyPrefix
+          }));
         }
 
-        return (
-          /*#__PURE__*/
-          _react["default"].createElement("ol", null, item.length === 0 ?
-          /*#__PURE__*/
-          _react["default"].createElement("li", null,
-          /*#__PURE__*/
-          _react["default"].createElement("em", null, "None")) : item.map(function (it, i) {
-            return (
-              /*#__PURE__*/
-              _react["default"].createElement("li", {
-                key: i
-              }, Detail.formValue(it, popLink, keyPrefix, atType, columnDefinitions, depth + 1, schemas))
-            );
-          }))
-        );
+        return _react["default"].createElement("ol", null, item.length === 0 ? _react["default"].createElement("li", null, _react["default"].createElement("em", null, "None")) : item.map(function (it, i) {
+          return _react["default"].createElement("li", {
+            key: i
+          }, Detail.formValue(it, popLink, keyPrefix, atType, columnDefinitions, depth + 1, schemas));
+        }));
       } else if (_typeof(item) === 'object' && item !== null) {
         var linkElement = _object.itemUtil.generateLink(item, true, 'display_title', {
           'target': popLink ? '_blank' : null
@@ -1052,60 +899,45 @@ function (_React$PureComponent2) {
             return c;
           }));
 
-          return (
-            /*#__PURE__*/
-            _react["default"].createElement(SubItemTitle, {
-              schemas: schemas,
-              content: item,
-              key: keyPrefix,
-              countProperties: _underscore["default"].keys(item).length,
-              popLink: popLink,
-              columnDefinitions: releventProperties
-            })
-          );
+          return _react["default"].createElement(SubItemTitle, {
+            schemas: schemas,
+            content: item,
+            key: keyPrefix,
+            countProperties: _underscore["default"].keys(item).length,
+            popLink: popLink,
+            columnDefinitions: releventProperties
+          });
         }
       } else if (typeof item === 'string') {
         if (keyPrefix === '@id') {
-          return (
-            /*#__PURE__*/
-            _react["default"].createElement("a", {
-              key: item,
-              href: item,
-              target: popLink ? "_blank" : null
-            }, item)
-          );
+          return _react["default"].createElement("a", {
+            key: item,
+            href: item,
+            target: popLink ? "_blank" : null
+          }, item);
         }
 
         if (item.charAt(0) === '/' && item.indexOf('@@download') > -1) {
           // This is a download link. Format appropriately
           var split_item = item.split('/');
           var attach_title = decodeURIComponent(split_item[split_item.length - 1]);
-          return (
-            /*#__PURE__*/
-            _react["default"].createElement("a", {
-              key: item,
-              href: item,
-              target: "_blank",
-              download: true,
-              rel: "noreferrer noopener"
-            }, attach_title || item)
-          );
+          return _react["default"].createElement("a", {
+            key: item,
+            href: item,
+            target: "_blank",
+            download: true,
+            rel: "noreferrer noopener"
+          }, attach_title || item);
         } else if (item.charAt(0) === '/') {
-          if (popLink) return (
-            /*#__PURE__*/
-            _react["default"].createElement("a", {
-              key: item,
-              href: item,
-              target: "_blank",
-              rel: "noreferrer noopener"
-            }, item)
-          );else return (
-            /*#__PURE__*/
-            _react["default"].createElement("a", {
-              key: item,
-              href: item
-            }, item)
-          );
+          if (popLink) return _react["default"].createElement("a", {
+            key: item,
+            href: item,
+            target: "_blank",
+            rel: "noreferrer noopener"
+          }, item);else return _react["default"].createElement("a", {
+            key: item,
+            href: item
+          }, item);
         } else {
           // TODO: more comprehensive regexp url validator needed, look at: https://stackoverflow.com/a/5717133
           // Is a URL. Check if we should render it as a link/uri.
@@ -1113,42 +945,27 @@ function (_React$PureComponent2) {
           var schemaPropertyFormat = schemaProperty && typeof schemaProperty.format === 'string' && schemaProperty.format.toLowerCase() || null;
 
           if (schemaPropertyFormat && ['uri', 'url'].indexOf(schemaPropertyFormat) > -1 && item.slice(0, 4) === 'http') {
-            return (
-              /*#__PURE__*/
-              _react["default"].createElement("a", {
-                key: item,
-                href: item,
-                target: "_blank",
-                rel: "noreferrer noopener"
-              }, item)
-            );
+            return _react["default"].createElement("a", {
+              key: item,
+              href: item,
+              target: "_blank",
+              rel: "noreferrer noopener"
+            }, item);
           } else {
-            return (
-              /*#__PURE__*/
-              _react["default"].createElement("span", null, termTransformFxn(keyPrefix, item))
-            );
+            return _react["default"].createElement("span", null, termTransformFxn(keyPrefix, item));
           }
         }
       } else if (typeof item === 'number') {
-        return (
-          /*#__PURE__*/
-          _react["default"].createElement("span", null, termTransformFxn(keyPrefix, item))
-        );
+        return _react["default"].createElement("span", null, termTransformFxn(keyPrefix, item));
       } else if (typeof item === 'boolean') {
-        return (
-          /*#__PURE__*/
-          _react["default"].createElement("span", {
-            style: {
-              'textTransform': 'capitalize'
-            }
-          }, item + '')
-        );
+        return _react["default"].createElement("span", {
+          style: {
+            'textTransform': 'capitalize'
+          }
+        }, item + '');
       }
 
-      return (
-        /*#__PURE__*/
-        _react["default"].createElement("span", null, item)
-      ); // Fallback
+      return _react["default"].createElement("span", null, item); // Fallback
     }
   }, {
     key: "columnDefinitions",
@@ -1188,7 +1005,7 @@ function (_React$PureComponent2) {
 
     _classCallCheck(this, Detail);
 
-    _this4 = _super3.call(this, props);
+    _this4 = _possibleConstructorReturn(this, _getPrototypeOf(Detail).call(this, props));
     _this4.renderDetailRow = _this4.renderDetailRow.bind(_assertThisInitialized(_this4));
     _this4.memoized = {
       columnDefinitions: (0, _memoizeOne["default"])(Detail.columnDefinitions),
@@ -1207,20 +1024,17 @@ function (_React$PureComponent2) {
           columnDefinitions = _this$props3.columnDefinitions,
           termTransformFxn = _this$props3.termTransformFxn;
       var colDefs = this.memoized.columnDefinitions(context, schemas, columnDefinitions);
-      return (
-        /*#__PURE__*/
-        _react["default"].createElement(DetailRow, {
-          key: key,
-          label: Detail.formKey(colDefs, key),
-          item: context[key],
-          popLink: popLink,
-          "data-key": key,
-          itemType: context['@type'] && context['@type'][0],
-          columnDefinitions: colDefs,
-          termTransformFxn: termTransformFxn,
-          schemas: schemas
-        })
-      );
+      return _react["default"].createElement(DetailRow, {
+        key: key,
+        label: Detail.formKey(colDefs, key),
+        item: context[key],
+        popLink: popLink,
+        "data-key": key,
+        itemType: context['@type'] && context['@type'][0],
+        columnDefinitions: colDefs,
+        termTransformFxn: termTransformFxn,
+        schemas: schemas
+      });
     }
   }, {
     key: "render",
@@ -1236,18 +1050,13 @@ function (_React$PureComponent2) {
           persistentKeys = _this$memoized$genera.persistentKeys,
           collapsibleKeys = _this$memoized$genera.collapsibleKeys;
 
-      return (
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: "overflow-hidden"
-        },
-        /*#__PURE__*/
-        _react["default"].createElement(_PartialList.PartialList, {
-          persistent: _underscore["default"].map(persistentKeys, this.renderDetailRow),
-          collapsible: _underscore["default"].map(collapsibleKeys, this.renderDetailRow),
-          open: open
-        }))
-      );
+      return _react["default"].createElement("div", {
+        className: "overflow-hidden"
+      }, _react["default"].createElement(_PartialList.PartialList, {
+        persistent: _underscore["default"].map(persistentKeys, this.renderDetailRow),
+        collapsible: _underscore["default"].map(collapsibleKeys, this.renderDetailRow),
+        open: open
+      }));
     }
   }]);
 
@@ -1285,12 +1094,9 @@ _defineProperty(Detail, "defaultProps", {
     },
     'subscriptions.url': {
       'render': function render(value) {
-        return (
-          /*#__PURE__*/
-          _react["default"].createElement("a", {
-            href: '/search/' + value
-          }, "View Results")
-        );
+        return _react["default"].createElement("a", {
+          href: '/search/' + value
+        }, "View Results");
       },
       'title': "Link",
       'description': "Link to results matching subscription query."
@@ -1316,12 +1122,9 @@ _defineProperty(Detail, "defaultProps", {
       'title': "E-Mail",
       'render': function render(value) {
         if (typeof value === 'string' && value.indexOf('@') > -1) {
-          return (
-            /*#__PURE__*/
-            _react["default"].createElement("a", {
-              href: 'mailto:' + value
-            }, value)
-          );
+          return _react["default"].createElement("a", {
+            href: 'mailto:' + value
+          }, value);
         }
 
         return value;
@@ -1337,40 +1140,26 @@ var ToggleJSONButton = _react["default"].memo(function (_ref3) {
   var onClick = _ref3.onClick,
       showingJSON = _ref3.showingJSON,
       className = _ref3.className;
-  return (
-    /*#__PURE__*/
-    _react["default"].createElement("button", {
-      type: "button",
-      className: "btn btn-block btn-outline-secondary",
-      onClick: onClick
-    }, showingJSON ?
-    /*#__PURE__*/
-    _react["default"].createElement(_react["default"].Fragment, null,
-    /*#__PURE__*/
-    _react["default"].createElement("i", {
-      className: "icon fas icon-fw icon-list"
-    }), " View as List") :
-    /*#__PURE__*/
-    _react["default"].createElement(_react["default"].Fragment, null,
-    /*#__PURE__*/
-    _react["default"].createElement("i", {
-      className: "icon fas icon-fw icon-code"
-    }), " View as JSON"))
-  );
+  return _react["default"].createElement("button", {
+    type: "button",
+    className: "btn btn-block btn-outline-secondary",
+    onClick: onClick
+  }, showingJSON ? _react["default"].createElement(_react["default"].Fragment, null, _react["default"].createElement("i", {
+    className: "icon fas icon-fw icon-list"
+  }), " View as List") : _react["default"].createElement(_react["default"].Fragment, null, _react["default"].createElement("i", {
+    className: "icon fas icon-fw icon-code"
+  }), " View as JSON"));
 });
 
 var SeeMoreRowsButton = _react["default"].memo(function (_ref4) {
   var onClick = _ref4.onClick,
       collapsed = _ref4.collapsed,
       className = _ref4.className;
-  return (
-    /*#__PURE__*/
-    _react["default"].createElement("button", {
-      type: "button",
-      className: "btn btn-block btn-outline-secondary",
-      onClick: onClick
-    }, collapsed ? "See advanced information" : "Hide")
-  );
+  return _react["default"].createElement("button", {
+    type: "button",
+    className: "btn btn-block btn-outline-secondary",
+    onClick: onClick
+  }, collapsed ? "See advanced information" : "Hide");
 });
 /**
  * A list of properties which belong to Item shown by ItemView.
@@ -1387,35 +1176,19 @@ var ItemDetailList =
 function (_React$PureComponent3) {
   _inherits(ItemDetailList, _React$PureComponent3);
 
-  var _super4 = _createSuper(ItemDetailList);
-
   _createClass(ItemDetailList, null, [{
     key: "getTabObject",
     value: function getTabObject(props) {
       return {
-        tab:
-        /*#__PURE__*/
-        _react["default"].createElement("span", null,
-        /*#__PURE__*/
-        _react["default"].createElement("i", {
+        tab: _react["default"].createElement("span", null, _react["default"].createElement("i", {
           className: "icon fas icon-list icon-fw"
         }), " Details"),
         key: 'details',
-        content:
-        /*#__PURE__*/
-        _react["default"].createElement("div", null,
-        /*#__PURE__*/
-        _react["default"].createElement("h3", {
+        content: _react["default"].createElement("div", null, _react["default"].createElement("h3", {
           className: "tab-section-title"
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("span", null, "Details")),
-        /*#__PURE__*/
-        _react["default"].createElement("hr", {
+        }, _react["default"].createElement("span", null, "Details")), _react["default"].createElement("hr", {
           className: "tab-section-title-horiz-divider mb-05"
-        }),
-        /*#__PURE__*/
-        _react["default"].createElement(ItemDetailList, props))
+        }), _react["default"].createElement(ItemDetailList, props))
       };
     }
   }]);
@@ -1425,7 +1198,7 @@ function (_React$PureComponent3) {
 
     _classCallCheck(this, ItemDetailList);
 
-    _this5 = _super4.call(this, props);
+    _this5 = _possibleConstructorReturn(this, _getPrototypeOf(ItemDetailList).call(this, props));
     _this5.handleToggleJSON = _this5.handleToggleJSON.bind(_assertThisInitialized(_this5));
     _this5.handleToggleCollapsed = _this5.handleToggleCollapsed.bind(_assertThisInitialized(_this5));
     _this5.state = {
@@ -1484,29 +1257,15 @@ function (_React$PureComponent3) {
       var body;
 
       if (showingJSON) {
-        body =
-        /*#__PURE__*/
-        _react["default"].createElement(_react["default"].Fragment, null,
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
+        body = _react["default"].createElement(_react["default"].Fragment, null, _react["default"].createElement("div", {
           className: "json-tree-wrapper"
-        },
-        /*#__PURE__*/
-        _react["default"].createElement(_reactJsonTree["default"], {
+        }, _react["default"].createElement(_reactJsonTree["default"], {
           data: context
-        })),
-        /*#__PURE__*/
-        _react["default"].createElement("br", null),
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
+        })), _react["default"].createElement("br", null), _react["default"].createElement("div", {
           className: "row"
-        },
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
+        }, _react["default"].createElement("div", {
           className: "col-12 col-sm-6"
-        },
-        /*#__PURE__*/
-        _react["default"].createElement(ToggleJSONButton, {
+        }, _react["default"].createElement(ToggleJSONButton, {
           onClick: this.handleToggleJSON,
           showingJSON: showingJSON
         }))));
@@ -1520,65 +1279,42 @@ function (_React$PureComponent3) {
         if (hideButtons) {
           buttonsRow = null;
         } else if (!showJSONButton) {
-          buttonsRow =
-          /*#__PURE__*/
-          _react["default"].createElement("div", {
+          buttonsRow = _react["default"].createElement("div", {
             className: "row"
-          },
-          /*#__PURE__*/
-          _react["default"].createElement("div", {
+          }, _react["default"].createElement("div", {
             className: "col-12"
-          },
-          /*#__PURE__*/
-          _react["default"].createElement(SeeMoreRowsButton, {
+          }, _react["default"].createElement(SeeMoreRowsButton, {
             onClick: this.handleToggleCollapsed,
             collapsed: collapsed
           })));
         } else {
-          buttonsRow =
-          /*#__PURE__*/
-          _react["default"].createElement("div", {
+          buttonsRow = _react["default"].createElement("div", {
             className: "row"
-          },
-          /*#__PURE__*/
-          _react["default"].createElement("div", {
+          }, _react["default"].createElement("div", {
             className: "col-6"
-          },
-          /*#__PURE__*/
-          _react["default"].createElement(SeeMoreRowsButton, {
+          }, _react["default"].createElement(SeeMoreRowsButton, {
             onClick: this.handleToggleCollapsed,
             collapsed: collapsed
-          })),
-          /*#__PURE__*/
-          _react["default"].createElement("div", {
+          })), _react["default"].createElement("div", {
             className: "col-6"
-          },
-          /*#__PURE__*/
-          _react["default"].createElement(ToggleJSONButton, {
+          }, _react["default"].createElement(ToggleJSONButton, {
             onClick: this.handleToggleJSON,
             showingJSON: showingJSON
           })));
         }
 
-        body =
-        /*#__PURE__*/
-        _react["default"].createElement(_react["default"].Fragment, null,
-        /*#__PURE__*/
-        _react["default"].createElement(Detail, _extends({}, this.props, {
+        body = _react["default"].createElement(_react["default"].Fragment, null, _react["default"].createElement(Detail, _extends({}, this.props, {
           open: !isCollapsed,
           columnDefinitions: colDefs
         })), buttonsRow);
       }
 
-      return (
-        /*#__PURE__*/
-        _react["default"].createElement("div", {
-          className: "item-page-detail",
-          style: typeof minHeight === 'number' ? {
-            minHeight: minHeight
-          } : null
-        }, body)
-      );
+      return _react["default"].createElement("div", {
+        className: "item-page-detail",
+        style: typeof minHeight === 'number' ? {
+          minHeight: minHeight
+        } : null
+      }, body);
     }
   }]);
 

--- a/src/components/forms/SubmissionView.js
+++ b/src/components/forms/SubmissionView.js
@@ -362,7 +362,7 @@ export default class SubmissionView extends React.PureComponent{
      * lookup even if applicable and move right to alias selection.
      */
     initCreateObj(ambiguousType, ambiguousIdx, creatingLink, init=false, parentField=null){
-        console.log("calling initCreateObj with:", ...arguments);
+        // console.log("calling initCreateObj with:", ...arguments);
         const { schemas } = this.props;
         const itemTypeHierarchy = schemaTransforms.schemasToItemTypeHierarchy(schemas);
         // check to see if we have an ambiguous linkTo type.
@@ -569,7 +569,7 @@ export default class SubmissionView extends React.PureComponent{
      * @param {Object} extraState - Additional state to set upon completion.
      */
     createObj(type, newIdx, newLink, alias, extraState={}){
-        console.log("CREATEOBJ", ...arguments);
+        // console.log("CREATEOBJ", ...arguments);
         const { errorCount } = this.state;
 
         // get rid of any hanging errors
@@ -649,7 +649,7 @@ export default class SubmissionView extends React.PureComponent{
      * existing object amounts to removing it from keyHierarchy.
      */
     removeObj(keyToRemove){
-        console.log("calling removeObj with keyToRemove=", keyToRemove);
+        // console.log("calling removeObj with keyToRemove=", keyToRemove);
         this.setState(function({ keyContext, keyValid, keyTypes, keyComplete, keyLinkBookmarks, keyLinks, roundTwoKeys, keyHierarchy }){
             const contextCopy = object.deepClone(keyContext);
             const validCopy = object.deepClone(keyValid);
@@ -912,8 +912,8 @@ export default class SubmissionView extends React.PureComponent{
     }
 
     realPostNewContext(e){
-        console.log("real posting new context");
-        console.log("submitting object with currkey: ", this.state.currKey);
+        // console.log("real posting new context");
+        // console.log("submitting object with currkey: ", this.state.currKey);
         e.preventDefault();
         this.submitObject(this.state.currKey);
     }
@@ -1250,7 +1250,7 @@ export default class SubmissionView extends React.PureComponent{
                         // if not submitting the principal object, update context and hierarchy
                         if (inKey !== 0) {
                             const { splitField, arrayIdx } = findFieldFromContext(contextCopy[parentKey], typesCopy[parentKey], schemas, inKey, responseData['@type']);
-                            console.log('Results from findFieldFromContext', splitField, arrayIdx);
+                            // console.log('Results from findFieldFromContext', splitField, arrayIdx);
 
                             modifyContextInPlace(splitField, contextCopy[parentKey], arrayIdx, "linked object", submitted_at_id);
                             replaceInHierarchy(hierCopy, inKey, submitted_at_id); // Modifies hierCopy in place.
@@ -1303,9 +1303,9 @@ export default class SubmissionView extends React.PureComponent{
                                 stateToSet.keyValid[parentKey] = newParentValidState;
                             }
 
-                            console.log("updating state with stateToSet: ", stateToSet);
-                            console.log("keyDisplay, ", keyDisplay);
-                            console.log("inKey: ", inKey);
+                            // console.log("updating state with stateToSet: ", stateToSet);
+                            // console.log("keyDisplay, ", keyDisplay);
+                            // console.log("inKey: ", inKey);
 
                             alert(keyDisplay[inKey] + ' was successfully submitted.');
 
@@ -1325,7 +1325,7 @@ export default class SubmissionView extends React.PureComponent{
                 submitProcessContd(myLab, myAward);
             });
         } else {
-            console.log("submitting process continued");
+            // console.log("submitting process continued");
             submitProcessContd();
         }
     }
@@ -1974,32 +1974,32 @@ class IndividualObjectView extends React.Component {
             }
         }
         if (Array.isArray(pointer[splitFieldLeaf]) && fieldType !== 'array'){
-            console.log("found an array, ", pointer[splitFieldLeaf]);
+            // console.log("found an array, ", pointer[splitFieldLeaf]);
             // move pointer into array
             pointer = pointer[splitFieldLeaf];
-            console.log("pointer is now: ", pointer);
+            // console.log("pointer is now: ", pointer);
             prevValue = pointer[arrayIdx[arrayIdxPointer]];
-            console.log("prevValue is now:", prevValue);
+            // console.log("prevValue is now:", prevValue);
             if (value === null){ // delete this array itemfieldType
-                console.log("what is value?", value);
-                console.log("pointer presplice", pointer);
+                // console.log("what is value?", value);
+                // console.log("pointer presplice", pointer);
                 pointer.splice(arrayIdx[arrayIdxPointer], 1);
-                console.log("pointer postsplice", pointer);
+                // console.log("pointer postsplice", pointer);
             } else {
-                console.log("arrayIdx for pointer", arrayIdx[arrayIdxPointer]);
+                // console.log("arrayIdx for pointer", arrayIdx[arrayIdxPointer]);
                 pointer[arrayIdx[arrayIdxPointer]] = value;
             }
         } else { // value we're trying to set is not inside an array at this point
             prevValue = pointer[splitFieldLeaf];
-            console.log("prevValue is now:", prevValue);
+            // console.log("prevValue is now:", prevValue);
             pointer[splitFieldLeaf] = value;
         }
         /* modifyContextInPlace can replace everything up until this point... need to update var names, though */
 
-        console.log("value and previousValue, ", value, prevValue);
-        console.log("modifyNewContext II", value, currContext);
+        // console.log("value and previousValue, ", value, prevValue);
+        // console.log("modifyNewContext II", value, currContext);
         if ((value === null || prevValue !== null) && (fieldType === 'linked object' || fieldType === "existing linked object" || fieldType === 'new linked object')){
-            console.log("removing obj ", prevValue);
+            // console.log("removing obj ", prevValue);
             removeObj(prevValue);
         }
 
@@ -2175,14 +2175,7 @@ class IndividualObjectView extends React.Component {
     /** Exit out of the selection process and clean up state */
     selectCancel(previousValue){
         var { selectField, selectArrayIdx } = this.state;
-        var { keyContext, currKey } = this.props;
 
-        console.log("previous value", previousValue);
-
-        console.log("curr value", keyContext[currKey][selectField]);
-
-        console.log("this.state", this.state);
-        console.log("this.props", this.props);
         this.modifyNewContext(selectField, previousValue || null, 'existing linked object', null, selectArrayIdx);
         this.setState({ 'selectType': null, 'selectField': null, 'selectArrayIdx': null });
     }

--- a/src/components/forms/SubmissionView.js
+++ b/src/components/forms/SubmissionView.js
@@ -65,10 +65,9 @@ export default class SubmissionView extends React.PureComponent{
         if (keyHierarchy === null) return 0;
         var validationReturn = 1;
         _.keys(keyHierarchy).forEach(function(key, index){
-            if(!isNaN(key)){
-                if (!keyComplete[key] && keyContext[key]){
-                    validationReturn = 0;
-                }
+            // If key is a number, item has not been submitted yet... see note below
+            if(!isNaN(key)) { // NOTE: as of SAYTAJAX, ONLY unsubmitted items are stored with numeric keys
+                validationReturn = 0;
             }
         });
         return validationReturn;
@@ -1298,9 +1297,15 @@ export default class SubmissionView extends React.PureComponent{
                                 this.setState(stateToSet);
                             }
                         } else {
+                            // Check if parent validation state will change based on current submission... update that alongside rest of state, if so
+                            const newParentValidState = SubmissionView.findValidationState(parentKey, stateToSet.keyHierarchy, stateToSet.keyContext, stateToSet.keyComplete);
+                            if (newParentValidState !== stateToSet.keyValid[parentKey]) {
+                                stateToSet.keyValid[parentKey] = newParentValidState;
+                            }
+
                             console.log("updating state with stateToSet: ", stateToSet);
                             console.log("keyDisplay, ", keyDisplay);
-                            console.log("inKey: , ", inKey);
+                            console.log("inKey: ", inKey);
 
                             alert(keyDisplay[inKey] + ' was successfully submitted.');
 
@@ -2098,8 +2103,7 @@ class IndividualObjectView extends React.Component {
         //     atIds=${atIds},
         //     customSelectField=${customSelectField},
         //     customSelectType=${customSelectType},
-        //     customArrayIdx=${customArrayIdx},
-        //     valueToReplace=${valueToReplace}`);
+        //     customArrayIdx=${customArrayIdx}`);
         const { currContext } = this.props;
         const {
             selectField: stateSelectField,

--- a/src/components/forms/SubmissionView.js
+++ b/src/components/forms/SubmissionView.js
@@ -1974,20 +1974,29 @@ class IndividualObjectView extends React.Component {
             }
         }
         if (Array.isArray(pointer[splitFieldLeaf]) && fieldType !== 'array'){
+            console.log("found an array, ", pointer[splitFieldLeaf]);
             // move pointer into array
             pointer = pointer[splitFieldLeaf];
+            console.log("pointer is now: ", pointer);
             prevValue = pointer[arrayIdx[arrayIdxPointer]];
+            console.log("prevValue is now:", prevValue);
             if (value === null){ // delete this array itemfieldType
+                console.log("what is value?", value);
+                console.log("pointer presplice", pointer);
                 pointer.splice(arrayIdx[arrayIdxPointer], 1);
+                console.log("pointer postsplice", pointer);
             } else {
+                console.log("arrayIdx for pointer", arrayIdx[arrayIdxPointer]);
                 pointer[arrayIdx[arrayIdxPointer]] = value;
             }
         } else { // value we're trying to set is not inside an array at this point
             prevValue = pointer[splitFieldLeaf];
+            console.log("prevValue is now:", prevValue);
             pointer[splitFieldLeaf] = value;
         }
         /* modifyContextInPlace can replace everything up until this point... need to update var names, though */
 
+        console.log("value and previousValue, ", value, prevValue);
         console.log("modifyNewContext II", value, currContext);
         if ((value === null || prevValue !== null) && (fieldType === 'linked object' || fieldType === "existing linked object" || fieldType === 'new linked object')){
             console.log("removing obj ", prevValue);
@@ -2164,9 +2173,17 @@ class IndividualObjectView extends React.Component {
     }
 
     /** Exit out of the selection process and clean up state */
-    selectCancel(e){
+    selectCancel(previousValue){
         var { selectField, selectArrayIdx } = this.state;
-        this.modifyNewContext(selectField, null, 'existing linked object', null, selectArrayIdx);
+        var { keyContext, currKey } = this.props;
+
+        console.log("previous value", previousValue);
+
+        console.log("curr value", keyContext[currKey][selectField]);
+
+        console.log("this.state", this.state);
+        console.log("this.props", this.props);
+        this.modifyNewContext(selectField, previousValue || null, 'existing linked object', null, selectArrayIdx);
         this.setState({ 'selectType': null, 'selectField': null, 'selectArrayIdx': null });
     }
 

--- a/src/components/forms/components/LinkToSelector.js
+++ b/src/components/forms/components/LinkToSelector.js
@@ -84,8 +84,6 @@ export class LinkToSelector extends React.PureComponent {
         this.setChildWindowMessageHandler   = this.setChildWindowMessageHandler.bind(this);
         this.handleChildWindowMessage       = this.handleChildWindowMessage.bind(this);
         this.receiveData                    = this.receiveData.bind(this);
-
-        console.log("LinkToSelector value", props.value);
     }
 
     componentDidMount(){
@@ -220,7 +218,6 @@ export class LinkToSelector extends React.PureComponent {
         }
         if (eventType === 'fourfrontcancelclick') {
             this.cleanChildWindow();
-            console.log("cancel click occurred... value:", value);
             onCloseChildWindow(value);
         }
 
@@ -258,7 +255,6 @@ export class LinkToSelector extends React.PureComponent {
      * @param {Array} items - array of {id:ID of selected Item, if any, json:JSON of selected Item, if present (NOT GUARANTEED TO BE PROVIDED)} object
      */
     receiveData(items) {
-        console.log("items, ", items);
         this.cleanChildWindow();
         this.props.onSelect(items, true);
     }

--- a/src/components/forms/components/LinkToSelector.js
+++ b/src/components/forms/components/LinkToSelector.js
@@ -46,7 +46,7 @@ export class LinkToSelector extends React.PureComponent {
             'style'             : PropTypes.string
         }),
         /** Optional callback called with no params when child window is closed. Could/should unset `props.isSelecting`. */
-        'onCloseChildWindow': PropTypes.func,
+        'onCloseChildWindow': PropTypes.func, // When used with SV, will generally be the IndvObject.selectCancel method
         /** If true, then allows to drag & drop Item to window */
         'enableWindowDrop'  : PropTypes.bool.isRequired,
         /** Text content of message filling window when being dragged over */
@@ -84,6 +84,8 @@ export class LinkToSelector extends React.PureComponent {
         this.setChildWindowMessageHandler   = this.setChildWindowMessageHandler.bind(this);
         this.handleChildWindowMessage       = this.handleChildWindowMessage.bind(this);
         this.receiveData                    = this.receiveData.bind(this);
+
+        console.log("LinkToSelector value", props.value);
     }
 
     componentDidMount(){
@@ -107,7 +109,7 @@ export class LinkToSelector extends React.PureComponent {
             return;
         }
 
-        const { searchURL, onCloseChildWindow } = this.props;
+        const { searchURL, value, onCloseChildWindow } = this.props;
         const { isSelecting: pastInSelection } = pastProps;
         const { isSelecting: nowInSelection } = nextProps;
         const hasUnsetInSelection = pastInSelection && !nowInSelection;
@@ -157,7 +159,7 @@ export class LinkToSelector extends React.PureComponent {
                     delete this.childWindowClosedInterval;
                     if (this && this.windowObjectReference && this.windowObjectReference.closed){
                         if (typeof onCloseChildWindow === 'function'){
-                            onCloseChildWindow();
+                            onCloseChildWindow(value);
                         }
                     }
                     this.cleanChildWindowEventHandlers();
@@ -188,6 +190,7 @@ export class LinkToSelector extends React.PureComponent {
      * @param {MessageEvent} evt - See https://developer.mozilla.org/en-US/docs/Web/API/MessageEvent.
      */
     handleChildWindowMessage(evt){
+        const { value, onCloseChildWindow } = this.props;
         const eventType = evt && evt.data && evt.data.eventType;
 
         if (!eventType) {
@@ -217,7 +220,8 @@ export class LinkToSelector extends React.PureComponent {
         }
         if (eventType === 'fourfrontcancelclick') {
             this.cleanChildWindow();
-            this.props.onCloseChildWindow();
+            console.log("cancel click occurred... value:", value);
+            onCloseChildWindow(value);
         }
 
         // If we have a `props.childWindowAlert`, show it once child window lets us know it has initialized it JS environment.

--- a/src/components/forms/components/SearchAsYouTypeAjax.js
+++ b/src/components/forms/components/SearchAsYouTypeAjax.js
@@ -265,7 +265,7 @@ export function SubmissionViewSearchAsYouTypeAjax(props){
         <div className="d-flex flex-wrap">
             <SearchAsYouTypeAjax showTips={true} {...{ value, onChange, baseHref, optionRenderFunction,
                 fieldsToRequest, titleRenderFunction, selectComplete }} {...props} />
-            <LinkedObj key="linked-item" {...props} {...{ baseHref }} />
+            <LinkedObj key="linked-item" {...props} {...{ value, baseHref }} />
         </div>
     );
 }
@@ -542,7 +542,8 @@ export class LinkedObj extends React.PureComponent {
             currType,
             nestedField,
             isMultiSelect,
-            baseHref
+            baseHref,
+            value
         } = this.props;
 
         const itemType = schema.linkTo;
@@ -560,7 +561,7 @@ export class LinkedObj extends React.PureComponent {
         }
 
         return <LinkToSelector isSelecting onSelect={this.handleFinishSelectItem} onCloseChildWindow={selectCancel}
-            childWindowAlert={this.childWindowAlert} dropMessage={dropMessage} searchURL={searchURL} />;
+            childWindowAlert={this.childWindowAlert} {...{ value, dropMessage, searchURL }} />;
     }
 
 


### PR DESCRIPTION
I ran into a bug in SubmissionView state that was causing the final create new linked object test in my SAYTAJAX cypress tests to fail. Apparently, we weren't checking/updating the validation state of the parent item anywhere upon submission of a newly created item. (I still sort of can't believe this? Was this maybe implemented at some point previously, and we accidentally deleted it? Or do you happen to know of something like this happening later in the flow of the 'create new linked item'-related methods?) 

Anyway, this resulted in there being occasions where the parent item had no more incomplete child objects, but was still unable to be validated (validate button disabled). So basically, I added a check before the state is set to see if the parent item's validation status would be changed based on the submission of the current object, and under the circumstances in which it is, added that change to the state update.

But that didn't actually work because at some point during the creation of SAYTAJAX we had to change the way the keys for recently submitted items were stored in keyHierarchy (instead of using the temporary index, newly submitted items are now keyed with their @id). I don't remember _exactly_ we made this change; maybe you can remind me. But it had the side effect of making the findValidationState function basically useless, since the conditions it was using to determine whether or not an item was complete were no longer consistent with the rest of the code.

This PR aims to fix both of those problems, and should have validation working properly again when new items are created. Although, if you could, please also test some other cases, like adding via advanced search, etc. I feel like it's too easy to break things in this view, and adv search is one area where we severely lack test coverage, unfortunately. Thanks.