### PR TITLE
fix for displayTitle onclick: use href from a elem

### DIFF
--- a/es/components/browse/components/table-commons/basicColumnExtensionMap.js
+++ b/es/components/browse/components/table-commons/basicColumnExtensionMap.js
@@ -12,6 +12,7 @@ import { getItemType, getTitleForType } from './../../../util/schema-transforms'
 import { getNestedProperty, itemUtil } from './../../../util/object';
 import { productClick as trackProductClick, hrefToListName } from './../../../util/analytics';
 import { LocalizedTime } from './../../../ui/LocalizedTime';
+import { elementIsChildOfLink } from '../../../../../es/components/util/layout';
 export var DEFAULT_WIDTH_MAP = {
   'lg': 200,
   'md': 180,
@@ -231,6 +232,27 @@ export var DisplayTitleColumnWrapper = /*#__PURE__*/React.memo(function (props) 
 
   var onClick = useMemo(function () {
     return function (evt) {
+      var _ref2$target = (evt || {}).target,
+          target = _ref2$target === void 0 ? null : _ref2$target;
+      var targetUrl;
+
+      if (target && target.href) {
+        targetUrl = target.href;
+      } else if (target && !target.href) {
+        // Check parent for hrefs if none found on current evt.target
+        var linkElement = elementIsChildOfLink(target);
+
+        var _ref3 = linkElement || {},
+            _ref3$href = _ref3.href,
+            _href = _ref3$href === void 0 ? null : _ref3$href;
+
+        if (_href) {
+          targetUrl = _href;
+        }
+      }
+
+      var navTarget = targetUrl || link; // Fallback to atId if no href found
+
       evt.preventDefault();
       evt.stopPropagation();
       var useHref = href || window && window.location.href || null;
@@ -240,7 +262,7 @@ export var DisplayTitleColumnWrapper = /*#__PURE__*/React.memo(function (props) 
       }, function () {
         // We explicitly use globalPageNavigate here and not props.navigate, as props.navigate might refer
         // to VirtualHrefController.virtualNavigate and would not bring you to new page.
-        globalPageNavigate(link);
+        globalPageNavigate(navTarget);
       }, context);
       return false;
     };
@@ -263,10 +285,10 @@ export var DisplayTitleColumnWrapper = /*#__PURE__*/React.memo(function (props) 
 });
 /** Button shown in first column (display_title) to open/close detail pane. */
 
-export var TableRowToggleOpenButton = /*#__PURE__*/React.memo(function (_ref2) {
-  var onClick = _ref2.onClick,
-      toggleDetailOpen = _ref2.toggleDetailOpen,
-      open = _ref2.open;
+export var TableRowToggleOpenButton = /*#__PURE__*/React.memo(function (_ref4) {
+  var onClick = _ref4.onClick,
+      toggleDetailOpen = _ref4.toggleDetailOpen,
+      open = _ref4.open;
   return /*#__PURE__*/React.createElement("div", {
     className: "toggle-detail-button-container"
   }, /*#__PURE__*/React.createElement("button", {

--- a/src/components/browse/components/table-commons/basicColumnExtensionMap.js
+++ b/src/components/browse/components/table-commons/basicColumnExtensionMap.js
@@ -6,6 +6,7 @@ import { getItemType, getTitleForType } from './../../../util/schema-transforms'
 import { getNestedProperty, itemUtil } from './../../../util/object';
 import { productClick as trackProductClick, hrefToListName } from './../../../util/analytics';
 import { LocalizedTime } from './../../../ui/LocalizedTime';
+import { elementIsChildOfLink } from '../../../../../es/components/util/layout';
 
 
 export const DEFAULT_WIDTH_MAP = { 'lg' : 200, 'md' : 180, 'sm' : 120, 'xs' : 120 };
@@ -182,6 +183,19 @@ export const DisplayTitleColumnWrapper = React.memo(function(props){
     /** Registers a list click event for Google Analytics then performs navigation. */
     const onClick = useMemo(function(){
         return function handleClick(evt){
+            const { target = null } = evt || {};
+            let targetUrl;
+
+            if (target && target.href) {
+                targetUrl = target.href;
+            } else if (target && !target.href) {
+                // Check parent for hrefs if none found on current evt.target
+                const linkElement = elementIsChildOfLink(target);
+                const { href = null } = linkElement || {};
+                if (href) { targetUrl = href; }
+            }
+
+            const navTarget = targetUrl || link; // Fallback to atId if no href found
             evt.preventDefault();
             evt.stopPropagation();
             const useHref = href || (window && window.location.href) || null;
@@ -191,7 +205,7 @@ export const DisplayTitleColumnWrapper = React.memo(function(props){
                 function(){
                     // We explicitly use globalPageNavigate here and not props.navigate, as props.navigate might refer
                     // to VirtualHrefController.virtualNavigate and would not bring you to new page.
-                    globalPageNavigate(link);
+                    globalPageNavigate(navTarget);
                 },
                 context
             );


### PR DESCRIPTION
**Changelog:**
- Bugfix for search table onclicks: give priority for navigation to href from `<a>` element (target or nearest parent) instead of always using item atID. 
- Uses atID as a fallback in the case no target or parent `<a>` is available

**Notes:**
- Necessary for full functionality of https://github.com/dbmi-bgm/cgap-portal/pull/345
- Seems like if multiple `<a>` tags are present (really shouldn't happen unless someone wraps the output of the column render function in a `<a>`), it'll use the innermost `<a>`'s href. Best way to avoid is to not do that, and instead pass link/href as a prop to the render f(x) instead.