### PR TITLE
Support props.indeterminate in Checkbox

### DIFF
--- a/es/components/browse/components/CustomColumnController.js
+++ b/es/components/browse/components/CustomColumnController.js
@@ -130,30 +130,31 @@ export var CustomColumnController = /*#__PURE__*/function (_React$Component) {
   }, {
     key: "addHiddenColumn",
     value: function addHiddenColumn(field) {
-      this.setState(function (currState) {
-        if (currState.hiddenColumns[field] === true) {
+      this.setState(function (_ref) {
+        var currHiddenColumns = _ref.hiddenColumns;
+
+        if (currHiddenColumns[field] === true) {
           return null;
         }
 
-        var hiddenColumns = _.clone(currState.hiddenColumns);
-
-        hiddenColumns[field] = true;
         return {
-          hiddenColumns: hiddenColumns
+          hiddenColumns: _objectSpread(_objectSpread({}, currHiddenColumns), {}, _defineProperty({}, field, true))
         };
       });
     }
   }, {
     key: "removeHiddenColumn",
     value: function removeHiddenColumn(field) {
-      this.setState(function (currState) {
-        if (currState.hiddenColumns[field] === false) {
+      this.setState(function (_ref2) {
+        var currHiddenColumns = _ref2.hiddenColumns;
+
+        if (currHiddenColumns[field] === false) {
           return null;
         }
 
-        var hiddenColumns = _.clone(currState.hiddenColumns);
+        var hiddenColumns = _objectSpread({}, currHiddenColumns);
 
-        hiddenColumns[field] = false;
+        delete hiddenColumns[field];
         return {
           hiddenColumns: hiddenColumns
         };
@@ -258,13 +259,12 @@ export var CustomColumnSelector = /*#__PURE__*/function (_React$PureComponent) {
           hiddenColumns = _this$props2.hiddenColumns,
           removeHiddenColumn = _this$props2.removeHiddenColumn,
           addHiddenColumn = _this$props2.addHiddenColumn;
-      setTimeout(function () {
-        if (hiddenColumns[field] === true) {
-          removeHiddenColumn(field);
-        } else {
-          addHiddenColumn(field);
-        }
-      }, 0);
+
+      if (hiddenColumns[field] === true) {
+        removeHiddenColumn(field);
+      } else {
+        addHiddenColumn(field);
+      }
     }
   }, {
     key: "render",

--- a/es/components/forms/components/Checkbox.js
+++ b/es/components/forms/components/Checkbox.js
@@ -5,6 +5,7 @@ function _objectWithoutProperties(source, excluded) { if (source == null) return
 function _objectWithoutPropertiesLoose(source, excluded) { if (source == null) return {}; var target = {}; var sourceKeys = Object.keys(source); var key, i; for (i = 0; i < sourceKeys.length; i++) { key = sourceKeys[i]; if (excluded.indexOf(key) >= 0) continue; target[key] = source[key]; } return target; }
 
 import React from 'react';
+import { IndeterminateCheckbox } from './IndeterminateCheckbox';
 /** Emulates React-Bootstrap 0.32.4 Checkbox for backwards compatibility */
 
 export var Checkbox = /*#__PURE__*/React.memo(function (props) {
@@ -15,17 +16,29 @@ export var Checkbox = /*#__PURE__*/React.memo(function (props) {
       title = props.title,
       _props$inputClassName = props.inputClassName,
       inputClassName = _props$inputClassName === void 0 ? "mr-08 align-middle" : _props$inputClassName,
-      passProps = _objectWithoutProperties(props, ["className", "children", "labelClassName", "title", "inputClassName"]);
+      _props$indeterminate = props.indeterminate,
+      indeterminate = _props$indeterminate === void 0 ? false : _props$indeterminate,
+      passProps = _objectWithoutProperties(props, ["className", "children", "labelClassName", "title", "inputClassName", "indeterminate"]);
 
   var disabled = passProps.disabled;
   var cls = "checkbox checkbox-with-label" + (disabled ? " disabled" : "") + (className ? " " + className : "");
+  var checkboxElement = indeterminate ?
+  /*#__PURE__*/
+  // We assume that we can never receive a props.indeterminate here unless also providing
+  // a boolean `props.checked` for fully controlled input element. Hence uncontrolled
+  // <input> shouldn't ever lose its uncontrolled state by changing to IndeterminateCheckbox.
+  React.createElement(IndeterminateCheckbox, _extends({
+    className: inputClassName
+  }, passProps, {
+    indeterminate: true
+  })) : /*#__PURE__*/React.createElement("input", _extends({
+    type: "checkbox",
+    className: inputClassName
+  }, passProps));
   return /*#__PURE__*/React.createElement("div", {
     className: cls
   }, /*#__PURE__*/React.createElement("label", {
     title: title,
     className: labelClassName
-  }, /*#__PURE__*/React.createElement("input", _extends({
-    type: "checkbox",
-    className: inputClassName
-  }, passProps)), children));
+  }, checkboxElement, children));
 });

--- a/es/components/forms/components/IndeterminateCheckbox.js
+++ b/es/components/forms/components/IndeterminateCheckbox.js
@@ -1,91 +1,21 @@
-function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function (obj) { return typeof obj; }; } else { _typeof = function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
-
 function _extends() { _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
 
 function _objectWithoutProperties(source, excluded) { if (source == null) return {}; var target = _objectWithoutPropertiesLoose(source, excluded); var key, i; if (Object.getOwnPropertySymbols) { var sourceSymbolKeys = Object.getOwnPropertySymbols(source); for (i = 0; i < sourceSymbolKeys.length; i++) { key = sourceSymbolKeys[i]; if (excluded.indexOf(key) >= 0) continue; if (!Object.prototype.propertyIsEnumerable.call(source, key)) continue; target[key] = source[key]; } } return target; }
 
 function _objectWithoutPropertiesLoose(source, excluded) { if (source == null) return {}; var target = {}; var sourceKeys = Object.keys(source); var key, i; for (i = 0; i < sourceKeys.length; i++) { key = sourceKeys[i]; if (excluded.indexOf(key) >= 0) continue; target[key] = source[key]; } return target; }
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-
-function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
-
-function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
-
-function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function (o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
-
-function _createSuper(Derived) { var hasNativeReflectConstruct = _isNativeReflectConstruct(); return function () { var Super = _getPrototypeOf(Derived), result; if (hasNativeReflectConstruct) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
-
-function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
-
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
-
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
-
-function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function (o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
-
 import React from 'react';
-import _ from 'underscore';
-export var IndeterminateCheckbox = /*#__PURE__*/function (_React$PureComponent) {
-  _inherits(IndeterminateCheckbox, _React$PureComponent);
+export function IndeterminateCheckbox(props) {
+  var _props$indeterminate = props.indeterminate,
+      indeterminate = _props$indeterminate === void 0 ? false : _props$indeterminate,
+      passProps = _objectWithoutProperties(props, ["indeterminate"]); // See https://reactjs.org/docs/refs-and-the-dom.html#callback-refs
 
-  var _super = _createSuper(IndeterminateCheckbox);
 
-  function IndeterminateCheckbox(props) {
-    var _this;
-
-    _classCallCheck(this, IndeterminateCheckbox);
-
-    _this = _super.call(this, props);
-    _this.setIndeterminateOnRef = _this.setIndeterminateOnRef.bind(_assertThisInitialized(_this));
-    _this.checkboxRef = /*#__PURE__*/React.createRef();
-    return _this;
-  }
-
-  _createClass(IndeterminateCheckbox, [{
-    key: "componentDidMount",
-    value: function componentDidMount() {
-      var indeterminate = this.props.indeterminate; // Can be skipped if not set to true.
-
-      if (indeterminate === true) {
-        this.setIndeterminateOnRef();
-      }
+  return /*#__PURE__*/React.createElement("input", _extends({
+    type: "checkbox"
+  }, passProps, {
+    ref: function callbackRef(el) {
+      if (indeterminate && el) el.indeterminate = indeterminate;
     }
-  }, {
-    key: "componentDidUpdate",
-    value: function componentDidUpdate(_ref) {
-      var pastIndeterminate = _ref.indeterminate;
-      var indeterminate = this.props.indeterminate;
-
-      if (pastIndeterminate !== indeterminate) {
-        this.setIndeterminateOnRef();
-      }
-    }
-  }, {
-    key: "setIndeterminateOnRef",
-    value: function setIndeterminateOnRef() {
-      var indeterminate = this.props.indeterminate;
-
-      if (this.checkboxRef.current) {
-        this.checkboxRef.current.indeterminate = indeterminate;
-      }
-    }
-  }, {
-    key: "render",
-    value: function render() {
-      var _this$props = this.props,
-          indeterminate = _this$props.indeterminate,
-          passProps = _objectWithoutProperties(_this$props, ["indeterminate"]);
-
-      return /*#__PURE__*/React.createElement("input", _extends({
-        type: "checkbox"
-      }, passProps, {
-        ref: this.checkboxRef
-      }));
-    }
-  }]);
-
-  return IndeterminateCheckbox;
-}(React.PureComponent);
+  }));
+}

--- a/es/components/forms/components/IndeterminateCheckbox.js
+++ b/es/components/forms/components/IndeterminateCheckbox.js
@@ -2,6 +2,10 @@ function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "functi
 
 function _extends() { _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
 
+function _objectWithoutProperties(source, excluded) { if (source == null) return {}; var target = _objectWithoutPropertiesLoose(source, excluded); var key, i; if (Object.getOwnPropertySymbols) { var sourceSymbolKeys = Object.getOwnPropertySymbols(source); for (i = 0; i < sourceSymbolKeys.length; i++) { key = sourceSymbolKeys[i]; if (excluded.indexOf(key) >= 0) continue; if (!Object.prototype.propertyIsEnumerable.call(source, key)) continue; target[key] = source[key]; } } return target; }
+
+function _objectWithoutPropertiesLoose(source, excluded) { if (source == null) return {}; var target = {}; var sourceKeys = Object.keys(source); var key, i; for (i = 0; i < sourceKeys.length; i++) { key = sourceKeys[i]; if (excluded.indexOf(key) >= 0) continue; target[key] = source[key]; } return target; }
+
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
@@ -43,31 +47,41 @@ export var IndeterminateCheckbox = /*#__PURE__*/function (_React$PureComponent) 
   _createClass(IndeterminateCheckbox, [{
     key: "componentDidMount",
     value: function componentDidMount() {
-      // Can be skipped if not set to true.
-      if (this.props.indeterminate === true) {
+      var indeterminate = this.props.indeterminate; // Can be skipped if not set to true.
+
+      if (indeterminate === true) {
         this.setIndeterminateOnRef();
       }
     }
   }, {
     key: "componentDidUpdate",
-    value: function componentDidUpdate(pastProps) {
-      if (pastProps.indeterminate !== this.props.indeterminate) {
+    value: function componentDidUpdate(_ref) {
+      var pastIndeterminate = _ref.indeterminate;
+      var indeterminate = this.props.indeterminate;
+
+      if (pastIndeterminate !== indeterminate) {
         this.setIndeterminateOnRef();
       }
     }
   }, {
     key: "setIndeterminateOnRef",
     value: function setIndeterminateOnRef() {
+      var indeterminate = this.props.indeterminate;
+
       if (this.checkboxRef.current) {
-        this.checkboxRef.current.indeterminate = this.props.indeterminate;
+        this.checkboxRef.current.indeterminate = indeterminate;
       }
     }
   }, {
     key: "render",
     value: function render() {
+      var _this$props = this.props,
+          indeterminate = _this$props.indeterminate,
+          passProps = _objectWithoutProperties(_this$props, ["indeterminate"]);
+
       return /*#__PURE__*/React.createElement("input", _extends({
         type: "checkbox"
-      }, _.omit(this.props, 'indeterminate'), {
+      }, passProps, {
         ref: this.checkboxRef
       }));
     }

--- a/src/components/browse/components/CustomColumnController.js
+++ b/src/components/browse/components/CustomColumnController.js
@@ -77,23 +77,21 @@ export class CustomColumnController extends React.Component {
     }
 
     addHiddenColumn(field){
-        this.setState(function(currState){
-            if (currState.hiddenColumns[field] === true){
+        this.setState(function({ hiddenColumns: currHiddenColumns }){
+            if (currHiddenColumns[field] === true){
                 return null;
             }
-            var hiddenColumns = _.clone(currState.hiddenColumns);
-            hiddenColumns[field] = true;
-            return { hiddenColumns };
+            return { hiddenColumns: { ...currHiddenColumns, [field]: true } };
         });
     }
 
     removeHiddenColumn(field){
-        this.setState(function(currState){
-            if (currState.hiddenColumns[field] === false){
+        this.setState(function({ hiddenColumns: currHiddenColumns }){
+            if (currHiddenColumns[field] === false){
                 return null;
             }
-            var hiddenColumns = _.clone(currState.hiddenColumns);
-            hiddenColumns[field] = false;
+            const hiddenColumns = { ...currHiddenColumns } ;
+            delete hiddenColumns[field];
             return { hiddenColumns };
         });
     }
@@ -166,13 +164,11 @@ export class CustomColumnSelector extends React.PureComponent {
         evt.stopPropagation();
         const field = evt.target.value;
         const { hiddenColumns, removeHiddenColumn, addHiddenColumn } = this.props;
-        setTimeout(function(){
-            if (hiddenColumns[field] === true){
-                removeHiddenColumn(field);
-            } else {
-                addHiddenColumn(field);
-            }
-        }, 0);
+        if (hiddenColumns[field] === true){
+            removeHiddenColumn(field);
+        } else {
+            addHiddenColumn(field);
+        }
     }
 
     render(){

--- a/src/components/forms/components/Checkbox.js
+++ b/src/components/forms/components/Checkbox.js
@@ -1,19 +1,36 @@
 import React from 'react';
+import { IndeterminateCheckbox } from './IndeterminateCheckbox';
 
 /** Emulates React-Bootstrap 0.32.4 Checkbox for backwards compatibility */
 
 export const Checkbox = React.memo(function Checkbox(props){
-    const { className, children, labelClassName = "mb-0", title, inputClassName = "mr-08 align-middle", ...passProps } = props;
+    const {
+        className,
+        children,
+        labelClassName = "mb-0",
+        title,
+        inputClassName = "mr-08 align-middle",
+        indeterminate = false,
+        ...passProps
+    } = props;
     const { disabled } = passProps;
     const cls = (
         "checkbox checkbox-with-label" +
         (disabled ? " disabled" : "") +
         (className ? " " + className : "")
     );
+
+    const checkboxElement = indeterminate ?
+        // We assume that we can never receive a props.indeterminate here unless also providing
+        // a boolean `props.checked` for fully controlled input element. Hence uncontrolled
+        // <input> shouldn't ever lose its uncontrolled state by changing to IndeterminateCheckbox.
+        <IndeterminateCheckbox className={inputClassName} {...passProps} indeterminate />
+        : <input type="checkbox" className={inputClassName} {...passProps} />;
+
     return (
         <div className={cls}>
             <label title={title} className={labelClassName}>
-                <input type="checkbox" className={inputClassName} {...passProps} />
+                { checkboxElement }
                 { children }
             </label>
         </div>

--- a/src/components/forms/components/IndeterminateCheckbox.js
+++ b/src/components/forms/components/IndeterminateCheckbox.js
@@ -2,6 +2,7 @@ import React from 'react';
 import _ from 'underscore';
 
 export class IndeterminateCheckbox extends React.PureComponent {
+
     constructor(props){
         super(props);
         this.setIndeterminateOnRef = this.setIndeterminateOnRef.bind(this);
@@ -9,25 +10,29 @@ export class IndeterminateCheckbox extends React.PureComponent {
     }
 
     componentDidMount(){
+        const { indeterminate } = this.props;
         // Can be skipped if not set to true.
-        if (this.props.indeterminate === true){
+        if (indeterminate === true){
             this.setIndeterminateOnRef();
         }
     }
 
-    componentDidUpdate(pastProps){
-        if (pastProps.indeterminate !== this.props.indeterminate){
+    componentDidUpdate({ indeterminate: pastIndeterminate }){
+        const { indeterminate } = this.props;
+        if (pastIndeterminate !== indeterminate){
             this.setIndeterminateOnRef();
         }
     }
 
     setIndeterminateOnRef(){
+        const { indeterminate } = this.props;
         if (this.checkboxRef.current){
-            this.checkboxRef.current.indeterminate = this.props.indeterminate;
+            this.checkboxRef.current.indeterminate = indeterminate;
         }
     }
 
     render(){
-        return <input type="checkbox" {..._.omit(this.props, 'indeterminate')} ref={this.checkboxRef} />;
+        const { indeterminate, ...passProps } = this.props;
+        return <input type="checkbox" {...passProps} ref={this.checkboxRef} />;
     }
 }

--- a/src/components/forms/components/IndeterminateCheckbox.js
+++ b/src/components/forms/components/IndeterminateCheckbox.js
@@ -1,38 +1,10 @@
 import React from 'react';
-import _ from 'underscore';
 
-export class IndeterminateCheckbox extends React.PureComponent {
-
-    constructor(props){
-        super(props);
-        this.setIndeterminateOnRef = this.setIndeterminateOnRef.bind(this);
-        this.checkboxRef = React.createRef();
-    }
-
-    componentDidMount(){
-        const { indeterminate } = this.props;
-        // Can be skipped if not set to true.
-        if (indeterminate === true){
-            this.setIndeterminateOnRef();
-        }
-    }
-
-    componentDidUpdate({ indeterminate: pastIndeterminate }){
-        const { indeterminate } = this.props;
-        if (pastIndeterminate !== indeterminate){
-            this.setIndeterminateOnRef();
-        }
-    }
-
-    setIndeterminateOnRef(){
-        const { indeterminate } = this.props;
-        if (this.checkboxRef.current){
-            this.checkboxRef.current.indeterminate = indeterminate;
-        }
-    }
-
-    render(){
-        const { indeterminate, ...passProps } = this.props;
-        return <input type="checkbox" {...passProps} ref={this.checkboxRef} />;
-    }
+export function IndeterminateCheckbox (props) {
+    const { indeterminate = false, ...passProps } = props;
+    // See https://reactjs.org/docs/refs-and-the-dom.html#callback-refs
+    const callbackRef = function(el){
+        if (indeterminate && el) el.indeterminate = indeterminate;
+    };
+    return <input type="checkbox" {...passProps} ref={callbackRef} />;
 }


### PR DESCRIPTION
Checkbox component (which provides label wrapper) now uses `IndeterminateCheckbox` instead of `<input type="checkbox">` JSX element if `props.indeterminate` is passed in and set to `true`.