### PR TITLE
Rebuild tooltips when change hiddenColumns

### DIFF
--- a/es/components/browse/components/CustomColumnController.js
+++ b/es/components/browse/components/CustomColumnController.js
@@ -38,9 +38,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import memoize from 'memoize-one';
 import _ from 'underscore';
+import ReactTooltip from 'react-tooltip';
 import { Checkbox } from './../../forms/components/Checkbox';
 import { listToObj } from './../../util/object';
-import { getColumnWidthFromDefinition } from './table-commons/ColumnCombiner';
 /**
  * This component stores an object of `hiddenColumns` in state which contains field names as keys and booleans as values.
  * This, along with functions `addHiddenColumn(field: string)` and `removeHiddenColumn(field: string)`, are passed down to
@@ -104,13 +104,20 @@ export var CustomColumnController = /*#__PURE__*/function (_React$Component) {
 
   _createClass(CustomColumnController, [{
     key: "componentDidUpdate",
-    value: function componentDidUpdate(pastProps) {
+    value: function componentDidUpdate(pastProps, pastState) {
       var defaultHiddenColumns = this.props.defaultHiddenColumns;
+      var hiddenColumns = this.state.hiddenColumns;
 
       if (pastProps.defaultHiddenColumns !== defaultHiddenColumns) {
         this.setState({
           "hiddenColumns": _.clone(defaultHiddenColumns || {})
         }); // Reset state.hiddenColumns.
+
+        return;
+      }
+
+      if (hiddenColumns !== pastState.hiddenColumns) {
+        setTimeout(ReactTooltip.rebuild, 0);
       }
     }
   }, {
@@ -195,11 +202,11 @@ export var CustomColumnController = /*#__PURE__*/function (_React$Component) {
 }(React.Component);
 
 _defineProperty(CustomColumnController, "propTypes", {
-  'children': PropTypes.instanceOf(React.Component),
-  'columnDefinitions': PropTypes.arrayOf(PropTypes.shape({
+  "children": PropTypes.instanceOf(React.Component),
+  "columnDefinitions": PropTypes.arrayOf(PropTypes.shape({
     'field': PropTypes.string
   })),
-  'hiddenColumns': PropTypes.array
+  "defaultHiddenColumns": PropTypes.array
 });
 
 export var CustomColumnSelector = /*#__PURE__*/function (_React$PureComponent) {

--- a/es/components/browse/components/table-commons/HeadersRow.js
+++ b/es/components/browse/components/table-commons/HeadersRow.js
@@ -638,7 +638,8 @@ var ColumnSorterIcon = /*#__PURE__*/function (_React$PureComponent3) {
 
 _defineProperty(ColumnSorterIcon, "propTypes", {
   'active': PropTypes.any,
-  'columnDefinition': HeadersRow.propTypes.columnDefinitions,
+  'columnDefinition': PropTypes.object,
+  // See HeadersRow.proptypes.columnDefinitions
   'sortByField': PropTypes.func.isRequired,
   'showingSortOptionsMenu': PropTypes.bool,
   'setShowingSortFieldsFor': PropTypes.func,

--- a/src/components/browse/components/CustomColumnController.js
+++ b/src/components/browse/components/CustomColumnController.js
@@ -5,9 +5,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import memoize from 'memoize-one';
 import _ from 'underscore';
+import ReactTooltip from 'react-tooltip';
 import { Checkbox } from './../../forms/components/Checkbox';
 import { listToObj } from './../../util/object';
-import { getColumnWidthFromDefinition } from './table-commons/ColumnCombiner';
 
 /**
  * This component stores an object of `hiddenColumns` in state which contains field names as keys and booleans as values.
@@ -36,11 +36,11 @@ export class CustomColumnController extends React.Component {
     }
 
     static propTypes = {
-        'children' : PropTypes.instanceOf(React.Component),
-        'columnDefinitions' : PropTypes.arrayOf(PropTypes.shape({
+        "children" : PropTypes.instanceOf(React.Component),
+        "columnDefinitions" : PropTypes.arrayOf(PropTypes.shape({
             'field' : PropTypes.string
         })),
-        'hiddenColumns' : PropTypes.array
+        "defaultHiddenColumns" : PropTypes.array
     };
 
     constructor(props){
@@ -60,10 +60,15 @@ export class CustomColumnController extends React.Component {
         };
     }
 
-    componentDidUpdate(pastProps){
+    componentDidUpdate(pastProps, pastState){
         const { defaultHiddenColumns } = this.props;
+        const { hiddenColumns } = this.state;
         if (pastProps.defaultHiddenColumns !== defaultHiddenColumns){
             this.setState({ "hiddenColumns" : _.clone(defaultHiddenColumns || {}) }); // Reset state.hiddenColumns.
+            return;
+        }
+        if (hiddenColumns !== pastState.hiddenColumns) {
+            setTimeout(ReactTooltip.rebuild, 0);
         }
     }
 

--- a/src/components/browse/components/table-commons/HeadersRow.js
+++ b/src/components/browse/components/table-commons/HeadersRow.js
@@ -349,7 +349,7 @@ class ColumnSorterIcon extends React.PureComponent {
 
     static propTypes = {
         'active' : PropTypes.any,
-        'columnDefinition' : HeadersRow.propTypes.columnDefinitions,
+        'columnDefinition' : PropTypes.object, // See HeadersRow.proptypes.columnDefinitions
         'sortByField' : PropTypes.func.isRequired,
         'showingSortOptionsMenu' : PropTypes.bool,
         'setShowingSortFieldsFor' : PropTypes.func,


### PR DESCRIPTION
No branches depend on this, just minor improvement. Can be glanced-over/reviewed/merged whenever have free time.