### PR TITLE
fix cannot read property 'apply' of null bug

### DIFF
--- a/es/components/util/navigate.js
+++ b/es/components/util/navigate.js
@@ -94,7 +94,9 @@ navigate.setNavigateFunction = function (navFxn) {
 };
 
 navigate.updateUserInfo = function () {
-  return cachedUpdateUserInfoFunction.apply(void 0, arguments);
+  if (cachedUpdateUserInfoFunction) {
+    return cachedUpdateUserInfoFunction.apply(void 0, arguments);
+  }
 };
 
 navigate.determineSeparatorChar = function (href) {

--- a/src/components/util/navigate.js
+++ b/src/components/util/navigate.js
@@ -73,7 +73,9 @@ navigate.setNavigateFunction = function(navFxn){
 };
 
 navigate.updateUserInfo = function(){
-    return cachedUpdateUserInfoFunction(...arguments);
+    if (cachedUpdateUserInfoFunction) {
+        return cachedUpdateUserInfoFunction(...arguments);
+    }
 };
 
 


### PR DESCRIPTION
Started having [issues with embedded search views](https://gyazo.com/28908ee252732a815e8245c68bdea559) after pulling in new master on CGAP. Traced it back to [this method](https://github.com/4dn-dcic/shared-portal-components/pull/50/files) in SPC.

```
Uncaught TypeError: Cannot read property 'apply' of null
    at Function.navigate.updateUserInfo (navigate.js:97)
    at onLoadResponse (VirtualHrefController.js:235)
    at XMLHttpRequest.xhr.onreadystatechange (ajax.js:110)
```

Not sure if this is a reasonable fix given the issue (could it have 4DN implications?), or just a convenient band-aid, but it does seem to stop the infinite-loading issue on my local, at least. Still thinking that this userUpdateInfo function not being cached properly, thus triggering the null error, is an issue that needs to be addressed? 

But not sure how this started happening? I didn't edit anything that has anything to do with this, and have tested on master of both branches and still get this bug. No updates to SPC have been merged to master in a while, either. Thought maybe it had something to do with Will's recent CGAP master edits, but it's not happening on `cgapdev` and he's recently deployed a version with updated master there, so maybe not? ¯\\_(ツ)_/¯ Could be a venv issue maybe? Idk.