### PR TITLE
Table Cells Not Correctly Rendered In Details Tab

### DIFF
--- a/es/components/ui/ItemDetailList.js
+++ b/es/components/ui/ItemDetailList.js
@@ -646,13 +646,36 @@ var SubItemTable = /*#__PURE__*/function (_React$Component) {
           }
 
           if (val && _typeof(val) === 'object' && ! /*#__PURE__*/React.isValidElement(val) && !Array.isArray(val)) {
-            val = SubItemTable.jsonify(val, columnKeys[j].key);
+            if (isAnItem(val)) {
+              val = /*#__PURE__*/React.createElement("a", {
+                href: itemUtil.atId(val)
+              }, v.display_title);
+            } else {
+              val = SubItemTable.jsonify(val, columnKeys[j].key);
+            }
           }
 
           if (Array.isArray(val) && val.length > 0 && !_.all(val, React.isValidElement)) {
+            var renderAsList = val.length > 1;
             val = _.map(val, function (v, i) {
-              return SubItemTable.jsonify(v, columnKeys[j].key + ':' + i);
+              var item = null;
+
+              if (isAnItem(v)) {
+                item = /*#__PURE__*/React.createElement("a", {
+                  href: itemUtil.atId(v)
+                }, v.display_title);
+              } else {
+                item = SubItemTable.jsonify(v, columnKeys[j].key + ':' + i);
+              }
+
+              return renderAsList ? /*#__PURE__*/React.createElement("li", {
+                key: i
+              }, item) : item;
             });
+
+            if (renderAsList) {
+              val = /*#__PURE__*/React.createElement("ol", null, val);
+            }
           }
 
           return /*#__PURE__*/React.createElement("td", {

--- a/es/components/ui/ItemDetailList.js
+++ b/es/components/ui/ItemDetailList.js
@@ -629,7 +629,8 @@ var SubItemTable = /*#__PURE__*/function (_React$Component) {
         }, [/*#__PURE__*/React.createElement("td", {
           key: "rowNumber"
         }, i + 1, ".")].concat(row.map(function (colVal, j) {
-          var val = colVal.value;
+          var val = colVal.value,
+              className = colVal.className;
 
           if (typeof val === 'boolean') {
             val = /*#__PURE__*/React.createElement("code", null, val ? 'True' : 'False');
@@ -675,12 +676,13 @@ var SubItemTable = /*#__PURE__*/function (_React$Component) {
 
             if (renderAsList) {
               val = /*#__PURE__*/React.createElement("ol", null, val);
+              className += ' text-left';
             }
           }
 
           return /*#__PURE__*/React.createElement("td", {
             key: "column-for-" + columnKeys[j].key,
-            className: colVal.className || null
+            className: className || null
           }, val);
         })));
       }))));

--- a/src/components/ui/ItemDetailList.js
+++ b/src/components/ui/ItemDetailList.js
@@ -548,10 +548,24 @@ class SubItemTable extends React.Component {
                                                         val = val.slice(0,50) + '...';
                                                     }
                                                     if (val && typeof val === 'object' && !React.isValidElement(val) && !Array.isArray(val)) {
-                                                        val = SubItemTable.jsonify(val, columnKeys[j].key);
+                                                        if (isAnItem(val)) {
+                                                            val = <a href={itemUtil.atId(val)}>{v.display_title}</a>;
+                                                        } else {
+                                                            val = SubItemTable.jsonify(val, columnKeys[j].key);
+                                                        }
                                                     }
-                                                    if (Array.isArray(val) && val.length > 0 && !_.all(val, React.isValidElement) ){
-                                                        val = _.map(val, function(v,i){ return SubItemTable.jsonify(v, columnKeys[j].key + ':' + i); });
+                                                    if (Array.isArray(val) && val.length > 0 && !_.all(val, React.isValidElement)) {
+                                                        const renderAsList = val.length > 1;
+                                                        val = _.map(val, function (v, i) {
+                                                            let item = null;
+                                                            if (isAnItem(v)) {
+                                                                item = <a href={itemUtil.atId(v)}>{v.display_title}</a>;
+                                                            } else {
+                                                                item = SubItemTable.jsonify(v, columnKeys[j].key + ':' + i);
+                                                            }
+                                                            return renderAsList ? <li key={i}>{item}</li> : item;
+                                                        });
+                                                        if (renderAsList) { val = <ol>{val}</ol>; }
                                                     }
                                                     return (
                                                         <td key={("column-for-" + columnKeys[j].key)} className={colVal.className || null}>

--- a/src/components/ui/ItemDetailList.js
+++ b/src/components/ui/ItemDetailList.js
@@ -537,7 +537,7 @@ class SubItemTable extends React.Component {
                                         {
                                             [<td key="rowNumber">{ i + 1 }.</td>]
                                                 .concat(row.map(function(colVal, j){
-                                                    var val = colVal.value;
+                                                    let { value: val, className } = colVal;
                                                     if (typeof val === 'boolean'){
                                                         val = <code>{ val ? 'True' : 'False' }</code>;
                                                     }
@@ -565,10 +565,13 @@ class SubItemTable extends React.Component {
                                                             }
                                                             return renderAsList ? <li key={i}>{item}</li> : item;
                                                         });
-                                                        if (renderAsList) { val = <ol>{val}</ol>; }
+                                                        if (renderAsList) {
+                                                            val = <ol>{val}</ol>;
+                                                            className += ' text-left';
+                                                        }
                                                     }
                                                     return (
-                                                        <td key={("column-for-" + columnKeys[j].key)} className={colVal.className || null}>
+                                                        <td key={("column-for-" + columnKeys[j].key)} className={className || null}>
                                                             { val }
                                                         </td>
                                                     );


### PR DESCRIPTION
Trello: https://trello.com/c/BbPD0VJm

For some cases, ItemDetailList displays object values as JSON text in table cells via calling `SubItemTable.jsonify(..)` function. (this is the fallback condition when a better choice not found) On the other hand, some objects are `Item` and could be rendered as links to Item pages instead of plain JSON text. This PR updates object handling.

release: https://github.com/4dn-dcic/shared-portal-components/tree/0.1.7b1