### PR TITLE
Touchups related to FSUI + (fix:) Unset filtering state on FacetLists Terms

### DIFF
--- a/es/components/browse/components/CustomColumnController.js
+++ b/es/components/browse/components/CustomColumnController.js
@@ -313,9 +313,9 @@ var ColumnOption = /*#__PURE__*/React.memo(function (props) {
 
   if (sameTitleColExists) {
     if (!description) {
-      showDescription = '<i class="icon icon-fw fas icon-code">&nbsp;</i><em class="text-300">' + field + '</em>';
+      showDescription = '<i class="icon icon-fw fas icon-code mr-07"></i><span class="text-300 text-monospace">' + field + '</span>';
     } else {
-      showDescription += '<br/><i class="icon icon-fw fas icon-code">&nbsp;</i><em class="text-300">' + field + '</em>';
+      showDescription += '<br/><i class="icon icon-fw fas icon-code mr-07"></i><span class="text-300 text-monospace">' + field + '</span>';
     }
   }
 

--- a/es/components/browse/components/FacetList/FacetTermsList.js
+++ b/es/components/browse/components/FacetList/FacetTermsList.js
@@ -167,9 +167,6 @@ export var Term = /*#__PURE__*/function (_React$PureComponent) {
 
     _this = _super.call(this, props);
     _this.handleClick = _this.handleClick.bind(_assertThisInitialized(_this));
-    _this.state = {
-      'filtering': false
-    };
     return _this;
   }
 
@@ -183,34 +180,6 @@ export var Term = /*#__PURE__*/function (_React$PureComponent) {
       e.preventDefault();
       onClick(facet, term, e);
     }
-    /**
-     * INCOMPLETE -
-     *   For future, in addition to making a nice date range title, we should
-     *   also ensure that can send a date range as a filter and be able to parse it on
-     *   back-end.
-     * Handle date fields, etc.
-     */
-
-    /*
-    customTitleRender(){
-        const { facet, term, termTransformFxn } = this.props;
-         if (facet.aggregation_type === 'range'){
-            return (
-                (typeof term.from !== 'undefined' ? termTransformFxn(facet.field, term.from, true) : '< ') +
-                (typeof term.from !== 'undefined' && typeof term.to !== 'undefined' ? ' - ' : '') +
-                (typeof term.to !== 'undefined' ? termTransformFxn(facet.field, term.to, true) : ' >')
-            );
-        }
-         if (facet.aggregation_type === 'date_histogram'){
-            var interval = Filters.getDateHistogramIntervalFromFacet(facet);
-            if (interval === 'month'){
-                return <DateUtility.LocalizedTime timestamp={term.key} formatType="date-month" localize={false} />;
-            }
-        }
-         return null;
-    }
-    */
-
   }, {
     key: "render",
     value: function render() {
@@ -219,8 +188,7 @@ export var Term = /*#__PURE__*/function (_React$PureComponent) {
           facet = _this$props2.facet,
           status = _this$props2.status,
           termTransformFxn = _this$props2.termTransformFxn,
-          isFiltering = _this$props2.isFiltering; // const { filtering } = this.state;
-
+          isFiltering = _this$props2.isFiltering;
       var count = term && term.doc_count || 0;
       var title = termTransformFxn(facet.field, term.key) || term.key;
       var icon = null;

--- a/es/components/browse/components/FacetList/FacetTermsList.js
+++ b/es/components/browse/components/FacetList/FacetTermsList.js
@@ -14,6 +14,10 @@ function _iterableToArrayLimit(arr, i) { if (typeof Symbol === "undefined" || !(
 
 function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 
+function _objectWithoutProperties(source, excluded) { if (source == null) return {}; var target = _objectWithoutPropertiesLoose(source, excluded); var key, i; if (Object.getOwnPropertySymbols) { var sourceSymbolKeys = Object.getOwnPropertySymbols(source); for (i = 0; i < sourceSymbolKeys.length; i++) { key = sourceSymbolKeys[i]; if (excluded.indexOf(key) >= 0) continue; if (!Object.prototype.propertyIsEnumerable.call(source, key)) continue; target[key] = source[key]; } } return target; }
+
+function _objectWithoutPropertiesLoose(source, excluded) { if (source == null) return {}; var target = {}; var sourceKeys = Object.keys(source); var key, i; for (i = 0; i < sourceKeys.length; i++) { key = sourceKeys[i]; if (excluded.indexOf(key) >= 0) continue; target[key] = source[key]; } return target; }
+
 function _extends() { _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -664,12 +668,12 @@ var ListOfTerms = /*#__PURE__*/React.memo(function (props) {
         open: expanded,
         persistent: persistentTerms,
         collapsible: collapsibleTerms
-      }), searchType !== 'sayt_without_terms' ? /*#__PURE__*/React.createElement("div", {
+      }), /*#__PURE__*/React.createElement("div", {
         className: "pt-08 pb-0"
       }, /*#__PURE__*/React.createElement("div", {
         className: "view-more-button",
         onClick: onToggleExpanded
-      }, expandButtonTitle)) : null)
+      }, expandButtonTitle)))
     }));
   } else {
     return /*#__PURE__*/React.createElement("div", commonProps, /*#__PURE__*/React.createElement(PartialList, {
@@ -680,27 +684,36 @@ var ListOfTerms = /*#__PURE__*/React.memo(function (props) {
     }));
   }
 });
-export var CountIndicator = /*#__PURE__*/React.memo(function (_ref7) {
-  var _ref7$count = _ref7.count,
-      count = _ref7$count === void 0 ? 1 : _ref7$count,
-      _ref7$countActive = _ref7.countActive,
-      countActive = _ref7$countActive === void 0 ? 0 : _ref7$countActive,
-      _ref7$height = _ref7.height,
-      height = _ref7$height === void 0 ? 16 : _ref7$height,
-      _ref7$width = _ref7.width,
-      width = _ref7$width === void 0 ? 40 : _ref7$width;
+export var CountIndicator = /*#__PURE__*/React.memo(function (props) {
+  var _props$count = props.count,
+      count = _props$count === void 0 ? 1 : _props$count,
+      _props$countActive = props.countActive,
+      countActive = _props$countActive === void 0 ? 0 : _props$countActive,
+      _props$height = props.height,
+      height = _props$height === void 0 ? 16 : _props$height,
+      _props$width = props.width,
+      width = _props$width === void 0 ? 40 : _props$width,
+      _props$ltr = props.ltr,
+      ltr = _props$ltr === void 0 ? false : _props$ltr,
+      _props$className = props.className,
+      className = _props$className === void 0 ? null : _props$className,
+      passProps = _objectWithoutProperties(props, ["count", "countActive", "height", "width", "ltr", "className"]);
+
   var dotCountToShow = Math.min(count, 21);
   var dotCoords = stackDotsInContainer(dotCountToShow, height, 4, 2, false);
-  var dots = dotCoords.map(function (_ref8, idx) {
-    var _ref9 = _slicedToArray(_ref8, 2),
-        x = _ref9[0],
-        y = _ref9[1];
+  var dots = dotCoords.map(function (_ref7, idx) {
+    var _ref8 = _slicedToArray(_ref7, 2),
+        x = _ref8[0],
+        y = _ref8[1];
 
     var colIdx = Math.floor(idx / 3); // Flip both axes so going bottom right to top left.
 
-    return /*#__PURE__*/React.createElement("circle", {
-      cx: width - x + 1,
-      cy: height - y + 1,
+    var cx = ltr ? x + 1 : width - x + 1;
+    var cy = ltr ? y + 1 : height - y + 1;
+    return /*#__PURE__*/React.createElement("circle", _extends({
+      cx: cx,
+      cy: cy
+    }, {
       r: 2,
       key: idx,
       "data-original-index": idx,
@@ -708,12 +721,13 @@ export var CountIndicator = /*#__PURE__*/React.memo(function (_ref7) {
         opacity: 1 - colIdx * .125
       },
       className: dotCountToShow - idx <= countActive ? "active" : null
-    });
+    }));
   });
-  return /*#__PURE__*/React.createElement("svg", {
-    className: "svg-count-indicator",
+  var cls = "svg-count-indicator" + (className ? " " + className : "");
+  return /*#__PURE__*/React.createElement("svg", _extends({}, passProps, {
+    className: cls,
     viewBox: "0 0 ".concat(width + 2, " ").concat(height + 2),
     width: width + 2,
     height: height + 2
-  }, dots);
+  }), dots);
 });

--- a/es/components/browse/components/FacetList/FacetTermsList.js
+++ b/es/components/browse/components/FacetList/FacetTermsList.js
@@ -707,12 +707,14 @@ export var CountIndicator = /*#__PURE__*/React.memo(function (props) {
 
   var dotCountToShow = Math.min(count, 21);
   var dotCoords = stackDotsInContainer(dotCountToShow, height, 4, 2, false);
+  var currColCounter = new Set();
   var dots = dotCoords.map(function (_ref8, idx) {
     var _ref9 = _slicedToArray(_ref8, 2),
         x = _ref9[0],
         y = _ref9[1];
 
-    var colIdx = Math.floor(idx / 3); // Flip both axes so going bottom right to top left.
+    currColCounter.add(x);
+    var colIdx = currColCounter.size - 1; // Flip both axes so going bottom right to top left.
 
     var cx = ltr ? x + 1 : width - x + 1;
     var cy = ltr ? y + 1 : height - y + 1;

--- a/es/components/browse/components/FacetList/RangeFacet.js
+++ b/es/components/browse/components/FacetList/RangeFacet.js
@@ -672,9 +672,7 @@ export var RangeFacet = /*#__PURE__*/function (_React$PureComponent) {
   }]);
 
   return RangeFacet;
-}(React.PureComponent); //const { field: currFilteringField, term: currFilteringTerm } = filteringFieldTerm || {};
-//const isClearing = currFilteringTerm === null && facetField === currFilteringField;
-
+}(React.PureComponent);
 var ListOfRanges = /*#__PURE__*/React.memo(function (props) {
   var facet = props.facet,
       facetOpen = props.facetOpen,

--- a/es/components/browse/components/FacetList/index.js
+++ b/es/components/browse/components/FacetList/index.js
@@ -633,7 +633,7 @@ export var FacetList = /*#__PURE__*/function (_React$PureComponent) {
     value: function onFilterMultipleExtended(filterObjArray, callback) {
       var _this$props4 = this.props,
           onFilterMultiple = _this$props4.onFilterMultiple,
-          contextFilters = _this$props4.context.filters; // Detect if setting both values of range field and set a { from, to } term.
+          contextFilters = _this$props4.context.filters; // Detect if setting both values of range field and set state.filteringFieldTerm = { field: string, term:string|[from, to] }.
 
       var facetFieldNames = new Set();
       var uniqueVals = new Set();
@@ -646,6 +646,8 @@ export var FacetList = /*#__PURE__*/function (_React$PureComponent) {
       });
 
       if (facetFieldNames.size === 1) {
+        // 2 values being set of same field
+        // (this is only use-case currently for onFilterMultipleExtended, via RangeFacet, but could change in future)
         var _ref6 = _toConsumableArray(facetFieldNames),
             facetFieldName = _ref6[0];
 

--- a/es/components/browse/components/FacetList/index.js
+++ b/es/components/browse/components/FacetList/index.js
@@ -512,7 +512,9 @@ export var FacetList = /*#__PURE__*/function (_React$PureComponent) {
     _this.state = {
       openFacets: {},
       // will be keyed by facet.field, value will be bool
-      openPopover: null // will contain `{ ref: React Ref, popover: JSX element/component }`. We might want to move this functionality up into like App.js.
+      openPopover: null,
+      // will contain `{ ref: React Ref, popover: JSX element/component }`. We might want to move this functionality up into like App.js.
+      filteringFieldTerm: null // will contain `{ field: string, term: string|[from, to] }`. Used to show loading indicators on clicked-on terms.
 
     };
     return _this;
@@ -576,26 +578,29 @@ export var FacetList = /*#__PURE__*/function (_React$PureComponent) {
       }
 
       if (context !== prevContext) {
-        // If new filterset causes a facet to drop into common properties section, clean up openFacets state accordingly.
+        var stateChange = {}; // If new filterset causes a facet to drop into common properties section, clean up openFacets state accordingly.
+
         var _this$renderFacetComp2 = this.renderFacetComponents(),
             staticFacetElements = _this$renderFacetComp2.staticFacetElements; // Should be performant re: memoization
 
 
         var nextOpenFacets = _.clone(openFacets);
 
-        var changed = false;
+        var changedOpenFacets = false;
         staticFacetElements.forEach(function (facetComponent) {
           if (nextOpenFacets[facetComponent.props.facet.field]) {
             delete nextOpenFacets[facetComponent.props.facet.field];
-            changed = true;
+            changedOpenFacets = true;
           }
         });
 
-        if (changed) {
-          this.setState({
-            openFacets: nextOpenFacets
-          });
-        }
+        if (changedOpenFacets) {
+          stateChange.openFacets = nextOpenFacets;
+        } // Newly loaded search response should clear any filteringFieldTerm state.
+
+
+        stateChange.filteringFieldTerm = null;
+        this.setState(stateChange);
       }
     }
     /**
@@ -606,25 +611,58 @@ export var FacetList = /*#__PURE__*/function (_React$PureComponent) {
 
   }, {
     key: "onFilterExtended",
-    value: function onFilterExtended(facet, term) {
+    value: function onFilterExtended(facet, term, callback) {
       var _this$props3 = this.props,
           onFilter = _this$props3.onFilter,
           contextFilters = _this$props3.context.filters;
-      FacetList.sendAnalyticsPreFilter(facet, term, contextFilters);
-      return onFilter.apply(void 0, arguments);
+      FacetList.sendAnalyticsPreFilter(facet, term, contextFilters); // Used to show loading indicators on clicked-on terms.
+      // (decorative, not core functionality, so not implemented for `onFilterMultipleExtended`)
+      // `facet.facetFieldName` is passed in only from RangeFacet, as the real `field` would have a '.from' or '.to' appendage.
+
+      this.setState({
+        "filteringFieldTerm": {
+          "field": facet.facetFieldName || facet.field,
+          "term": term.key
+        }
+      }, function () {
+        onFilter(facet, term, callback);
+      });
     }
   }, {
     key: "onFilterMultipleExtended",
-    value: function onFilterMultipleExtended(filterObjArray) {
+    value: function onFilterMultipleExtended(filterObjArray, callback) {
       var _this$props4 = this.props,
           onFilterMultiple = _this$props4.onFilterMultiple,
-          contextFilters = _this$props4.context.filters;
+          contextFilters = _this$props4.context.filters; // Detect if setting both values of range field and set a { from, to } term.
+
+      var facetFieldNames = new Set();
+      var uniqueVals = new Set();
       filterObjArray.forEach(function (filterObj) {
         var facet = filterObj.facet,
             term = filterObj.term;
+        facetFieldNames.add(facet.facetFieldName || null);
+        uniqueVals.add(term.key);
         FacetList.sendAnalyticsPreFilter(facet, term, contextFilters);
       });
-      return onFilterMultiple.apply(void 0, arguments);
+
+      if (facetFieldNames.size === 1) {
+        var _ref6 = _toConsumableArray(facetFieldNames),
+            facetFieldName = _ref6[0];
+
+        if (facetFieldName !== null) {
+          this.setState({
+            "filteringFieldTerm": {
+              "field": facetFieldName,
+              "term": uniqueVals.size > 1 ? _toConsumableArray(uniqueVals).sort() : _toConsumableArray(uniqueVals)[0]
+            }
+          }, function () {
+            onFilterMultiple(filterObjArray, callback);
+          });
+          return;
+        }
+      }
+
+      onFilterMultiple(filterObjArray, callback);
     }
   }, {
     key: "getTermStatus",
@@ -636,8 +674,8 @@ export var FacetList = /*#__PURE__*/function (_React$PureComponent) {
     key: "handleToggleFacetOpen",
     value: function handleToggleFacetOpen(facetField) {
       var nextOpen = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : null;
-      this.setState(function (_ref6) {
-        var prevOpenFacets = _ref6.openFacets;
+      this.setState(function (_ref7) {
+        var prevOpenFacets = _ref7.openFacets;
 
         var openFacets = _.clone(prevOpenFacets);
 
@@ -661,9 +699,9 @@ export var FacetList = /*#__PURE__*/function (_React$PureComponent) {
     value: function setOpenPopover() {
       var nextPopover = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : null;
       var cb = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : null;
-      this.setState(function (_ref7) {
-        var _ref7$openPopover = _ref7.openPopover,
-            openPopover = _ref7$openPopover === void 0 ? null : _ref7$openPopover;
+      this.setState(function (_ref8) {
+        var _ref8$openPopover = _ref8.openPopover,
+            openPopover = _ref8$openPopover === void 0 ? null : _ref8$openPopover;
 
         if (!openPopover) {
           if (!nextPopover) return null;
@@ -718,7 +756,8 @@ export var FacetList = /*#__PURE__*/function (_React$PureComponent) {
       var filters = context.filters;
       var _this$state2 = this.state,
           openFacets = _this$state2.openFacets,
-          openPopover = _this$state2.openPopover;
+          openPopover = _this$state2.openPopover,
+          filteringFieldTerm = _this$state2.filteringFieldTerm;
       var facetComponentProps = {
         href: href,
         schemas: schemas,
@@ -728,6 +767,7 @@ export var FacetList = /*#__PURE__*/function (_React$PureComponent) {
         persistentCount: persistentCount,
         separateSingleTermFacets: separateSingleTermFacets,
         openPopover: openPopover,
+        filteringFieldTerm: filteringFieldTerm,
         onFilter: this.onFilterExtended,
         onFilterMultiple: this.onFilterMultipleExtended,
         getTermStatus: this.getTermStatus,
@@ -765,9 +805,9 @@ export var FacetList = /*#__PURE__*/function (_React$PureComponent) {
           openFacets = _this$state3.openFacets,
           openPopover = _this$state3.openPopover;
 
-      var _ref8 = openPopover || {},
-          popoverJSX = _ref8.popover,
-          popoverTargetRef = _ref8.ref;
+      var _ref9 = openPopover || {},
+          popoverJSX = _ref9.popover,
+          popoverTargetRef = _ref9.ref;
 
       if (!facets || !Array.isArray(facets) || facets.length === 0) {
         return /*#__PURE__*/React.createElement("div", {

--- a/es/components/forms/SubmissionView.js
+++ b/es/components/forms/SubmissionView.js
@@ -1425,6 +1425,14 @@ var SubmissionView = /*#__PURE__*/function (_React$PureComponent) {
 
           if (currSchema.properties.lab && !('lab' in finalizedContext)) {
             finalizedContext.lab = object.itemUtil.atId(context.lab);
+          }
+
+          if (currSchema.properties.institution && !('institution' in finalizedContext)) {
+            finalizedContext.institution = object.itemUtil.atId(context.institution);
+          }
+
+          if (currSchema.properties.project && !('project' in finalizedContext)) {
+            finalizedContext.project = object.itemUtil.atId(context.project);
           } // an admin is editing. Use the pre-existing submitted_by
           // otherwise, permissions won't let us change this field
 
@@ -1437,16 +1445,26 @@ var SubmissionView = /*#__PURE__*/function (_React$PureComponent) {
               finalizedContext.submitted_by = object.itemUtil.atId(currentSubmittingUser);
             }
           }
-        } else if (userLab && userAward && currType !== 'User') {
+        } else if (currType !== 'User') {
           // Otherwise, use lab/award of user submitting unless values present
           // Skip this is we are working on a User object
-          if (currSchema.properties.award && !('award' in finalizedContext)) {
+          if (userAward && currSchema.properties.award && !('award' in finalizedContext)) {
             finalizedContext.award = object.itemUtil.atId(userAward);
           }
 
-          if (currSchema.properties.lab && !('lab' in finalizedContext)) {
+          if (userLab && currSchema.properties.lab && !('lab' in finalizedContext)) {
             finalizedContext.lab = object.itemUtil.atId(userLab);
           }
+
+          if (currSchema.properties.institution && !('institution' in finalizedContext) && currentSubmittingUser.user_institution) {
+            finalizedContext.institution = object.itemUtil.atId(currentSubmittingUser.user_institution);
+          }
+
+          if (currSchema.properties.project && !('project' in finalizedContext) && currentSubmittingUser.project) {
+            finalizedContext.project = object.itemUtil.atId(currentSubmittingUser.project);
+          }
+
+          console.log("DDD", currentSubmittingUser, finalizedContext);
         }
 
         var destination;

--- a/src/components/browse/components/CustomColumnController.js
+++ b/src/components/browse/components/CustomColumnController.js
@@ -202,9 +202,9 @@ const ColumnOption = React.memo(function ColumnOption(props){
 
     if (sameTitleColExists){
         if (!description){
-            showDescription = '<i class="icon icon-fw fas icon-code">&nbsp;</i><em class="text-300">' + field + '</em>';
+            showDescription = '<i class="icon icon-fw fas icon-code mr-07"></i><span class="text-300 text-monospace">' + field + '</span>';
         } else {
-            showDescription += '<br/><i class="icon icon-fw fas icon-code">&nbsp;</i><em class="text-300">' + field + '</em>';
+            showDescription += '<br/><i class="icon icon-fw fas icon-code mr-07"></i><span class="text-300 text-monospace">' + field + '</span>';
         }
     }
 

--- a/src/components/browse/components/FacetList/FacetTermsList.js
+++ b/src/components/browse/components/FacetList/FacetTermsList.js
@@ -111,9 +111,6 @@ export class Term extends React.PureComponent {
     constructor(props){
         super(props);
         this.handleClick = this.handleClick.bind(this);
-        this.state = {
-            'filtering' : false
-        };
     }
 
     handleClick(e) {
@@ -122,39 +119,8 @@ export class Term extends React.PureComponent {
         onClick(facet, term, e);
     }
 
-    /**
-     * INCOMPLETE -
-     *   For future, in addition to making a nice date range title, we should
-     *   also ensure that can send a date range as a filter and be able to parse it on
-     *   back-end.
-     * Handle date fields, etc.
-     */
-    /*
-    customTitleRender(){
-        const { facet, term, termTransformFxn } = this.props;
-
-        if (facet.aggregation_type === 'range'){
-            return (
-                (typeof term.from !== 'undefined' ? termTransformFxn(facet.field, term.from, true) : '< ') +
-                (typeof term.from !== 'undefined' && typeof term.to !== 'undefined' ? ' - ' : '') +
-                (typeof term.to !== 'undefined' ? termTransformFxn(facet.field, term.to, true) : ' >')
-            );
-        }
-
-        if (facet.aggregation_type === 'date_histogram'){
-            var interval = Filters.getDateHistogramIntervalFromFacet(facet);
-            if (interval === 'month'){
-                return <DateUtility.LocalizedTime timestamp={term.key} formatType="date-month" localize={false} />;
-            }
-        }
-
-        return null;
-    }
-    */
-
     render() {
         const { term, facet, status, termTransformFxn, isFiltering } = this.props;
-        // const { filtering } = this.state;
         const selected = (status !== 'none');
         const count = (term && term.doc_count) || 0;
         let title = termTransformFxn(facet.field, term.key) || term.key;

--- a/src/components/browse/components/FacetList/FacetTermsList.js
+++ b/src/components/browse/components/FacetList/FacetTermsList.js
@@ -450,10 +450,9 @@ const ListOfTerms = React.memo(function ListOfTerms(props){
                     <React.Fragment>
                         {facetSearch}
                         <PartialList className="mb-0" open={expanded} persistent={persistentTerms} collapsible={collapsibleTerms} />
-                        {(searchType !== 'sayt_without_terms' ? (
-                            <div className="pt-08 pb-0">
-                                <div className="view-more-button" onClick={onToggleExpanded}>{expandButtonTitle}</div>
-                            </div>) : null)}
+                        <div className="pt-08 pb-0">
+                            <div className="view-more-button" onClick={onToggleExpanded}>{expandButtonTitle}</div>
+                        </div>
                     </React.Fragment>
                 } />
             </div>
@@ -473,19 +472,31 @@ const ListOfTerms = React.memo(function ListOfTerms(props){
 });
 
 
-export const CountIndicator = React.memo(function CountIndicator({ count = 1, countActive = 0, height = 16, width = 40 }){
+export const CountIndicator = React.memo(function CountIndicator(props){
+    const {
+        count = 1,
+        countActive = 0,
+        height = 16,
+        width = 40,
+        ltr = false,
+        className = null,
+        ...passProps
+    } = props;
     const dotCountToShow = Math.min(count, 21);
     const dotCoords = stackDotsInContainer(dotCountToShow, height, 4, 2, false);
     const dots = dotCoords.map(function([ x, y ], idx){
         const colIdx = Math.floor(idx / 3);
         // Flip both axes so going bottom right to top left.
+        const cx = ltr ? x + 1 : width - x + 1;
+        const cy = ltr ? y + 1 : height - y + 1;
         return (
-            <circle cx={width - x + 1} cy={height - y + 1} r={2} key={idx} data-original-index={idx}
+            <circle {...{ cx, cy }} r={2} key={idx} data-original-index={idx}
                 style={{ opacity: 1 - (colIdx * .125) }} className={(dotCountToShow - idx) <= countActive ? "active" : null} />
         );
     });
+    const cls = "svg-count-indicator" + (className ? " " + className : "");
     return (
-        <svg className="svg-count-indicator" viewBox={`0 0 ${width + 2} ${height + 2}`} width={width + 2} height={height + 2}>
+        <svg {...passProps} className={cls} viewBox={`0 0 ${width + 2} ${height + 2}`} width={width + 2} height={height + 2}>
             { dots}
         </svg>
     );

--- a/src/components/browse/components/FacetList/FacetTermsList.js
+++ b/src/components/browse/components/FacetList/FacetTermsList.js
@@ -498,8 +498,10 @@ export const CountIndicator = React.memo(function CountIndicator(props){
     } = props;
     const dotCountToShow = Math.min(count, 21);
     const dotCoords = stackDotsInContainer(dotCountToShow, height, 4, 2, false);
+    const currColCounter = new Set();
     const dots = dotCoords.map(function([ x, y ], idx){
-        const colIdx = Math.floor(idx / 3);
+        currColCounter.add(x);
+        const colIdx = currColCounter.size - 1;
         // Flip both axes so going bottom right to top left.
         const cx = ltr ? x + 1 : width - x + 1;
         const cy = ltr ? y + 1 : height - y + 1;

--- a/src/components/browse/components/FacetList/RangeFacet.js
+++ b/src/components/browse/components/FacetList/RangeFacet.js
@@ -91,8 +91,6 @@ export function formatRangeVal(termTransformFxn, fieldFacetObj, rangeValue, allo
 
     let valToShow = termTransformFxn(field, rangeValue, allowJSX);
 
-    // console.log("ABCD3", valToShow, field, rangeValue);
-
     if (typeof valToShow === "number") {
         const absVal = Math.abs(valToShow);
         if (absVal.toString().length <= 6){
@@ -298,7 +296,11 @@ export class RangeFacet extends React.PureComponent {
         const { fromVal } = this.state;
         // console.log("performUpdateFrom", fromVal);
         onFilter(
-            { ...facet, field: facet.field + ".from" },
+            {
+                ...facet,
+                field: facet.field + ".from",
+                facetFieldName: facet.field // Used to inform UI in FacetList/index only.
+            },
             { key: fromVal },
             callback
         );
@@ -309,7 +311,11 @@ export class RangeFacet extends React.PureComponent {
         const { toVal } = this.state;
         // console.log("performUpdateTo", toVal);
         onFilter(
-            { ...facet, field: facet.field + ".to" },
+            {
+                ...facet,
+                field: facet.field + ".to",
+                facetFieldName: facet.field // Used to inform UI in FacetList/index only.
+            },
             { key: toVal },
             callback
         );
@@ -318,14 +324,22 @@ export class RangeFacet extends React.PureComponent {
     performUpdateToAndFrom(callback) {
         const { onFilterMultiple, facet } = this.props;
         const { toVal, fromVal } = this.state;
-        // console.log("performUpdate", toVal, fromVal);
+        // console.log("performUpdate", toVal, fromVal, facet.field);
         onFilterMultiple(
             [{
-                facet: { ...facet, field: facet.field + ".from" },
+                facet: {
+                    ...facet,
+                    field: facet.field + ".from",
+                    facetFieldName: facet.field // Used to inform UI in FacetList/index only.
+                },
                 term: { key: fromVal }
             },
             {
-                facet: { ...facet, field: facet.field + ".to" },
+                facet: {
+                    ...facet,
+                    field: facet.field + ".to",
+                    facetFieldName: facet.field // Used to inform UI in FacetList/index only.
+                },
                 term: { key: toVal }
             }],
             callback
@@ -384,7 +398,8 @@ export class RangeFacet extends React.PureComponent {
             toVal: savedToVal,
             facetOpen,
             openPopover,
-            setOpenPopover
+            setOpenPopover,
+            filteringFieldTerm
         } = this.props;
         const {
             aggregation_type,
@@ -468,8 +483,11 @@ export class RangeFacet extends React.PureComponent {
                 <div className="facet-list" data-open={facetOpen} data-any-active={(savedFromVal || savedToVal) ? true : false}>
                     <PartialList className="inner-panel" open={facetOpen}
                         persistent={[
-                            <RangeClear {...{ savedFromVal, savedToVal, facet, fieldSchema, termTransformFxn }} resetAll={this.resetAll}
-                                resetFrom={fromVal !== null ? this.resetFrom : null} resetTo={toVal !== null ? this.resetTo : null} key={0} />
+                            <RangeClear {...{ savedFromVal, savedToVal, facet, fieldSchema, termTransformFxn, filteringFieldTerm }}
+                                resetAll={this.resetAll}
+                                resetFrom={fromVal !== null ? this.resetFrom : null}
+                                resetTo={toVal !== null ? this.resetTo : null}
+                                key={0} />
                         ]}
                         collapsible={[
                             <div className="range-drop-group row" key={0}>
@@ -515,10 +533,23 @@ export class RangeFacet extends React.PureComponent {
 
 }
 
+//const { field: currFilteringField, term: currFilteringTerm } = filteringFieldTerm || {};
+//const isClearing = currFilteringTerm === null && facetField === currFilteringField;
+
 
 const ListOfRanges = React.memo(function ListOfRanges(props){
-    const { facet, facetOpen, facetClosing, persistentCount = 10, selectRange, expanded, onToggleExpanded, termTransformFxn, toVal, fromVal } = props;
-    const { ranges = [] } = facet;
+    const {
+        facet,
+        facetOpen, facetClosing,
+        persistentCount = 10,
+        selectRange,
+        expanded, onToggleExpanded,
+        termTransformFxn,
+        toVal, fromVal,
+        filteringFieldTerm
+    } = props;
+    const { ranges = [], field: facetField } = facet;
+
 
     /** Create range components and sort by status (selected->omitted->unselected) */
     const { termComponents, activeTermComponents, unselectedTermComponents,
@@ -528,12 +559,23 @@ const ListOfRanges = React.memo(function ListOfRanges(props){
         collapsibleTermsCount = 0,
         collapsibleTermsItemCount = 0
     } = useMemo(function(){
+        const { field: currFilteringField, term: currFilteringTerm } = filteringFieldTerm || {};
+        // Ranges always presumed to have a from & to, so ignore if filtering a single value/term.
+        const isFilteringCurrField = currFilteringField === facetField;
         const {
             selected: selectedTermComponents    = [],
             omitted : omittedTermComponents     = [],
             none    : unselectedTermComponents  = []
         } = segmentComponentsByStatus(ranges.map(function(range){
-            return <RangeTerm {...{ facet, range, termTransformFxn, selectRange }} key={`${range.to}-${range.from}`} status={getRangeStatus(range, toVal, fromVal)} />;
+            const { from: rangeFrom = null, to: rangeTo = null } = range;
+            const isFiltering = isFilteringCurrField && (
+                // Sometimes a range may be 0 - 0 (and result in single value instead of array for currFilteringTerm)
+                (
+                    (Array.isArray(currFilteringTerm) && rangeFrom === currFilteringTerm[0] && rangeTo === currFilteringTerm[1]) ||
+                    (currFilteringTerm === rangeTo && currFilteringTerm === rangeFrom)
+                )
+            );
+            return <RangeTerm {...{ facet, range, termTransformFxn, selectRange, isFiltering }} key={`${rangeFrom}-${rangeTo}`} status={getRangeStatus(range, toVal, fromVal)} />;
         }));
 
         const selectedLen = selectedTermComponents.length;
@@ -565,7 +607,7 @@ const ListOfRanges = React.memo(function ListOfRanges(props){
 
         return retObj;
 
-    }, [ ranges, persistentCount, toVal, fromVal ]);
+    }, [ ranges, persistentCount, toVal, fromVal, filteringFieldTerm ]);
 
 
 
@@ -624,10 +666,7 @@ export class RangeTerm extends React.PureComponent {
 
     constructor(props){
         super(props);
-        this.handleClick = _.debounce(this.handleClick.bind(this), 500, true);
-        this.state = {
-            'filtering' : false
-        };
+        this.handleClick = this.handleClick.bind(this);
     }
 
     handleClick(e) {
@@ -637,20 +676,16 @@ export class RangeTerm extends React.PureComponent {
         e.preventDefault();
         e.stopPropagation();
 
-        this.setState({ 'filtering' : true }, () => {
-            const isSelected = status === "selected";
-            selectRange(
-                isSelected ? null : to,
-                isSelected ? null : from,
-                () => this.setState({ 'filtering' : false })
-            );
-        });
+        const isSelected = status === "selected";
+        selectRange(
+            isSelected ? null : to,
+            isSelected ? null : from
+        );
     }
 
     render() {
-        const { range, facet, status } = this.props;
+        const { range, facet, status, isFiltering = false } = this.props;
         const { doc_count, from, to, label } = range;
-        const { filtering } = this.state;
         const selected = (status !== 'none');
         let icon = null;
 
@@ -660,7 +695,7 @@ export class RangeTerm extends React.PureComponent {
             (typeof to !== 'undefined' ? to : '+ ')
         );
 
-        if (filtering) {
+        if (isFiltering) {
             icon = <i className="icon fas icon-circle-notch icon-spin icon-fw" />;
         } else if (status === 'selected' || status === 'omitted') {
             icon = <i className="icon icon-dot-circle icon-fw fas" />;
@@ -749,15 +784,20 @@ const RangeClear = React.memo(function RangeClear(props){
         resetAll,
         facet,
         fieldSchema = null,
-        termTransformFxn
+        termTransformFxn,
+        filteringFieldTerm
     } = props;
 
     const {
+        field: facetField,
         title: facetTitle,
         abbreviation: facetAbbreviation = null
     } = facet;
 
     const { abbreviation: fieldAbbreviation = null } = fieldSchema || {};
+
+    const { field: currFilteringField, term: currFilteringTerm } = filteringFieldTerm || {};
+    const isClearing = currFilteringTerm === null && facetField === currFilteringField;
 
     const abbreviatedTitle = facetAbbreviation || fieldAbbreviation || (facetTitle.length > 5 ? <em>N</em> : facetTitle);
 
@@ -781,7 +821,7 @@ const RangeClear = React.memo(function RangeClear(props){
         <li className="selected facet-list-element clickable">
             <a onClick={unselectRange}>
                 <span className="facet-selector">
-                    <i className="icon icon-fw fas icon-minus-circle"/>
+                    <i className={"icon icon-fw fas icon-" + (isClearing ? "circle-notch icon-spin" : "minus-circle")}/>
                 </span>
                 <span className="facet-item text-center" style={{ marginLeft: "-5px" }}>
                     <FormattedToFromRangeValue {...{ termTransformFxn, facet }} from={savedFromVal} to={savedToVal} title={abbreviatedTitle} />

--- a/src/components/browse/components/FacetList/RangeFacet.js
+++ b/src/components/browse/components/FacetList/RangeFacet.js
@@ -533,9 +533,6 @@ export class RangeFacet extends React.PureComponent {
 
 }
 
-//const { field: currFilteringField, term: currFilteringTerm } = filteringFieldTerm || {};
-//const isClearing = currFilteringTerm === null && facetField === currFilteringField;
-
 
 const ListOfRanges = React.memo(function ListOfRanges(props){
     const {

--- a/src/components/browse/components/FacetList/index.js
+++ b/src/components/browse/components/FacetList/index.js
@@ -452,8 +452,9 @@ export class FacetList extends React.PureComponent {
         };
 
         this.state = {
-            openFacets : {}, // will be keyed by facet.field, value will be bool
-            openPopover: null // will contain `{ ref: React Ref, popover: JSX element/component }`. We might want to move this functionality up into like App.js.
+            openFacets : {},    // will be keyed by facet.field, value will be bool
+            openPopover: null,  // will contain `{ ref: React Ref, popover: JSX element/component }`. We might want to move this functionality up into like App.js.
+            filteringFieldTerm: null    // will contain `{ field: string, term: string|[from, to] }`. Used to show loading indicators on clicked-on terms.
         };
     }
 
@@ -498,19 +499,29 @@ export class FacetList extends React.PureComponent {
         }
 
         if (context !== prevContext) {
+
+            const stateChange = {};
+
             // If new filterset causes a facet to drop into common properties section, clean up openFacets state accordingly.
             const { staticFacetElements } = this.renderFacetComponents(); // Should be performant re: memoization
             const nextOpenFacets = _.clone(openFacets);
-            let changed = false;
+            let changedOpenFacets = false;
             staticFacetElements.forEach(function(facetComponent){
                 if (nextOpenFacets[facetComponent.props.facet.field]) {
                     delete nextOpenFacets[facetComponent.props.facet.field];
-                    changed = true;
+                    changedOpenFacets = true;
                 }
             });
-            if (changed) {
-                this.setState({ openFacets: nextOpenFacets });
+
+            if (changedOpenFacets) {
+                stateChange.openFacets = nextOpenFacets;
             }
+
+            // Newly loaded search response should clear any filteringFieldTerm state.
+            stateChange.filteringFieldTerm = null;
+
+
+            this.setState(stateChange);
         }
 
     }
@@ -523,18 +534,50 @@ export class FacetList extends React.PureComponent {
     onFilterExtended(facet, term, callback){
         const { onFilter, context: { filters: contextFilters } } = this.props;
         FacetList.sendAnalyticsPreFilter(facet, term, contextFilters);
-        return onFilter(...arguments);
+
+        // Used to show loading indicators on clicked-on terms.
+        // (decorative, not core functionality, so not implemented for `onFilterMultipleExtended`)
+        // `facet.facetFieldName` is passed in only from RangeFacet, as the real `field` would have a '.from' or '.to' appendage.
+        this.setState({
+            "filteringFieldTerm": {
+                "field": (facet.facetFieldName || facet.field),
+                "term": term.key
+            }
+        }, function(){
+            onFilter(facet, term, callback);
+        });
     }
 
-    onFilterMultipleExtended(filterObjArray) {
+    onFilterMultipleExtended(filterObjArray, callback) {
         const { onFilterMultiple, context: { filters: contextFilters } } = this.props;
+
+        // Detect if setting both values of range field and set a { from, to } term.
+        const facetFieldNames = new Set();
+        const uniqueVals = new Set();
 
         filterObjArray.forEach((filterObj) => {
             const { facet, term } = filterObj;
+            facetFieldNames.add(facet.facetFieldName || null);
+            uniqueVals.add(term.key);
             FacetList.sendAnalyticsPreFilter(facet, term, contextFilters);
         });
 
-        return onFilterMultiple(...arguments);
+        if (facetFieldNames.size === 1) {
+            const [ facetFieldName ] = [ ...facetFieldNames ];
+            if (facetFieldName !== null) {
+                this.setState({
+                    "filteringFieldTerm": {
+                        "field": facetFieldName,
+                        "term": uniqueVals.size > 1 ? [...uniqueVals].sort() : [...uniqueVals][0]
+                    }
+                }, function(){
+                    onFilterMultiple(filterObjArray, callback);
+                });
+                return;
+            }
+        }
+
+        onFilterMultiple(filterObjArray, callback);
     }
 
     getTermStatus(term, facet){
@@ -591,10 +634,11 @@ export class FacetList extends React.PureComponent {
             href, schemas, itemTypeForSchemas, termTransformFxn, persistentCount
         } = this.props;
         const { filters } = context;
-        const { openFacets, openPopover } = this.state;
+        const { openFacets, openPopover, filteringFieldTerm } = this.state;
         const facetComponentProps = {
             href, schemas, context, itemTypeForSchemas, termTransformFxn, persistentCount, separateSingleTermFacets,
             openPopover,
+            filteringFieldTerm,
             onFilter:       this.onFilterExtended,
             onFilterMultiple: this.onFilterMultipleExtended,
             getTermStatus:  this.getTermStatus,

--- a/src/components/browse/components/FacetList/index.js
+++ b/src/components/browse/components/FacetList/index.js
@@ -551,7 +551,7 @@ export class FacetList extends React.PureComponent {
     onFilterMultipleExtended(filterObjArray, callback) {
         const { onFilterMultiple, context: { filters: contextFilters } } = this.props;
 
-        // Detect if setting both values of range field and set a { from, to } term.
+        // Detect if setting both values of range field and set state.filteringFieldTerm = { field: string, term:string|[from, to] }.
         const facetFieldNames = new Set();
         const uniqueVals = new Set();
 
@@ -563,6 +563,8 @@ export class FacetList extends React.PureComponent {
         });
 
         if (facetFieldNames.size === 1) {
+            // 2 values being set of same field
+            // (this is only use-case currently for onFilterMultipleExtended, via RangeFacet, but could change in future)
             const [ facetFieldName ] = [ ...facetFieldNames ];
             if (facetFieldName !== null) {
                 this.setState({

--- a/src/components/forms/SubmissionView.js
+++ b/src/components/forms/SubmissionView.js
@@ -1085,6 +1085,14 @@ export default class SubmissionView extends React.PureComponent{
                     finalizedContext.lab = object.itemUtil.atId(context.lab);
                 }
 
+                if (currSchema.properties.institution && !('institution' in finalizedContext)){
+                    finalizedContext.institution = object.itemUtil.atId(context.institution);
+                }
+
+                if (currSchema.properties.project && !('project' in finalizedContext)){
+                    finalizedContext.project = object.itemUtil.atId(context.project);
+                }
+
                 // an admin is editing. Use the pre-existing submitted_by
                 // otherwise, permissions won't let us change this field
                 if (currentSubmittingUser.groups && _.contains(currentSubmittingUser.groups, 'admin')){
@@ -1096,15 +1104,29 @@ export default class SubmissionView extends React.PureComponent{
                     }
                 }
 
-            } else if (userLab && userAward && currType !== 'User') {
+            } else if (currType !== 'User') {
+
                 // Otherwise, use lab/award of user submitting unless values present
                 // Skip this is we are working on a User object
-                if (currSchema.properties.award && !('award' in finalizedContext)){
+
+                if (userAward && currSchema.properties.award && !('award' in finalizedContext)){
                     finalizedContext.award = object.itemUtil.atId(userAward);
                 }
-                if (currSchema.properties.lab && !('lab' in finalizedContext)){
+
+                if (userLab && currSchema.properties.lab && !('lab' in finalizedContext)){
                     finalizedContext.lab = object.itemUtil.atId(userLab);
                 }
+
+                if (currSchema.properties.institution && !('institution' in finalizedContext) && currentSubmittingUser.user_institution){
+                    finalizedContext.institution = object.itemUtil.atId(currentSubmittingUser.user_institution);
+                }
+
+                if (currSchema.properties.project && !('project' in finalizedContext) && currentSubmittingUser.project){
+                    finalizedContext.project = object.itemUtil.atId(currentSubmittingUser.project);
+                }
+
+                console.log("DDD", currentSubmittingUser, finalizedContext);
+
             }
 
             let destination;


### PR DESCRIPTION
#### 2021-04-12
Cleanup

#### 2021-04-09
Minor update to CountIndicator (better determination of column idx when not 3 dots per column)

#### 2021-04-07

Bundled in fix for issue Will mentioned re: unsetting of FacetList Terms on /search/ and /browse/ views when click many (or single 1) rapidly. [Should now work like this](https://gyazo.com/a2e1aab36e2d27660c67ea8c34a2be8f).

#### 2021-04-06

Minor touchups done while working on FilterSetUI.

~~Despite the branch name, none of these are breaking changes nor does current FSUI (CGAP) PR depend on this. Can be merged whenever.~~
~~I take that back; added prop `ltr` to CountIndicator, which is used in CGAP FSUI now.~~
Nevermind again, `ltr` no longer used.

Most significant of these is auto-including institution and project in SubmissionView to allow creation to work. Not super pretty but it works.