### PR TITLE
Render linkTo Objects[] as link elements in table cells

### DIFF
--- a/es/components/browse/components/table-commons/ResultRowColumnBlockValue.js
+++ b/es/components/browse/components/table-commons/ResultRowColumnBlockValue.js
@@ -129,9 +129,28 @@ function (_React$Component) {
         return null;
       }
 
-      if (typeof termTransformFxn === "function") {
+      if (_typeof(uniquedValues[0]) === "object" && uniquedValues[0]["@id"] && typeof termTransformFxn === "function") {
+        // If LinkTo Item(s), return array of JSX elements (spans) which wrap links (assuming is output from termTransformFxn).
+        var uniquedLinkToItems = _underscore["default"].uniq(uniquedValues, false, "@id");
+
+        return uniquedLinkToItems.map(function (v, i) {
+          var transformedValue = termTransformFxn(field, v, true); // Likely a link element.
+
+          if (i === 0 && uniquedLinkToItems.length === 1) {
+            return transformedValue;
+          }
+
+          return (
+            /*#__PURE__*/
+            _react["default"].createElement("span", {
+              key: i,
+              className: "link-wrapper"
+            }, i > 0 ? ", " : null, transformedValue)
+          );
+        });
+      } else if (typeof termTransformFxn === "function") {
         return uniquedValues.map(function (v) {
-          return termTransformFxn(field, v, false);
+          return termTransformFxn(field, v, false); // Don't allow JSX element/component(s) because joining w. ", ".
         }).join(', '); // Most often will be just 1 value in set/array.
       } else {
         console.warn("No termTransformFxn supplied.");
@@ -205,7 +224,7 @@ function (_React$Component) {
         _react["default"].createElement("small", {
           className: "value text-center"
         }, "-");
-      } else if (_react["default"].isValidElement(value) && value.type === "a") {
+      } else if (_react["default"].isValidElement(value) && value.type === "a" || Array.isArray(value) && _react["default"].isValidElement(value[0]) && (value[0].type === "a" || value[0].props.className === "link-wrapper")) {
         // We let other columnRender funcs define their `value` container (if any)
         // But if is link, e.g. from termTransformFxn, then wrap it to center it.
         value =

--- a/es/components/browse/components/table-commons/ResultRowColumnBlockValue.js
+++ b/es/components/browse/components/table-commons/ResultRowColumnBlockValue.js
@@ -134,10 +134,10 @@ function (_React$Component) {
         var uniquedLinkToItems = _underscore["default"].uniq(uniquedValues, false, "@id");
 
         return uniquedLinkToItems.map(function (v, i) {
-          var transformedValue = termTransformFxn(field, v, true); // Likely a link element.
+          var transformedValue = termTransformFxn(field, v, true); // `allowJSXOutput=true` == likely a link element.
 
           if (i === 0 && uniquedLinkToItems.length === 1) {
-            return transformedValue;
+            return transformedValue; // Only 1 value, no need to wrap in <span>, {value}</span> to provide comma(s).
           }
 
           return (
@@ -150,7 +150,7 @@ function (_React$Component) {
         });
       } else if (typeof termTransformFxn === "function") {
         return uniquedValues.map(function (v) {
-          return termTransformFxn(field, v, false); // Don't allow JSX element/component(s) because joining w. ", ".
+          return termTransformFxn(field, v, false); // `allowJSXOutput=false` == don't allow JSX element/component(s) because joining w. ", ".
         }).join(', '); // Most often will be just 1 value in set/array.
       } else {
         console.warn("No termTransformFxn supplied.");

--- a/src/components/browse/components/table-commons/ResultRowColumnBlockValue.js
+++ b/src/components/browse/components/table-commons/ResultRowColumnBlockValue.js
@@ -51,9 +51,9 @@ export class ResultRowColumnBlockValue extends React.Component {
             // If LinkTo Item(s), return array of JSX elements (spans) which wrap links (assuming is output from termTransformFxn).
             const uniquedLinkToItems = _.uniq(uniquedValues, false, "@id");
             return uniquedLinkToItems.map(function(v, i){
-                const transformedValue = termTransformFxn(field, v, true); // Likely a link element.
+                const transformedValue = termTransformFxn(field, v, true); // `allowJSXOutput=true` == likely a link element.
                 if (i === 0 && uniquedLinkToItems.length === 1) {
-                    return transformedValue;
+                    return transformedValue; // Only 1 value, no need to wrap in <span>, {value}</span> to provide comma(s).
                 }
                 return (
                     <span key={i} className="link-wrapper">{ i > 0 ? ", " : null }{ transformedValue }</span>
@@ -61,7 +61,7 @@ export class ResultRowColumnBlockValue extends React.Component {
             });
         } else if (typeof termTransformFxn === "function") {
             return uniquedValues.map(function(v){
-                return termTransformFxn(field, v, false); // Don't allow JSX element/component(s) because joining w. ", ".
+                return termTransformFxn(field, v, false); // `allowJSXOutput=false` == don't allow JSX element/component(s) because joining w. ", ".
             }).join(', '); // Most often will be just 1 value in set/array.
         } else {
             console.warn("No termTransformFxn supplied.");

--- a/src/components/browse/components/table-commons/ResultRowColumnBlockValue.js
+++ b/src/components/browse/components/table-commons/ResultRowColumnBlockValue.js
@@ -47,9 +47,21 @@ export class ResultRowColumnBlockValue extends React.Component {
             return null;
         }
 
-        if (typeof termTransformFxn === "function") {
+        if (typeof uniquedValues[0] === "object" && uniquedValues[0]["@id"] && typeof termTransformFxn === "function") {
+            // If LinkTo Item(s), return array of JSX elements (spans) which wrap links (assuming is output from termTransformFxn).
+            const uniquedLinkToItems = _.uniq(uniquedValues, false, "@id");
+            return uniquedLinkToItems.map(function(v, i){
+                const transformedValue = termTransformFxn(field, v, true); // Likely a link element.
+                if (i === 0 && uniquedLinkToItems.length === 1) {
+                    return transformedValue;
+                }
+                return (
+                    <span key={i} className="link-wrapper">{ i > 0 ? ", " : null }{ transformedValue }</span>
+                );
+            });
+        } else if (typeof termTransformFxn === "function") {
             return uniquedValues.map(function(v){
-                return termTransformFxn(field, v, false);
+                return termTransformFxn(field, v, false); // Don't allow JSX element/component(s) because joining w. ", ".
             }).join(', '); // Most often will be just 1 value in set/array.
         } else {
             console.warn("No termTransformFxn supplied.");
@@ -114,7 +126,10 @@ export class ResultRowColumnBlockValue extends React.Component {
             value = <span className="value text-center">{ value }</span>;
         } else if (value === null){
             value = <small className="value text-center">-</small>;
-        } else if (React.isValidElement(value) && value.type === "a") {
+        } else if (
+            (React.isValidElement(value) && value.type === "a") ||
+            (Array.isArray(value) && React.isValidElement(value[0]) && (value[0].type === "a" || value[0].props.className === "link-wrapper"))
+        ) {
             // We let other columnRender funcs define their `value` container (if any)
             // But if is link, e.g. from termTransformFxn, then wrap it to center it.
             value = <span className="value text-center">{ value }</span>;


### PR DESCRIPTION
If have array of objects (linkTos) as value, then output array of link elements instead of ~ [Object object]. Should be self-explanatory from code. Output could look like, if change 4DN ExperimentSetTables.js defaultProps.columns `"experiments_in_set.biosample.biosource.individual.organism.name"` to `"experiments_in_set.biosample.biosource.individual.organism"`:

![](https://i.gyazo.com/20c43982c0b960232853ec4582f704f8.png)