### PR TITLE
targetTabKey prop added to embedded search tables

### DIFF
--- a/es/components/browse/EmbeddedSearchView.js
+++ b/es/components/browse/EmbeddedSearchView.js
@@ -219,7 +219,8 @@ _defineProperty(EmbeddedSearchView, "propTypes", {
   'facetListComponent': PropTypes.element,
   'facetColumnClassName': PropTypes.string,
   'tableColumnClassName': PropTypes.string,
-  'allowPostRequest': PropTypes.bool
+  'allowPostRequest': PropTypes.bool,
+  'targetTabKey': PropTypes.string
 });
 
 _defineProperty(EmbeddedSearchView, "defaultProps", {

--- a/es/components/browse/components/ControlsAndResults.js
+++ b/es/components/browse/components/ControlsAndResults.js
@@ -119,6 +119,7 @@ export var ControlsAndResults = /*#__PURE__*/function (_React$PureComponent) {
           facetColumnClassName = _this$props2$facetCol === void 0 ? "col-12 col-sm-5 col-lg-4 col-xl-3" : _this$props2$facetCol,
           _this$props2$tableCol = _this$props2.tableColumnClassName,
           tableColumnClassName = _this$props2$tableCol === void 0 ? "col-12 col-sm-7 col-lg-8 col-xl-9" : _this$props2$tableCol,
+          targetTabKey = _this$props2.targetTabKey,
           _this$props2$aboveTab = _this$props2.aboveTableComponent,
           aboveTableComponent = _this$props2$aboveTab === void 0 ? /*#__PURE__*/React.createElement(AboveSearchViewTableControls, null) : _this$props2$aboveTab,
           _this$props2$aboveFac = _this$props2.aboveFacetListComponent,
@@ -258,6 +259,7 @@ export var ControlsAndResults = /*#__PURE__*/function (_React$PureComponent) {
         rowHeight: rowHeight,
         defaultOpenIndices: defaultOpenIndices,
         maxHeight: maxHeight,
+        targetTabKey: targetTabKey,
         isContextLoading: isContextLoading // <- Only applicable for EmbeddedSearchView, else is false always
 
       }, {

--- a/es/components/browse/components/SearchResultTable.js
+++ b/es/components/browse/components/SearchResultTable.js
@@ -1292,7 +1292,7 @@ var DimensioningContainer = /*#__PURE__*/function (_React$PureComponent3) {
         tableContainerScrollLeft: tableContainerScrollLeft
       });
 
-      var resultRowCommonProps = _.extend(_.pick(this.props, 'renderDetailPane', 'detailPane', 'href', 'currentAction', 'schemas', 'termTransformFxn'), {
+      var resultRowCommonProps = _.extend(_.pick(this.props, 'renderDetailPane', 'detailPane', 'href', 'currentAction', 'schemas', 'termTransformFxn', 'targetTabKey'), {
         context: context,
         rowHeight: rowHeight,
         navigate: navigate,

--- a/es/components/browse/components/table-commons/basicColumnExtensionMap.js
+++ b/es/components/browse/components/table-commons/basicColumnExtensionMap.js
@@ -34,7 +34,8 @@ export var basicColumnExtensionMap = {
           context = parentProps.context,
           rowNumber = parentProps.rowNumber,
           detailOpen = parentProps.detailOpen,
-          toggleDetailOpen = parentProps.toggleDetailOpen;
+          toggleDetailOpen = parentProps.toggleDetailOpen,
+          targetTabKey = parentProps.targetTabKey;
       var _result$Type = result['@type'],
           itemTypeList = _result$Type === void 0 ? ["Item"] : _result$Type;
       var renderElem;
@@ -45,7 +46,8 @@ export var basicColumnExtensionMap = {
         });
       } else {
         renderElem = /*#__PURE__*/React.createElement(DisplayTitleColumnDefault, {
-          result: result
+          result: result,
+          targetTabKey: targetTabKey
         });
       }
 
@@ -191,18 +193,26 @@ export var DisplayTitleColumnUser = /*#__PURE__*/React.memo(function (_ref) {
 
 export var DisplayTitleColumnDefault = /*#__PURE__*/React.memo(function (props) {
   var result = props.result,
-      link = props.link,
+      propLink = props.link,
       onClick = props.onClick,
       _props$className = props.className,
-      className = _props$className === void 0 ? null : _props$className;
+      className = _props$className === void 0 ? null : _props$className,
+      _props$targetTabKey = props.targetTabKey,
+      targetTabKey = _props$targetTabKey === void 0 ? null : _props$targetTabKey;
   var title = itemUtil.getTitleStringFromContext(result); // Gets display_title || title || accession || ...
   // Monospace accessions, file formats
 
   var shouldMonospace = itemUtil.isDisplayTitleAccession(result, title) || result.file_format && result.file_format === title;
   var tooltip = typeof title === "string" && title.length > 20 && title || null;
 
-  if (link) {
+  if (propLink) {
     // This should be the case always
+    var link = propLink;
+
+    if (targetTabKey && typeof targetTabKey === 'string') {
+      link = "".concat(propLink, "#").concat(targetTabKey);
+    }
+
     title = /*#__PURE__*/React.createElement("a", {
       key: "title",
       href: link || '#',

--- a/src/components/browse/EmbeddedSearchView.js
+++ b/src/components/browse/EmbeddedSearchView.js
@@ -59,7 +59,8 @@ export class EmbeddedSearchView extends React.PureComponent {
         'facetListComponent' : PropTypes.element,
         'facetColumnClassName' : PropTypes.string,
         'tableColumnClassName' : PropTypes.string,
-        'allowPostRequest' : PropTypes.bool
+        'allowPostRequest' : PropTypes.bool,
+        'targetTabKey': PropTypes.string
     };
 
     static listToObj(hideFacetStrs){

--- a/src/components/browse/components/ControlsAndResults.js
+++ b/src/components/browse/components/ControlsAndResults.js
@@ -59,6 +59,7 @@ export class ControlsAndResults extends React.PureComponent {
             separateSingleTermFacets, navigate,
             facetColumnClassName = "col-12 col-sm-5 col-lg-4 col-xl-3",
             tableColumnClassName = "col-12 col-sm-7 col-lg-8 col-xl-9",
+            targetTabKey,
             // Default is component that renders out predefined buttons if receives props/data for them such as "Create New", "Full Screen", and "Column Selector".
             aboveTableComponent = <AboveSearchViewTableControls />, // Gets cloned further down in code to receive props from this ControlsAndResults component.
             // Default is blank element with same height as AboveSearchViewTableControls that allows to align tops of FacetList+Table headings.
@@ -98,7 +99,7 @@ export class ControlsAndResults extends React.PureComponent {
             columnDefinitions, visibleColumnDefinitions,
             setColumnWidths, columnWidths, detailPane,
             isOwnPage, sortBy, sortColumn, sortReverse, termTransformFxn, windowWidth, registerWindowOnScrollHandler, rowHeight,
-            defaultOpenIndices, maxHeight,
+            defaultOpenIndices, maxHeight, targetTabKey,
             isContextLoading // <- Only applicable for EmbeddedSearchView, else is false always
         };
 

--- a/src/components/browse/components/SearchResultTable.js
+++ b/src/components/browse/components/SearchResultTable.js
@@ -970,7 +970,7 @@ class DimensioningContainer extends React.PureComponent {
         };
 
         const resultRowCommonProps = _.extend(
-            _.pick(this.props, 'renderDetailPane', 'detailPane', 'href', 'currentAction', 'schemas', 'termTransformFxn'),
+            _.pick(this.props, 'renderDetailPane', 'detailPane', 'href', 'currentAction', 'schemas', 'termTransformFxn', 'targetTabKey'),
             {
                 context, rowHeight, navigate, isOwnPage, columnWidths,
                 columnDefinitions, tableContainerWidth, tableContainerScrollLeft, windowWidth,

--- a/src/components/browse/components/table-commons/basicColumnExtensionMap.js
+++ b/src/components/browse/components/table-commons/basicColumnExtensionMap.js
@@ -18,13 +18,13 @@ export const basicColumnExtensionMap = {
         'minColumnWidth' : 90,
         'order' : -100,
         'render' : function renderDisplayTitleColumn(result, parentProps){
-            const { href, context, rowNumber, detailOpen, toggleDetailOpen } = parentProps;
+            const { href, context, rowNumber, detailOpen, toggleDetailOpen, targetTabKey } = parentProps;
             const { '@type' : itemTypeList = ["Item"] } = result;
             let renderElem;
             if (itemTypeList[0] === "User") {
                 renderElem = <DisplayTitleColumnUser {...{ result }}/>;
             } else {
-                renderElem = <DisplayTitleColumnDefault {...{ result }}/>;
+                renderElem = <DisplayTitleColumnDefault {...{ result, targetTabKey }}/>;
             }
             return (
                 <DisplayTitleColumnWrapper {...{ result, href, context, rowNumber, detailOpen, toggleDetailOpen }}>
@@ -143,7 +143,7 @@ export const DisplayTitleColumnUser = React.memo(function DisplayTitleColumnUser
  * overrides/extensions.
  */
 export const DisplayTitleColumnDefault = React.memo(function DisplayTitleColumnDefault(props){
-    const { result, link, onClick, className = null } = props;
+    const { result, link: propLink, onClick, className = null, targetTabKey = null } = props;
 
     let title = itemUtil.getTitleStringFromContext(result); // Gets display_title || title || accession || ...
 
@@ -151,8 +151,12 @@ export const DisplayTitleColumnDefault = React.memo(function DisplayTitleColumnD
     const shouldMonospace = (itemUtil.isDisplayTitleAccession(result, title) || (result.file_format && result.file_format === title));
     const tooltip = (typeof title === "string" && title.length > 20 && title) || null;
 
-    if (link){ // This should be the case always
-        title = <a key="title" href={link || '#'} onClick={onClick}>{ title }</a>;
+    if (propLink){ // This should be the case always
+        let link = propLink;
+        if (targetTabKey && typeof targetTabKey === 'string'){
+            link = `${propLink}#${targetTabKey}`;
+        }
+        title = <a key="title" href={link || '#'} onClick={onClick}>{title}</a>;
     }
 
     const cls = (


### PR DESCRIPTION
Pls also check FF PR: https://github.com/4dn-dcic/fourfront/pull/1493

New `targetTabKey` prop (string) is added to embedded search tables. When a valid `targetTabKey` is passed, it is appended to result's `display_title` link's href with "#".

**Why do we need targetTabKey?**

When the user clicks the item link in the `display_title` column in the search results, it is navigated to the "Item" page with the default tab (1st tab) open. But we sometimes need to navigate to a specific tab. Here, `targetTabKey` helps us to navigate to the intended tab instead of the default.

Screencast (navigated to Exp.Set's Supplementary Files tab): https://i.gyazo.com/7f6f9d0146927bcffccb11a2423ee315.gif



