### PR TITLE
SearchView & Related: Enabling aboveTableComponent etc.

### DIFF
--- a/es/components/browse/EmbeddedSearchView.js
+++ b/es/components/browse/EmbeddedSearchView.js
@@ -171,8 +171,10 @@ var EmbeddedSearchView = /*#__PURE__*/function (_React$PureComponent) {
           columns = _this$props$columns === void 0 ? null : _this$props$columns,
           hideColumns = _this$props.hideColumns,
           facets = _this$props.facets,
-          _this$props$showAbove = _this$props.showAboveTableControls,
-          showAboveTableControls = _this$props$showAbove === void 0 ? false : _this$props$showAbove,
+          _this$props$aboveTabl = _this$props.aboveTableComponent,
+          aboveTableComponent = _this$props$aboveTabl === void 0 ? null : _this$props$aboveTabl,
+          _this$props$aboveFace = _this$props.aboveFacetListComponent,
+          aboveFacetListComponent = _this$props$aboveFace === void 0 ? null : _this$props$aboveFace,
           _this$props$columnExt = _this$props.columnExtensionMap,
           columnExtensionMap = _this$props$columnExt === void 0 ? _tableCommons.basicColumnExtensionMap : _this$props$columnExt,
           _this$props$onLoad = _this$props.onLoad,
@@ -185,13 +187,14 @@ var EmbeddedSearchView = /*#__PURE__*/function (_React$PureComponent) {
           embeddedTableHeader = _this$props$embeddedT === void 0 ? null : _this$props$embeddedT,
           onClearFiltersVirtual = _this$props.onClearFiltersVirtual,
           isClearFiltersBtnVisible = _this$props.isClearFiltersBtnVisible,
-          passProps = _objectWithoutProperties(_this$props, ["href", "context", "currentAction", "searchHref", "navigate", "columns", "hideColumns", "facets", "showAboveTableControls", "columnExtensionMap", "onLoad", "filterFacetFxn", "filterColumnFxn", "windowWidth", "embeddedTableHeader", "onClearFiltersVirtual", "isClearFiltersBtnVisible"]); // If facets are null (hidden/excluded), set table col to be full width of container.
+          passProps = _objectWithoutProperties(_this$props, ["href", "context", "currentAction", "searchHref", "navigate", "columns", "hideColumns", "facets", "aboveTableComponent", "aboveFacetListComponent", "columnExtensionMap", "onLoad", "filterFacetFxn", "filterColumnFxn", "windowWidth", "embeddedTableHeader", "onClearFiltersVirtual", "isClearFiltersBtnVisible"]); // If facets are null (hidden/excluded), set table col to be full width of container.
 
 
       var tableColumnClassName = facets === null ? "col-12" : undefined; // Includes pass-through props like `maxHeight`, `hideFacets`, etc.
 
       var viewProps = _objectSpread(_objectSpread({}, passProps), {}, {
-        showAboveTableControls: showAboveTableControls,
+        aboveTableComponent: aboveTableComponent,
+        aboveFacetListComponent: aboveFacetListComponent,
         tableColumnClassName: tableColumnClassName
       });
 

--- a/es/components/browse/EmbeddedSearchView.js
+++ b/es/components/browse/EmbeddedSearchView.js
@@ -242,6 +242,7 @@ _defineProperty(EmbeddedSearchView, "propTypes", {
   'facets': _propTypes["default"].array,
   'separateSingleTermFacets': _propTypes["default"].bool.isRequired,
   'renderDetailPane': _propTypes["default"].func,
+  'detailPane': _propTypes["default"].element,
   'onLoad': _propTypes["default"].func,
   'hideFacets': _propTypes["default"].arrayOf(_propTypes["default"].string),
   'hideColumns': _propTypes["default"].arrayOf(_propTypes["default"].string),

--- a/es/components/browse/SearchView.js
+++ b/es/components/browse/SearchView.js
@@ -129,6 +129,7 @@ var SearchView = /*#__PURE__*/function (_React$PureComponent) {
       var _this$props = this.props,
           href = _this$props.href,
           context = _this$props.context,
+          showClearFiltersButton = _this$props.showClearFiltersButton,
           _this$props$schemas = _this$props.schemas,
           schemas = _this$props$schemas === void 0 ? null : _this$props$schemas,
           _this$props$currentAc = _this$props.currentAction,
@@ -142,7 +143,7 @@ var SearchView = /*#__PURE__*/function (_React$PureComponent) {
           columnExtensionMap = _this$props$columnExt === void 0 ? _tableCommons.basicColumnExtensionMap : _this$props$columnExt,
           placeholderReplacementFxn = _this$props.placeholderReplacementFxn,
           windowWidth = _this$props.windowWidth,
-          passProps = _objectWithoutProperties(_this$props, ["href", "context", "schemas", "currentAction", "facets", "navigate", "columns", "columnExtensionMap", "placeholderReplacementFxn", "windowWidth"]);
+          passProps = _objectWithoutProperties(_this$props, ["href", "context", "showClearFiltersButton", "schemas", "currentAction", "facets", "navigate", "columns", "columnExtensionMap", "placeholderReplacementFxn", "windowWidth"]);
 
       var contextFacets = context.facets; // All these controllers pass props down to their children.
       // So we don't need to be repetitive here; i.e. may assume 'context' is available
@@ -159,7 +160,8 @@ var SearchView = /*#__PURE__*/function (_React$PureComponent) {
 
       var controllersAndView = /*#__PURE__*/_react["default"].createElement(_WindowNavigationController.WindowNavigationController, _extends({
         href: href,
-        context: context
+        context: context,
+        showClearFiltersButton: showClearFiltersButton
       }, {
         navigate: propNavigate
       }), /*#__PURE__*/_react["default"].createElement(_tableCommons.ColumnCombiner, {
@@ -207,7 +209,9 @@ _defineProperty(SearchView, "propTypes", {
   'isFullscreen': _propTypes["default"].bool.isRequired,
   'toggleFullScreen': _propTypes["default"].func.isRequired,
   'separateSingleTermFacets': _propTypes["default"].bool.isRequired,
+  'detailPane': _propTypes["default"].element,
   'renderDetailPane': _propTypes["default"].func,
+  'showClearFiltersButton': _propTypes["default"].bool,
   'isOwnPage': _propTypes["default"].bool,
   'schemas': _propTypes["default"].object,
   'placeholderReplacementFxn': _propTypes["default"].func // Passed down to AboveSearchTablePanel StaticSection

--- a/es/components/browse/components/ControlsAndResults.js
+++ b/es/components/browse/components/ControlsAndResults.js
@@ -7,15 +7,7 @@ exports.ControlsAndResults = void 0;
 
 var _react = _interopRequireDefault(require("react"));
 
-var _propTypes = _interopRequireDefault(require("prop-types"));
-
-var _url = _interopRequireDefault(require("url"));
-
-var _underscore = _interopRequireDefault(require("underscore"));
-
 var _memoizeOne = _interopRequireDefault(require("memoize-one"));
-
-var _reactTooltip = _interopRequireDefault(require("react-tooltip"));
 
 var _misc = require("./../../util/misc");
 
@@ -142,7 +134,6 @@ var ControlsAndResults = /*#__PURE__*/function (_React$PureComponent) {
           termTransformFxn = _this$props2.termTransformFxn,
           rowHeight = _this$props2.rowHeight,
           separateSingleTermFacets = _this$props2.separateSingleTermFacets,
-          topLeftChildren = _this$props2.topLeftChildren,
           navigate = _this$props2.navigate,
           _this$props2$facetCol = _this$props2.facetColumnClassName,
           facetColumnClassName = _this$props2$facetCol === void 0 ? "col-12 col-sm-5 col-lg-4 col-xl-3" : _this$props2$facetCol,
@@ -156,6 +147,8 @@ var ControlsAndResults = /*#__PURE__*/function (_React$PureComponent) {
       }) : _this$props2$aboveFac,
           _this$props2$defaultO = _this$props2.defaultOpenIndices,
           defaultOpenIndices = _this$props2$defaultO === void 0 ? null : _this$props2$defaultO,
+          _this$props2$detailPa = _this$props2.detailPane,
+          detailPane = _this$props2$detailPa === void 0 ? null : _this$props2$detailPa,
           href = _this$props2.href,
           onFilter = _this$props2.onFilter,
           _this$props2$showClea = _this$props2.showClearFiltersButton,
@@ -209,20 +202,15 @@ var ControlsAndResults = /*#__PURE__*/function (_React$PureComponent) {
         removeFromBodyClassList: removeFromBodyClassList
       };
       var aboveTableControlsProps = {
-        // 'isFullscreen' & 'toggleFullScreen' are specific to 4DN's App.js, we could ideally refactor this out eventually.
-        // Perhaps in same way as 'topLeftChildren' is setup... food 4 thought.
         context: context,
         showTotalResults: showTotalResults,
         hiddenColumns: hiddenColumns,
         columnDefinitions: columnDefinitions,
         addHiddenColumn: addHiddenColumn,
         removeHiddenColumn: removeHiddenColumn,
-        isFullscreen: isFullscreen,
-        toggleFullScreen: toggleFullScreen,
         currentAction: currentAction,
         windowWidth: windowWidth,
-        windowHeight: windowHeight,
-        topLeftChildren: topLeftChildren
+        windowHeight: windowHeight
       };
       var extendedAboveTableComponent, extendedAboveFacetListComponent;
 
@@ -262,6 +250,7 @@ var ControlsAndResults = /*#__PURE__*/function (_React$PureComponent) {
         visibleColumnDefinitions: visibleColumnDefinitions,
         setColumnWidths: setColumnWidths,
         columnWidths: columnWidths,
+        detailPane: detailPane,
         isOwnPage: isOwnPage,
         sortBy: sortBy,
         sortColumn: sortColumn,

--- a/es/components/browse/components/ControlsAndResults.js
+++ b/es/components/browse/components/ControlsAndResults.js
@@ -148,8 +148,12 @@ var ControlsAndResults = /*#__PURE__*/function (_React$PureComponent) {
           facetColumnClassName = _this$props2$facetCol === void 0 ? "col-12 col-sm-5 col-lg-4 col-xl-3" : _this$props2$facetCol,
           _this$props2$tableCol = _this$props2.tableColumnClassName,
           tableColumnClassName = _this$props2$tableCol === void 0 ? "col-12 col-sm-7 col-lg-8 col-xl-9" : _this$props2$tableCol,
-          _this$props2$showAbov = _this$props2.showAboveTableControls,
-          showAboveTableControls = _this$props2$showAbov === void 0 ? true : _this$props2$showAbov,
+          _this$props2$aboveTab = _this$props2.aboveTableComponent,
+          aboveTableComponent = _this$props2$aboveTab === void 0 ? /*#__PURE__*/_react["default"].createElement(_AboveSearchViewTableControls.AboveSearchViewTableControls, null) : _this$props2$aboveTab,
+          _this$props2$aboveFac = _this$props2.aboveFacetListComponent,
+          aboveFacetListComponent = _this$props2$aboveFac === void 0 ? /*#__PURE__*/_react["default"].createElement("div", {
+        className: "above-results-table-row"
+      }) : _this$props2$aboveFac,
           _this$props2$defaultO = _this$props2.defaultOpenIndices,
           defaultOpenIndices = _this$props2$defaultO === void 0 ? null : _this$props2$defaultO,
           href = _this$props2.href,
@@ -204,20 +208,7 @@ var ControlsAndResults = /*#__PURE__*/function (_React$PureComponent) {
         addToBodyClassList: addToBodyClassList,
         removeFromBodyClassList: removeFromBodyClassList
       };
-      return /*#__PURE__*/_react["default"].createElement("div", {
-        className: "row search-view-controls-and-results",
-        "data-search-item-type": searchItemType,
-        "data-search-abstract-type": searchAbstractItemType
-      }, Array.isArray(facets) && facets.length ? /*#__PURE__*/_react["default"].createElement("div", {
-        className: facetColumnClassName
-      }, showAboveTableControls ?
-      /*#__PURE__*/
-      // temporary-ish
-      _react["default"].createElement("div", {
-        className: "above-results-table-row"
-      }) : null, /*#__PURE__*/_react["default"].createElement(_FacetList.FacetList, facetListProps)) : null, /*#__PURE__*/_react["default"].createElement("div", {
-        className: tableColumnClassName
-      }, showAboveTableControls ? /*#__PURE__*/_react["default"].createElement(_AboveSearchViewTableControls.AboveSearchViewTableControls, {
+      var aboveTableControlsProps = {
         // 'isFullscreen' & 'toggleFullScreen' are specific to 4DN's App.js, we could ideally refactor this out eventually.
         // Perhaps in same way as 'topLeftChildren' is setup... food 4 thought.
         context: context,
@@ -232,7 +223,35 @@ var ControlsAndResults = /*#__PURE__*/function (_React$PureComponent) {
         windowWidth: windowWidth,
         windowHeight: windowHeight,
         topLeftChildren: topLeftChildren
-      }) : null, /*#__PURE__*/_react["default"].createElement(_SearchResultTable.SearchResultTable, _extends({}, {
+      };
+      var extendedAboveTableComponent, extendedAboveFacetListComponent;
+
+      var extendChild = function (child) {
+        if (typeof child.type === "string") {
+          // Element, not component
+          return child;
+        }
+
+        return /*#__PURE__*/_react["default"].cloneElement(child, aboveTableControlsProps);
+      };
+
+      if (aboveTableComponent) {
+        extendedAboveTableComponent = _react["default"].Children.map(aboveTableComponent, extendChild);
+      }
+
+      if (aboveFacetListComponent) {
+        extendedAboveFacetListComponent = _react["default"].Children.map(aboveFacetListComponent, extendChild);
+      }
+
+      return /*#__PURE__*/_react["default"].createElement("div", {
+        className: "row search-view-controls-and-results",
+        "data-search-item-type": searchItemType,
+        "data-search-abstract-type": searchAbstractItemType
+      }, Array.isArray(facets) && facets.length ? /*#__PURE__*/_react["default"].createElement("div", {
+        className: facetColumnClassName
+      }, extendedAboveFacetListComponent, /*#__PURE__*/_react["default"].createElement(_FacetList.FacetList, facetListProps)) : null, /*#__PURE__*/_react["default"].createElement("div", {
+        className: tableColumnClassName
+      }, extendedAboveTableComponent, /*#__PURE__*/_react["default"].createElement(_SearchResultTable.SearchResultTable, _extends({}, {
         context: context,
         href: href,
         navigate: navigate,

--- a/es/components/browse/components/WindowNavigationController.js
+++ b/es/components/browse/components/WindowNavigationController.js
@@ -151,11 +151,12 @@ var WindowNavigationController = /*#__PURE__*/function (_React$PureComponent) {
     value: function render() {
       var _this$props3 = this.props,
           children = _this$props3.children,
-          passProps = _objectWithoutProperties(_this$props3, ["children"]);
+          propShowClearFiltersBtn = _this$props3.showClearFiltersButton,
+          passProps = _objectWithoutProperties(_this$props3, ["children", "showClearFiltersButton"]);
 
       var href = passProps.href,
           context = passProps.context;
-      var showClearFiltersButton = this.memoized.isClearFiltersBtnVisible(href, context || {});
+      var showClearFiltersButton = typeof propShowClearFiltersBtn === "boolean" ? propShowClearFiltersBtn : this.memoized.isClearFiltersBtnVisible(href, context || {});
 
       var propsToPass = _objectSpread(_objectSpread({}, passProps), {}, {
         showClearFiltersButton: showClearFiltersButton,

--- a/es/components/browse/components/table-commons/ColumnCombiner.js
+++ b/es/components/browse/components/table-commons/ColumnCombiner.js
@@ -140,7 +140,8 @@ var ColumnCombiner = /*#__PURE__*/function (_React$PureComponent) {
       // We want `defaultHiddenColumns` memoized separately from `columnDefinitions`
       // because `defaultHiddenColumns` change triggers reset in `ColumnCombiner`.
       // This is becaused `columnExtensionMap` may change more frequently than `columns`.
-      // e.g. in response to SelectedFiles' state.selectedFiles changing.
+      // e.g. in response to SelectedFiles' state.selectedFiles changing display_title column
+      // render func in portal-specific logic or `detailPane`, like-wise.
       getDefaultHiddenColumns: (0, _memoizeOne["default"])(defaultHiddenColumnMapFromColumns, function (_ref, _ref2) {
         var _ref3 = _slicedToArray(_ref, 1),
             nextColumns = _ref3[0];

--- a/es/components/browse/components/table-commons/HeadersRow.js
+++ b/es/components/browse/components/table-commons/HeadersRow.js
@@ -289,6 +289,7 @@ var HeadersRow = /*#__PURE__*/function (_React$PureComponent) {
       var _this$props3 = this.props,
           columnDefinitions = _this$props3.columnDefinitions,
           renderDetailPane = _this$props3.renderDetailPane,
+          detailPane = _this$props3.detailPane,
           _this$props3$sortColu = _this$props3.sortColumn,
           sortColumn = _this$props3$sortColu === void 0 ? null : _this$props3$sortColu,
           _this$props3$sortReve = _this$props3.sortReverse,
@@ -307,7 +308,7 @@ var HeadersRow = /*#__PURE__*/function (_React$PureComponent) {
       var leftOffset = 0 - tableContainerScrollLeft;
       var isSortable = typeof sortBy === "function";
       var isAdjustable = !!(typeof setColumnWidths === "function" && columnWidths);
-      var outerClassName = "search-headers-row" + (isAdjustable ? '' : ' non-adjustable') + (typeof renderDetailPane !== 'function' ? ' no-detail-pane' : '');
+      var outerClassName = "search-headers-row" + (isAdjustable ? '' : ' non-adjustable') + (typeof renderDetailPane !== 'function' && !detailPane ? ' no-detail-pane' : '');
       var commonProps = {
         sortByField: isSortable ? this.sortByField : null,
         // Disable sorting if no sortBy func.
@@ -385,6 +386,7 @@ _defineProperty(HeadersRow, "propTypes", {
     })
   })).isRequired,
   'mounted': _propTypes["default"].bool.isRequired,
+  'detailPane': _propTypes["default"].element,
   'renderDetailPane': _propTypes["default"].func,
   'width': _propTypes["default"].number,
   'defaultMinColumnWidth': _propTypes["default"].number,

--- a/src/components/browse/EmbeddedSearchView.js
+++ b/src/components/browse/EmbeddedSearchView.js
@@ -109,7 +109,9 @@ export class EmbeddedSearchView extends React.PureComponent {
             columns = null,
             hideColumns,
             facets,
-            showAboveTableControls = false, // Deprecated? Unused here? Will become deprecated for EmbeddedSearchView purposes at least probably.
+            // showAboveTableControls = false, // Deprecated? Unused here? Will become deprecated for EmbeddedSearchView purposes at least probably.
+            aboveTableComponent = null,         // Override default default to be null.
+            aboveFacetListComponent = null,     // Override default default to be null.
             columnExtensionMap = basicColumnExtensionMap,
             onLoad = null,
             filterFacetFxn: propFacetFilterFxn = null,
@@ -129,7 +131,7 @@ export class EmbeddedSearchView extends React.PureComponent {
         // If facets are null (hidden/excluded), set table col to be full width of container.
         const tableColumnClassName = facets === null ? "col-12" : undefined;
         // Includes pass-through props like `maxHeight`, `hideFacets`, etc.
-        const viewProps = { ...passProps, showAboveTableControls, tableColumnClassName };
+        const viewProps = { ...passProps, aboveTableComponent, aboveFacetListComponent, tableColumnClassName };
         const filterFacetFxn = propFacetFilterFxn || this.filterFacetFxn;
 
         return (

--- a/src/components/browse/EmbeddedSearchView.js
+++ b/src/components/browse/EmbeddedSearchView.js
@@ -43,6 +43,7 @@ export class EmbeddedSearchView extends React.PureComponent {
         'facets'        : PropTypes.array,
         'separateSingleTermFacets' : PropTypes.bool.isRequired,
         'renderDetailPane' : PropTypes.func,
+        'detailPane'    : PropTypes.element,
         'onLoad'        : PropTypes.func,
         'hideFacets'    : PropTypes.arrayOf(PropTypes.string),
         'hideColumns'    : PropTypes.arrayOf(PropTypes.string),
@@ -124,6 +125,7 @@ export class EmbeddedSearchView extends React.PureComponent {
             onClearFiltersVirtual,
             // Optional prop to override VirtualHrefController's own calculation of this.
             // Must be static function that accepts currentSearchHref as first parameter and original searchHref as second one.
+            // (On other hand, `SearchView` component accepts boolean `showClearFiltersButton`, as we have `context` etc available there.)
             isClearFiltersBtnVisible,
             ...passProps
         } = this.props;

--- a/src/components/browse/SearchView.js
+++ b/src/components/browse/SearchView.js
@@ -36,7 +36,9 @@ export class SearchView extends React.PureComponent {
         'isFullscreen'  : PropTypes.bool.isRequired,
         'toggleFullScreen' : PropTypes.func.isRequired,
         'separateSingleTermFacets' : PropTypes.bool.isRequired,
+        'detailPane'    : PropTypes.element,
         'renderDetailPane' : PropTypes.func,
+        'showClearFiltersButton' : PropTypes.bool,
         'isOwnPage'     : PropTypes.bool,
         'schemas'       : PropTypes.object,
         'placeholderReplacementFxn' : PropTypes.func // Passed down to AboveSearchTablePanel StaticSection
@@ -72,6 +74,7 @@ export class SearchView extends React.PureComponent {
         const {
             href,
             context,
+            showClearFiltersButton, // If present/bool, overrides WindowNavigationController's internal calculation (if any non-'type' queries in URL)
             schemas = null,
             currentAction = null,
             facets : propFacets,
@@ -101,7 +104,7 @@ export class SearchView extends React.PureComponent {
         };
 
         let controllersAndView = (
-            <WindowNavigationController {...{ href, context }} navigate={propNavigate}>
+            <WindowNavigationController {...{ href, context, showClearFiltersButton }} navigate={propNavigate}>
                 <ColumnCombiner {...{ columns, columnExtensionMap }}>
                     <CustomColumnController>
                         <SortController>

--- a/src/components/browse/components/ControlsAndResults.js
+++ b/src/components/browse/components/ControlsAndResults.js
@@ -63,7 +63,10 @@ export class ControlsAndResults extends React.PureComponent {
             separateSingleTermFacets, topLeftChildren, navigate,
             facetColumnClassName = "col-12 col-sm-5 col-lg-4 col-xl-3",
             tableColumnClassName = "col-12 col-sm-7 col-lg-8 col-xl-9",
-            showAboveTableControls = true,
+            // Default is component that renders out predefined buttons if receives props/data for them such as "Create New", "Full Screen", and "Column Selector".
+            aboveTableComponent = <AboveSearchViewTableControls />, // Gets cloned further down in code to receive props from this ControlsAndResults component.
+            // Default is blank element with same height as AboveSearchViewTableControls that allows to align tops of FacetList+Table headings.
+            aboveFacetListComponent = <div className="above-results-table-row"/>,
             defaultOpenIndices = null,
 
             // From WindowNavigationController or VirtualHrefController (or similar) (possibly from Redux store re: href)
@@ -116,20 +119,33 @@ export class ControlsAndResults extends React.PureComponent {
             isFullscreen, toggleFullScreen, currentAction, windowWidth, windowHeight, topLeftChildren
         };
 
+        let extendedAboveTableComponent, extendedAboveFacetListComponent;
+
+        const extendChild = function(child){
+            if (typeof child.type === "string") { // Element, not component
+                return child;
+            }
+            return React.cloneElement(child, aboveTableControlsProps);
+        };
+
+        if (aboveTableComponent) {
+            extendedAboveTableComponent = React.Children.map(aboveTableComponent, extendChild);
+        }
+
+        if (aboveFacetListComponent) {
+            extendedAboveFacetListComponent = React.Children.map(aboveFacetListComponent, extendChild);
+        }
+
         return (
             <div className="row search-view-controls-and-results" data-search-item-type={searchItemType} data-search-abstract-type={searchAbstractItemType}>
                 { Array.isArray(facets) && facets.length ?
                     <div className={facetColumnClassName}>
-                        { showAboveTableControls? // temporary-ish
-                            <div className="above-results-table-row"/>
-                            : null }
+                        { extendedAboveFacetListComponent }
                         <FacetList {...facetListProps} />
                     </div>
                     : null }
                 <div className={tableColumnClassName}>
-                    { showAboveTableControls?
-                        <AboveSearchViewTableControls {...aboveTableControlsProps} />
-                        : null }
+                    { extendedAboveTableComponent }
                     <SearchResultTable {...searchResultTableProps} ref={this.searchResultTableRef} renderDetailPane={this.renderSearchDetailPane} />
                     { isSelectAction(currentAction) && selectedItems !== null ?
                         <SelectStickyFooter {...{ context, schemas, selectedItems, currentAction }}

--- a/src/components/browse/components/ControlsAndResults.js
+++ b/src/components/browse/components/ControlsAndResults.js
@@ -1,11 +1,7 @@
 'use strict';
 
 import React from 'react';
-import PropTypes from 'prop-types';
-import url from 'url';
-import _ from 'underscore';
 import memoize from 'memoize-one';
-import ReactTooltip from 'react-tooltip';
 import { isSelectAction } from './../../util/misc';
 import { getAbstractTypeForType, getSchemaTypeFromSearchContext } from './../../util/schema-transforms';
 import { patchedConsoleInstance as console } from './../../util/patched-console';
@@ -60,7 +56,7 @@ export class ControlsAndResults extends React.PureComponent {
 
             // From SearchView or similar portal-specific HOCs (e.g. BrowseView, ...):
             facets, termTransformFxn, rowHeight,
-            separateSingleTermFacets, topLeftChildren, navigate,
+            separateSingleTermFacets, navigate,
             facetColumnClassName = "col-12 col-sm-5 col-lg-4 col-xl-3",
             tableColumnClassName = "col-12 col-sm-7 col-lg-8 col-xl-9",
             // Default is component that renders out predefined buttons if receives props/data for them such as "Create New", "Full Screen", and "Column Selector".
@@ -68,6 +64,7 @@ export class ControlsAndResults extends React.PureComponent {
             // Default is blank element with same height as AboveSearchViewTableControls that allows to align tops of FacetList+Table headings.
             aboveFacetListComponent = <div className="above-results-table-row"/>,
             defaultOpenIndices = null,
+            detailPane = null,
 
             // From WindowNavigationController or VirtualHrefController (or similar) (possibly from Redux store re: href)
             href, onFilter,
@@ -97,7 +94,7 @@ export class ControlsAndResults extends React.PureComponent {
 
         const searchResultTableProps = {
             context, href, navigate, currentAction, schemas, results, columnDefinitions, visibleColumnDefinitions,
-            setColumnWidths, columnWidths,
+            setColumnWidths, columnWidths, detailPane,
             isOwnPage, sortBy, sortColumn, sortReverse, termTransformFxn, windowWidth, registerWindowOnScrollHandler, rowHeight,
             defaultOpenIndices, maxHeight, isContextLoading // <- Only applicable for EmbeddedSearchView, else is false always
         };
@@ -113,10 +110,8 @@ export class ControlsAndResults extends React.PureComponent {
         };
 
         const aboveTableControlsProps = {
-            // 'isFullscreen' & 'toggleFullScreen' are specific to 4DN's App.js, we could ideally refactor this out eventually.
-            // Perhaps in same way as 'topLeftChildren' is setup... food 4 thought.
             context, showTotalResults, hiddenColumns, columnDefinitions, addHiddenColumn, removeHiddenColumn,
-            isFullscreen, toggleFullScreen, currentAction, windowWidth, windowHeight, topLeftChildren
+            currentAction, windowWidth, windowHeight
         };
 
         let extendedAboveTableComponent, extendedAboveFacetListComponent;

--- a/src/components/browse/components/WindowNavigationController.js
+++ b/src/components/browse/components/WindowNavigationController.js
@@ -84,9 +84,14 @@ export class WindowNavigationController extends React.PureComponent {
     }
 
     render(){
-        const { children, ...passProps } = this.props;
+        const {
+            children,
+            showClearFiltersButton: propShowClearFiltersBtn,
+            ...passProps
+        } = this.props;
         const { href, context } = passProps;
-        const showClearFiltersButton = this.memoized.isClearFiltersBtnVisible(href, context || {});
+        const showClearFiltersButton = typeof propShowClearFiltersBtn === "boolean" ?
+            propShowClearFiltersBtn : this.memoized.isClearFiltersBtnVisible(href, context || {});
 
         const propsToPass = {
             ...passProps,

--- a/src/components/browse/components/table-commons/ColumnCombiner.js
+++ b/src/components/browse/components/table-commons/ColumnCombiner.js
@@ -66,7 +66,8 @@ export class ColumnCombiner extends React.PureComponent {
             // We want `defaultHiddenColumns` memoized separately from `columnDefinitions`
             // because `defaultHiddenColumns` change triggers reset in `ColumnCombiner`.
             // This is becaused `columnExtensionMap` may change more frequently than `columns`.
-            // e.g. in response to SelectedFiles' state.selectedFiles changing.
+            // e.g. in response to SelectedFiles' state.selectedFiles changing display_title column
+            // render func in portal-specific logic or `detailPane`, like-wise.
             getDefaultHiddenColumns: memoize(
                 defaultHiddenColumnMapFromColumns,
                 ([ nextColumns ], [ prevColumns ]) => !this.memoized.haveContextColumnsChanged(prevColumns, nextColumns)

--- a/src/components/browse/components/table-commons/HeadersRow.js
+++ b/src/components/browse/components/table-commons/HeadersRow.js
@@ -32,6 +32,7 @@ export class HeadersRow extends React.PureComponent {
             })
         })).isRequired,
         'mounted' : PropTypes.bool.isRequired,
+        'detailPane' : PropTypes.element,
         'renderDetailPane' : PropTypes.func,
         'width' : PropTypes.number,
         'defaultMinColumnWidth' : PropTypes.number,
@@ -206,6 +207,7 @@ export class HeadersRow extends React.PureComponent {
         const {
             columnDefinitions,
             renderDetailPane,
+            detailPane,
             sortColumn = null,
             sortReverse = false,
             sortBy,
@@ -223,7 +225,7 @@ export class HeadersRow extends React.PureComponent {
         const outerClassName = (
             "search-headers-row"
             + (isAdjustable ? '' : ' non-adjustable')
-            + (typeof renderDetailPane !== 'function' ? ' no-detail-pane' : '')
+            + ((typeof renderDetailPane !== 'function' && !detailPane) ? ' no-detail-pane' : '')
         );
         const outerStyle = {
             'width' : width || null // Only passed in from ItemPage


### PR DESCRIPTION
### Changes

- Remove support for `props.topLeftChildren` & `props.selectedFiles`
- Enable support for `props.aboveTableComponent`
- Enable support for `props.aboveFacetListComponent`
- Enable support for `props.detailPane`
- (Unlikely) Might consider removing `props.renderDetailPane` in future sometime in favor of just `detailPane`