### PR TITLE
Flexible Description Box Long Text Clipping Off Issue

### DIFF
--- a/es/components/util/layout.js
+++ b/es/components/util/layout.js
@@ -236,7 +236,13 @@ export var textContentWidth = memoize(function (textContent) {
   var style = arguments.length > 4 && arguments[4] !== undefined ? arguments[4] : null;
   var contElem = document.createElement(containerElementType);
   contElem.className = "off-screen " + (containerClassName || '');
-  contElem.innerHTML = textContent + contElem.offsetHeight;
+  var constOffsetHeight = contElem.offsetHeight;
+
+  for (var i = 0; i < constOffsetHeight; i++) {
+    textContent += " ";
+  }
+
+  contElem.innerHTML = textContent;
   if (style) contElem.style = style;
   contElem.style.whiteSpace = "nowrap";
   document.body.appendChild(contElem);

--- a/es/components/util/layout.js
+++ b/es/components/util/layout.js
@@ -236,7 +236,7 @@ export var textContentWidth = memoize(function (textContent) {
   var style = arguments.length > 4 && arguments[4] !== undefined ? arguments[4] : null;
   var contElem = document.createElement(containerElementType);
   contElem.className = "off-screen " + (containerClassName || '');
-  contElem.innerHTML = textContent;
+  contElem.innerHTML = textContent + contElem.offsetHeight;
   if (style) contElem.style = style;
   contElem.style.whiteSpace = "nowrap";
   document.body.appendChild(contElem);
@@ -247,7 +247,7 @@ export var textContentWidth = memoize(function (textContent) {
     contElem.style.whiteSpace = "";
     contElem.style.display = "block";
     contElem.style.width = widthForHeightCheck + "px";
-    fullContainerHeight = contElem.clientHeight;
+    fullContainerHeight = window.innerWidth <= 768 ? Math.max(contElem.clientHeight, window.innerHeight || 0) : contElem.clientHeight;
   }
 
   document.body.removeChild(contElem);

--- a/src/components/util/layout.js
+++ b/src/components/util/layout.js
@@ -224,7 +224,7 @@ export const textContentWidth = memoize(function(
 ){
     var contElem = document.createElement(containerElementType);
     contElem.className = "off-screen " + (containerClassName || '');
-    contElem.innerHTML = textContent;
+    contElem.innerHTML = textContent+ contElem.offsetHeight;
     if (style) contElem.style = style;
     contElem.style.whiteSpace = "nowrap";
     document.body.appendChild(contElem);
@@ -234,7 +234,7 @@ export const textContentWidth = memoize(function(
         contElem.style.whiteSpace = "";
         contElem.style.display = "block";
         contElem.style.width = widthForHeightCheck + "px";
-        fullContainerHeight = contElem.clientHeight;
+        fullContainerHeight = window.innerWidth <= 768 ? Math.max(contElem.clientHeight, window.innerHeight|| 0): contElem.clientHeight;
     }
     document.body.removeChild(contElem);
     if (fullContainerHeight) {

--- a/src/components/util/layout.js
+++ b/src/components/util/layout.js
@@ -224,7 +224,7 @@ export const textContentWidth = memoize(function(
 ){
     var contElem = document.createElement(containerElementType);
     contElem.className = "off-screen " + (containerClassName || '');
-    contElem.innerHTML = textContent+ contElem.offsetHeight;
+    contElem.innerHTML = textContent + contElem.offsetHeight;
     if (style) contElem.style = style;
     contElem.style.whiteSpace = "nowrap";
     document.body.appendChild(contElem);
@@ -234,7 +234,7 @@ export const textContentWidth = memoize(function(
         contElem.style.whiteSpace = "";
         contElem.style.display = "block";
         contElem.style.width = widthForHeightCheck + "px";
-        fullContainerHeight = window.innerWidth <= 768 ? Math.max(contElem.clientHeight, window.innerHeight|| 0): contElem.clientHeight;
+        fullContainerHeight = window.innerWidth <= 768 ? Math.max(contElem.clientHeight, window.innerHeight || 0) : contElem.clientHeight;
     }
     document.body.removeChild(contElem);
     if (fullContainerHeight) {

--- a/src/components/util/layout.js
+++ b/src/components/util/layout.js
@@ -224,7 +224,10 @@ export const textContentWidth = memoize(function(
 ){
     var contElem = document.createElement(containerElementType);
     contElem.className = "off-screen " + (containerClassName || '');
-    contElem.innerHTML = textContent + contElem.offsetHeight;
+    const constOffsetHeight = contElem.offsetHeight;
+    for (var i = 0; i < constOffsetHeight; i++) { textContent += " " ;}
+    contElem.innerHTML = textContent;
+
     if (style) contElem.style = style;
     contElem.style.whiteSpace = "nowrap";
     document.body.appendChild(contElem);

--- a/src/components/util/layout.js
+++ b/src/components/util/layout.js
@@ -222,17 +222,17 @@ export const textContentWidth = memoize(function(
     widthForHeightCheck = null,
     style = null
 ){
-    var contElem = document.createElement(containerElementType);
+    const contElem = document.createElement(containerElementType);
     contElem.className = "off-screen " + (containerClassName || '');
     const constOffsetHeight = contElem.offsetHeight;
-    for (var i = 0; i < constOffsetHeight; i++) { textContent += " " ;}
+    for (var i = 0; i < constOffsetHeight; i++) { textContent += " "; }
     contElem.innerHTML = textContent;
 
     if (style) contElem.style = style;
     contElem.style.whiteSpace = "nowrap";
     document.body.appendChild(contElem);
-    var textLineWidth = contElem.clientWidth;
-    var fullContainerHeight;
+    const textLineWidth = contElem.clientWidth;
+    let fullContainerHeight;
     if (widthForHeightCheck){
         contElem.style.whiteSpace = "";
         contElem.style.display = "block";


### PR DESCRIPTION
Please handle this PR along with https://github.com/4dn-dcic/fourfront/pull/1499

Trello: https://trello.com/c/Cypdy46K

Some lines of long descriptions are clipped off due to miscalculation of content height. This issue is observed in Chrome's desktop version and all mobile browsers.

Chrome has a known issue since version 47: https://stackoverflow.com/questions/65453475/getting-wrong-window-height-in-chrome

### Old:

![Browser Chrome](https://user-images.githubusercontent.com/49978017/122381347-7d936d80-cf71-11eb-96f5-f68914783fad.png)
![Screen Shot 2021-06-16 at 11 55 23](https://user-images.githubusercontent.com/49978017/122381352-7f5d3100-cf71-11eb-8763-89f411a5c0d5.png)
![Screen Shot 2021-06-16 at 11 53 09](https://user-images.githubusercontent.com/49978017/122381354-7f5d3100-cf71-11eb-9324-cb8c227d7c29.png)

### New:

![BrowserChrome1](https://user-images.githubusercontent.com/49978017/122381337-7bc9aa00-cf71-11eb-819a-43f6d8a3b1f7.png)
![Screen Shot 2021-06-16 at 11 55 58](https://user-images.githubusercontent.com/49978017/122381351-7ec49a80-cf71-11eb-86d3-7c9f97e07a1d.png)
![Screen Shot 2021-06-16 at 11 54 38](https://user-images.githubusercontent.com/49978017/122381334-7a987d00-cf71-11eb-881b-408edcad805c.png)