### PR TITLE
Performant Display of Stacked Tables Having Lots of Items

### DIFF
--- a/es/components/browse/components/StackedBlockTable.js
+++ b/es/components/browse/components/StackedBlockTable.js
@@ -191,8 +191,11 @@ export var StackedBlockList = /*#__PURE__*/function (_React$PureComponent3) {
     _this = _super3.call(this, props);
     _this.adjustedChildren = _this.adjustedChildren.bind(_assertThisInitialized(_this));
     _this.handleCollapseToggle = _this.handleCollapseToggle.bind(_assertThisInitialized(_this));
+    _this.handleCollapseMoreThanClick = _this.handleCollapseMoreThanClick.bind(_assertThisInitialized(_this));
+    _this.handleCollapseMoreLessClick = _this.handleCollapseMoreLessClick.bind(_assertThisInitialized(_this));
     _this.state = {
-      'collapsed': props.defaultCollapsed
+      'collapsed': props.defaultCollapsed,
+      'collapsibleCounter': 0
     };
     return _this;
   }
@@ -217,7 +220,7 @@ export var StackedBlockList = /*#__PURE__*/function (_React$PureComponent3) {
           stackDepth: stackDepth + 1
         }; //const childProps = _.pick(this.props, 'colWidthStyles', 'selectedFiles', 'columnHeaders', 'handleFileCheckboxChange');
 
-        _.forEach(['collapseLongLists', 'collapseLimit', 'collapseShow', 'defaultCollapsed'], function (prop) {
+        _.forEach(['collapseLongLists', 'collapseLimit', 'collapseShow', 'defaultCollapsed', 'collapseShowMoreLimit'], function (prop) {
           if (typeof c.props[prop] === 'undefined') {
             childProps[prop] = _this2.props[prop] || null;
           }
@@ -243,8 +246,24 @@ export var StackedBlockList = /*#__PURE__*/function (_React$PureComponent3) {
       });
     }
   }, {
+    key: "handleCollapseMoreThanClick",
+    value: function handleCollapseMoreThanClick(count) {
+      this.setState({
+        'collapsibleCounter': count + 100
+      });
+    }
+  }, {
+    key: "handleCollapseMoreLessClick",
+    value: function handleCollapseMoreLessClick(count) {
+      this.setState({
+        'collapsibleCounter': count
+      });
+    }
+  }, {
     key: "render",
     value: function render() {
+      var _this3 = this;
+
       var _this$props4 = this.props,
           collapseLongLists = _this$props4.collapseLongLists,
           stackDepth = _this$props4.stackDepth,
@@ -252,8 +271,11 @@ export var StackedBlockList = /*#__PURE__*/function (_React$PureComponent3) {
           collapseShow = _this$props4.collapseShow,
           className = _this$props4.className,
           colWidthStyles = _this$props4.colWidthStyles,
-          columnClass = _this$props4.columnClass;
-      var collapsed = this.state.collapsed;
+          columnClass = _this$props4.columnClass,
+          collapseShowMoreLimit = _this$props4.collapseShowMoreLimit;
+      var _this$state = this.state,
+          collapsed = _this$state.collapsed,
+          collapsibleCounter = _this$state.collapsibleCounter;
       var children = this.adjustedChildren();
       var useStyle = colWidthStyles["list:" + columnClass]; // columnClass here is of parent StackedBlock, not of its children.
 
@@ -267,15 +289,28 @@ export var StackedBlockList = /*#__PURE__*/function (_React$PureComponent3) {
         }, children);
       }
 
-      var collapsibleChildren = children.slice(collapseShow);
+      var collapsibleChildren; //More than collapse calculate
+
+      if (children.length > collapseShowMoreLimit) {
+        collapsibleChildren = children.slice(0, collapsibleCounter + collapseShow);
+      } else {
+        collapsibleChildren = children.slice(collapseShow);
+      }
+
       var collapsibleChildrenLen = collapsibleChildren.length;
       var collapsibleChildrenElemsList;
 
       if (collapsibleChildrenLen > Math.min(collapseShow, 10)) {
         // Don't transition
-        collapsibleChildrenElemsList = collapsed ? null : /*#__PURE__*/React.createElement("div", {
-          className: "collapsible-s-block-ext"
-        }, collapsibleChildren);
+        if (collapsibleCounter > 0) {
+          collapsibleChildrenElemsList = /*#__PURE__*/React.createElement("div", {
+            className: "collapsible-s-block-ext"
+          }, children.slice(0, collapsibleCounter));
+        } else {
+          collapsibleChildrenElemsList = collapsed ? null : /*#__PURE__*/React.createElement("div", {
+            className: "collapsible-s-block-ext"
+          }, collapsibleChildren);
+        }
       } else {
         collapsibleChildrenElemsList = /*#__PURE__*/React.createElement(Collapse, {
           "in": !collapsed
@@ -284,15 +319,45 @@ export var StackedBlockList = /*#__PURE__*/function (_React$PureComponent3) {
         }, collapsibleChildren));
       }
 
+      var calculateCollapseCounter = children.length - collapsibleChildren <= 100 ? children.length : collapsibleCounter;
+      var collapseType = null;
+      var title;
+
+      if (children.length - collapsibleChildren.length <= 100) {
+        title = "Show ".concat(children.length - collapsibleChildren.length, " More Files");
+      } else {
+        title = "Show 100 More Files (Total ".concat(children.length - collapsibleChildren.length, " Files to Show)");
+      }
+
+      if (children.length > collapseShowMoreLimit) {
+        collapseType = children.length > collapseShowMoreLimit && children.length - collapsibleCounter > 0 ? /*#__PURE__*/React.createElement("div", {
+          className: "view-more-button",
+          onClick: function onClick() {
+            _this3.handleCollapseMoreThanClick(calculateCollapseCounter);
+          }
+        }, /*#__PURE__*/React.createElement("i", {
+          className: "mr-1 icon fas icon-plus"
+        }), /*#__PURE__*/React.createElement("span", null, " ", title, " ")) : null;
+      } else {
+        collapseType = /*#__PURE__*/React.createElement(StackedBlockListViewMoreButton, _extends({}, this.props, {
+          collapsibleChildren: collapsibleChildren,
+          collapsed: collapsed,
+          handleCollapseToggle: this.handleCollapseToggle
+        }));
+      }
+
       return /*#__PURE__*/React.createElement("div", {
         className: cls,
         "data-count-collapsed": collapsibleChildren.length,
         style: useStyle
-      }, children.slice(0, collapseShow), collapsibleChildrenElemsList, /*#__PURE__*/React.createElement(StackedBlockListViewMoreButton, _extends({}, this.props, {
-        collapsibleChildren: collapsibleChildren,
-        collapsed: collapsed,
-        handleCollapseToggle: this.handleCollapseToggle
-      })));
+      }, collapsibleCounter > collapseShow ? /*#__PURE__*/React.createElement("div", {
+        className: "view-more-button",
+        onClick: function onClick() {
+          _this3.handleCollapseMoreLessClick(calculateCollapseCounter - 100);
+        }
+      }, /*#__PURE__*/React.createElement("i", {
+        className: "icon fas icon-minus mr-1 ml-02 small"
+      }), /*#__PURE__*/React.createElement("span", null, " ", 'Show Fewer Files ')) : null, children.slice(0, collapseShow), collapsibleChildrenElemsList, collapseType);
     }
   }]);
 
@@ -308,7 +373,8 @@ _defineProperty(StackedBlockList, "propTypes", {
   'collapseLongLists': PropTypes.bool,
   'defaultCollapsed': PropTypes.bool,
   'children': PropTypes.arrayOf(PropTypes.node),
-  'stackDepth': PropTypes.number
+  'stackDepth': PropTypes.number,
+  'collapseShowMoreLimit': PropTypes.number
 });
 
 export var StackedBlock = /*#__PURE__*/function (_React$PureComponent4) {
@@ -318,19 +384,19 @@ export var StackedBlock = /*#__PURE__*/function (_React$PureComponent4) {
 
   /** TODO MAYBE USE HERE & ON LIST */
   function StackedBlock(props) {
-    var _this3;
+    var _this4;
 
     _classCallCheck(this, StackedBlock);
 
-    _this3 = _super4.call(this, props);
-    _this3.adjustedChildren = _this3.adjustedChildren.bind(_assertThisInitialized(_this3));
-    return _this3;
+    _this4 = _super4.call(this, props);
+    _this4.adjustedChildren = _this4.adjustedChildren.bind(_assertThisInitialized(_this4));
+    return _this4;
   }
 
   _createClass(StackedBlock, [{
     key: "adjustedChildren",
     value: function adjustedChildren() {
-      var _this4 = this;
+      var _this5 = this;
 
       var _this$props5 = this.props,
           children = _this$props5.children,
@@ -355,15 +421,15 @@ export var StackedBlock = /*#__PURE__*/function (_React$PureComponent4) {
         );
         */
 
-        _.forEach(['collapseLongLists', 'collapseLimit', 'collapseShow', 'defaultCollapsed', 'preventExpand'], function (prop) {
+        _.forEach(['collapseLongLists', 'collapseLimit', 'collapseShow', 'defaultCollapsed', 'preventExpand', 'collapseShowMoreLimit'], function (prop) {
           if (typeof c.props[prop] === 'undefined') {
-            childProps[prop] = _this4.props[prop];
+            childProps[prop] = _this5.props[prop];
           }
         });
 
-        _.forEach(_.keys(_this4.props), function (prop) {
+        _.forEach(_.keys(_this5.props), function (prop) {
           if (typeof c.props[prop] === 'undefined' && typeof childProps[prop] === 'undefined' && !StackedBlock.excludedPassedProps.has(prop)) {
-            childProps[prop] = _this4.props[prop];
+            childProps[prop] = _this5.props[prop];
           }
         });
 
@@ -472,21 +538,21 @@ export var StackedBlockTable = /*#__PURE__*/function (_React$PureComponent5) {
   }]);
 
   function StackedBlockTable(props) {
-    var _this5;
+    var _this6;
 
     _classCallCheck(this, StackedBlockTable);
 
-    _this5 = _super5.call(this, props);
-    _this5.adjustedChildren = _this5.adjustedChildren.bind(_assertThisInitialized(_this5));
-    _this5.setCollapsingState = _.throttle(_this5.setCollapsingState.bind(_assertThisInitialized(_this5)));
-    _this5.memoized = {
+    _this6 = _super5.call(this, props);
+    _this6.adjustedChildren = _this6.adjustedChildren.bind(_assertThisInitialized(_this6));
+    _this6.setCollapsingState = _.throttle(_this6.setCollapsingState.bind(_assertThisInitialized(_this6)));
+    _this6.memoized = {
       totalColumnsMinWidth: memoize(StackedBlockTable.totalColumnsMinWidth),
       colWidthStyles: memoize(StackedBlockTable.colWidthStyles)
     };
-    _this5.state = {
+    _this6.state = {
       'mounted': false
     };
-    return _this5;
+    return _this6;
   }
 
   _createClass(StackedBlockTable, [{
@@ -506,7 +572,7 @@ export var StackedBlockTable = /*#__PURE__*/function (_React$PureComponent5) {
   }, {
     key: "adjustedChildren",
     value: function adjustedChildren() {
-      var _this6 = this;
+      var _this7 = this;
 
       var _this$props7 = this.props,
           children = _this$props7.children,
@@ -515,7 +581,7 @@ export var StackedBlockTable = /*#__PURE__*/function (_React$PureComponent5) {
       var colWidthStyles = this.memoized.colWidthStyles(columnHeaders, defaultInitialColumnWidth);
       return React.Children.map(children, function (c) {
         // Includes handleFileCheckboxChange, selectedFiles, etc. if present
-        var addedProps = _.omit(_this6.props, 'columnHeaders', 'stackDepth', 'colWidthStyles', 'width'); // REQUIRED & PASSED DOWN TO STACKEDBLOCKLIST
+        var addedProps = _.omit(_this7.props, 'columnHeaders', 'stackDepth', 'colWidthStyles', 'width'); // REQUIRED & PASSED DOWN TO STACKEDBLOCKLIST
 
 
         addedProps.colWidthStyles = colWidthStyles;
@@ -603,6 +669,7 @@ _defineProperty(StackedBlockTable, "defaultProps", {
   'collapseShow': 3,
   'preventExpand': false,
   'collapseLongLists': true,
+  'collapseShowMoreLimit': 100,
   'defaultCollapsed': true
 });
 

--- a/es/components/browse/components/StackedBlockTable.js
+++ b/es/components/browse/components/StackedBlockTable.js
@@ -310,10 +310,10 @@ export var StackedBlockList = /*#__PURE__*/function (_React$PureComponent3) {
           titleStr = "Show Fewer ".concat(title);
           nextCount = collapseShow;
         } else if (incrementalExpandVisibleCount + incrementalExpandStep > children.length) {
-          titleStr = "Show ".concat(children.length - collapsibleChildren.length, " More ").concat(title);
+          titleStr = "Show ".concat(children.length - collapsibleChildren.length - collapseShow, " More ").concat(title);
           nextCount = children.length;
         } else {
-          titleStr = "Show ".concat(incrementalExpandStep, " More ").concat(title, " (Total ").concat(children.length - collapsibleChildren.length, " ").concat(title, " to Show)");
+          titleStr = "Show ".concat(incrementalExpandStep, " More ").concat(title, " (Total ").concat(children.length - collapsibleChildren.length - collapseShow, " ").concat(title, " to Show)");
           nextCount = incrementalExpandVisibleCount + incrementalExpandStep;
         }
 

--- a/es/components/browse/components/StackedBlockTable.js
+++ b/es/components/browse/components/StackedBlockTable.js
@@ -191,11 +191,9 @@ export var StackedBlockList = /*#__PURE__*/function (_React$PureComponent3) {
     _this = _super3.call(this, props);
     _this.adjustedChildren = _this.adjustedChildren.bind(_assertThisInitialized(_this));
     _this.handleCollapseToggle = _this.handleCollapseToggle.bind(_assertThisInitialized(_this));
-    _this.handleCollapseMoreThanClick = _this.handleCollapseMoreThanClick.bind(_assertThisInitialized(_this));
-    _this.handleCollapseMoreLessClick = _this.handleCollapseMoreLessClick.bind(_assertThisInitialized(_this));
     _this.state = {
       'collapsed': props.defaultCollapsed,
-      'collapsibleCounter': 0
+      'incrementalExpandVisibleCount': props.collapseShow
     };
     return _this;
   }
@@ -220,7 +218,7 @@ export var StackedBlockList = /*#__PURE__*/function (_React$PureComponent3) {
           stackDepth: stackDepth + 1
         }; //const childProps = _.pick(this.props, 'colWidthStyles', 'selectedFiles', 'columnHeaders', 'handleFileCheckboxChange');
 
-        _.forEach(['collapseLongLists', 'collapseLimit', 'collapseShow', 'defaultCollapsed', 'collapseShowMoreLimit'], function (prop) {
+        _.forEach(['collapseLongLists', 'collapseLimit', 'collapseShow', 'defaultCollapsed', 'incrementalExpandLimit'], function (prop) {
           if (typeof c.props[prop] === 'undefined') {
             childProps[prop] = _this2.props[prop] || null;
           }
@@ -246,37 +244,32 @@ export var StackedBlockList = /*#__PURE__*/function (_React$PureComponent3) {
       });
     }
   }, {
-    key: "handleCollapseMoreThanClick",
-    value: function handleCollapseMoreThanClick(count) {
-      this.setState({
-        'collapsibleCounter': count
-      });
-    }
-  }, {
-    key: "handleCollapseMoreLessClick",
-    value: function handleCollapseMoreLessClick(count) {
-      this.setState({
-        'collapsibleCounter': count
+    key: "handleIncrementalExpandClick",
+    value: function handleIncrementalExpandClick(count) {
+      this.setState(function () {
+        return {
+          'incrementalExpandVisibleCount': count
+        };
       });
     }
   }, {
     key: "render",
     value: function render() {
-      var _this3 = this;
-
       var _this$props4 = this.props,
           collapseLongLists = _this$props4.collapseLongLists,
           stackDepth = _this$props4.stackDepth,
           collapseLimit = _this$props4.collapseLimit,
           collapseShow = _this$props4.collapseShow,
+          _this$props4$title = _this$props4.title,
+          title = _this$props4$title === void 0 ? 'Items' : _this$props4$title,
           className = _this$props4.className,
           colWidthStyles = _this$props4.colWidthStyles,
           columnClass = _this$props4.columnClass,
-          collapseShowMoreLimit = _this$props4.collapseShowMoreLimit,
-          collapseItemsIncrement = _this$props4.collapseItemsIncrement;
+          incrementalExpandLimit = _this$props4.incrementalExpandLimit,
+          incrementalExpandStep = _this$props4.incrementalExpandStep;
       var _this$state = this.state,
           collapsed = _this$state.collapsed,
-          collapsibleCounter = _this$state.collapsibleCounter;
+          incrementalExpandVisibleCount = _this$state.incrementalExpandVisibleCount;
       var children = this.adjustedChildren();
       var useStyle = colWidthStyles["list:" + columnClass]; // columnClass here is of parent StackedBlock, not of its children.
 
@@ -290,33 +283,16 @@ export var StackedBlockList = /*#__PURE__*/function (_React$PureComponent3) {
         }, children);
       }
 
-      var collapsibleChildren; //More than collapse calculate
-
-      if (children.length > collapseShowMoreLimit) {
-        //collapse Item Increment total lenght calculate.
-        //collapseShow first child items.
-        collapsibleChildren = children.slice(0, collapsibleCounter + collapseShow);
-      } else {
-        //Collapse Origin
-        collapsibleChildren = children.slice(collapseShow);
-      }
-
+      var isIncrementalExpand = children.length > incrementalExpandLimit;
+      var collapsibleChildren = !isIncrementalExpand ? children.slice(collapseShow) : children.slice(collapseShow, incrementalExpandVisibleCount);
       var collapsibleChildrenLen = collapsibleChildren.length;
       var collapsibleChildrenElemsList;
 
-      if (collapsibleChildrenLen > Math.min(collapseShow, 10)) {
+      if (collapsibleChildrenLen > Math.min(collapseShow, 10) || isIncrementalExpand) {
         // Don't transition
-        if (collapsibleCounter > 0) {
-          //Collapse Increment items for exp:(0,100)
-          collapsibleChildrenElemsList = /*#__PURE__*/React.createElement("div", {
-            className: "collapsible-s-block-ext"
-          }, children.slice(0, collapsibleCounter));
-        } else {
-          //Origin collapse Full items
-          collapsibleChildrenElemsList = collapsed ? null : /*#__PURE__*/React.createElement("div", {
-            className: "collapsible-s-block-ext"
-          }, collapsibleChildren);
-        }
+        collapsibleChildrenElemsList = !collapsed || isIncrementalExpand && collapsibleChildrenLen > 0 ? /*#__PURE__*/React.createElement("div", {
+          className: "collapsible-s-block-ext"
+        }, collapsibleChildren) : null;
       } else {
         collapsibleChildrenElemsList = /*#__PURE__*/React.createElement(Collapse, {
           "in": !collapsed
@@ -325,37 +301,30 @@ export var StackedBlockList = /*#__PURE__*/function (_React$PureComponent3) {
         }, collapsibleChildren));
       }
 
-      var calculateCollapseCounter = children.length - collapsibleChildren <= collapseItemsIncrement ? children.length : collapsibleCounter;
-      var collapseType = null;
-      var title;
+      var viewMoreButton = null;
 
-      if (children.length - collapsibleChildren.length <= collapseItemsIncrement) {
-        title = "Show ".concat(children.length - collapsibleChildren.length, " More Files");
-      } else {
-        title = "Show 100 More Files (Total ".concat(children.length - collapsibleChildren.length, " Files to Show)");
-      }
+      if (isIncrementalExpand) {
+        var titleStr, nextCount;
 
-      if (children.length > collapseShowMoreLimit) {
-        collapseType = children.length > collapseShowMoreLimit && children.length - collapsibleCounter > 0 ? /*#__PURE__*/React.createElement("div", {
-          className: "view-more-button",
-          onClick: function onClick() {
-            _this3.handleCollapseMoreThanClick(calculateCollapseCounter + collapseItemsIncrement);
-          }
+        if (collapsibleChildrenLen + collapseShow >= children.length) {
+          titleStr = "Show Fewer ".concat(title);
+          nextCount = collapseShow;
+        } else if (incrementalExpandVisibleCount + incrementalExpandStep > children.length) {
+          titleStr = "Show ".concat(children.length - collapsibleChildren.length, " More ").concat(title);
+          nextCount = children.length;
+        } else {
+          titleStr = "Show ".concat(incrementalExpandStep, " More ").concat(title, " (Total ").concat(children.length - collapsibleChildren.length, " ").concat(title, " to Show)");
+          nextCount = incrementalExpandVisibleCount + incrementalExpandStep;
+        }
+
+        viewMoreButton = /*#__PURE__*/React.createElement("div", {
+          className: "view-more-button clickable",
+          onClick: this.handleIncrementalExpandClick.bind(this, nextCount)
         }, /*#__PURE__*/React.createElement("i", {
-          className: "mr-1 icon fas icon-plus"
-        }), /*#__PURE__*/React.createElement("span", null, " ", title, " ")) :
-        /*#__PURE__*/
-        //Collapse Fewer files
-        React.createElement("div", {
-          className: "view-more-button",
-          onClick: function onClick() {
-            _this3.handleCollapseMoreLessClick(collapseShow);
-          }
-        }, /*#__PURE__*/React.createElement("i", {
-          className: "icon fas icon-minus mr-1 ml-02 small"
-        }), /*#__PURE__*/React.createElement("span", null, " ", 'Show Fewer Files '));
+          className: "mr-1 icon fas icon-" + (nextCount >= incrementalExpandVisibleCount ? "plus" : "minus")
+        }), /*#__PURE__*/React.createElement("span", null, " ", titleStr, " "));
       } else {
-        collapseType = /*#__PURE__*/React.createElement(StackedBlockListViewMoreButton, _extends({}, this.props, {
+        viewMoreButton = /*#__PURE__*/React.createElement(StackedBlockListViewMoreButton, _extends({}, this.props, {
           collapsibleChildren: collapsibleChildren,
           collapsed: collapsed,
           handleCollapseToggle: this.handleCollapseToggle
@@ -366,7 +335,7 @@ export var StackedBlockList = /*#__PURE__*/function (_React$PureComponent3) {
         className: cls,
         "data-count-collapsed": collapsibleChildren.length,
         style: useStyle
-      }, children.slice(0, collapseShow), collapsibleChildrenElemsList, collapseType);
+      }, children.slice(0, collapseShow), collapsibleChildrenElemsList, viewMoreButton);
     }
   }]);
 
@@ -383,8 +352,8 @@ _defineProperty(StackedBlockList, "propTypes", {
   'defaultCollapsed': PropTypes.bool,
   'children': PropTypes.arrayOf(PropTypes.node),
   'stackDepth': PropTypes.number,
-  'collapseShowMoreLimit': PropTypes.number,
-  'collapseItemsIncrement': PropTypes.number
+  'incrementalExpandLimit': PropTypes.number,
+  'incrementalExpandStep': PropTypes.number
 });
 
 export var StackedBlock = /*#__PURE__*/function (_React$PureComponent4) {
@@ -394,19 +363,19 @@ export var StackedBlock = /*#__PURE__*/function (_React$PureComponent4) {
 
   /** TODO MAYBE USE HERE & ON LIST */
   function StackedBlock(props) {
-    var _this4;
+    var _this3;
 
     _classCallCheck(this, StackedBlock);
 
-    _this4 = _super4.call(this, props);
-    _this4.adjustedChildren = _this4.adjustedChildren.bind(_assertThisInitialized(_this4));
-    return _this4;
+    _this3 = _super4.call(this, props);
+    _this3.adjustedChildren = _this3.adjustedChildren.bind(_assertThisInitialized(_this3));
+    return _this3;
   }
 
   _createClass(StackedBlock, [{
     key: "adjustedChildren",
     value: function adjustedChildren() {
-      var _this5 = this;
+      var _this4 = this;
 
       var _this$props5 = this.props,
           children = _this$props5.children,
@@ -431,15 +400,15 @@ export var StackedBlock = /*#__PURE__*/function (_React$PureComponent4) {
         );
         */
 
-        _.forEach(['collapseLongLists', 'collapseLimit', 'collapseShow', 'defaultCollapsed', 'preventExpand', 'collapseShowMoreLimit'], function (prop) {
+        _.forEach(['collapseLongLists', 'collapseLimit', 'collapseShow', 'defaultCollapsed', 'preventExpand', 'incrementalExpandLimit'], function (prop) {
           if (typeof c.props[prop] === 'undefined') {
-            childProps[prop] = _this5.props[prop];
+            childProps[prop] = _this4.props[prop];
           }
         });
 
-        _.forEach(_.keys(_this5.props), function (prop) {
+        _.forEach(_.keys(_this4.props), function (prop) {
           if (typeof c.props[prop] === 'undefined' && typeof childProps[prop] === 'undefined' && !StackedBlock.excludedPassedProps.has(prop)) {
-            childProps[prop] = _this5.props[prop];
+            childProps[prop] = _this4.props[prop];
           }
         });
 
@@ -548,21 +517,21 @@ export var StackedBlockTable = /*#__PURE__*/function (_React$PureComponent5) {
   }]);
 
   function StackedBlockTable(props) {
-    var _this6;
+    var _this5;
 
     _classCallCheck(this, StackedBlockTable);
 
-    _this6 = _super5.call(this, props);
-    _this6.adjustedChildren = _this6.adjustedChildren.bind(_assertThisInitialized(_this6));
-    _this6.setCollapsingState = _.throttle(_this6.setCollapsingState.bind(_assertThisInitialized(_this6)));
-    _this6.memoized = {
+    _this5 = _super5.call(this, props);
+    _this5.adjustedChildren = _this5.adjustedChildren.bind(_assertThisInitialized(_this5));
+    _this5.setCollapsingState = _.throttle(_this5.setCollapsingState.bind(_assertThisInitialized(_this5)));
+    _this5.memoized = {
       totalColumnsMinWidth: memoize(StackedBlockTable.totalColumnsMinWidth),
       colWidthStyles: memoize(StackedBlockTable.colWidthStyles)
     };
-    _this6.state = {
+    _this5.state = {
       'mounted': false
     };
-    return _this6;
+    return _this5;
   }
 
   _createClass(StackedBlockTable, [{
@@ -582,7 +551,7 @@ export var StackedBlockTable = /*#__PURE__*/function (_React$PureComponent5) {
   }, {
     key: "adjustedChildren",
     value: function adjustedChildren() {
-      var _this7 = this;
+      var _this6 = this;
 
       var _this$props7 = this.props,
           children = _this$props7.children,
@@ -591,7 +560,7 @@ export var StackedBlockTable = /*#__PURE__*/function (_React$PureComponent5) {
       var colWidthStyles = this.memoized.colWidthStyles(columnHeaders, defaultInitialColumnWidth);
       return React.Children.map(children, function (c) {
         // Includes handleFileCheckboxChange, selectedFiles, etc. if present
-        var addedProps = _.omit(_this7.props, 'columnHeaders', 'stackDepth', 'colWidthStyles', 'width'); // REQUIRED & PASSED DOWN TO STACKEDBLOCKLIST
+        var addedProps = _.omit(_this6.props, 'columnHeaders', 'stackDepth', 'colWidthStyles', 'width'); // REQUIRED & PASSED DOWN TO STACKEDBLOCKLIST
 
 
         addedProps.colWidthStyles = colWidthStyles;
@@ -679,8 +648,8 @@ _defineProperty(StackedBlockTable, "defaultProps", {
   'collapseShow': 3,
   'preventExpand': false,
   'collapseLongLists': true,
-  'collapseShowMoreLimit': 100,
-  'collapseItemsIncrement': 100,
+  'incrementalExpandLimit': 100,
+  'incrementalExpandStep': 100,
   'defaultCollapsed': true
 });
 

--- a/es/components/browse/components/StackedBlockTable.js
+++ b/es/components/browse/components/StackedBlockTable.js
@@ -249,7 +249,7 @@ export var StackedBlockList = /*#__PURE__*/function (_React$PureComponent3) {
     key: "handleCollapseMoreThanClick",
     value: function handleCollapseMoreThanClick(count) {
       this.setState({
-        'collapsibleCounter': count + 100
+        'collapsibleCounter': count
       });
     }
   }, {
@@ -272,7 +272,8 @@ export var StackedBlockList = /*#__PURE__*/function (_React$PureComponent3) {
           className = _this$props4.className,
           colWidthStyles = _this$props4.colWidthStyles,
           columnClass = _this$props4.columnClass,
-          collapseShowMoreLimit = _this$props4.collapseShowMoreLimit;
+          collapseShowMoreLimit = _this$props4.collapseShowMoreLimit,
+          collapseItemsIncrement = _this$props4.collapseItemsIncrement;
       var _this$state = this.state,
           collapsed = _this$state.collapsed,
           collapsibleCounter = _this$state.collapsibleCounter;
@@ -292,8 +293,11 @@ export var StackedBlockList = /*#__PURE__*/function (_React$PureComponent3) {
       var collapsibleChildren; //More than collapse calculate
 
       if (children.length > collapseShowMoreLimit) {
+        //collapse Item Increment total lenght calculate.
+        //collapseShow first child items.
         collapsibleChildren = children.slice(0, collapsibleCounter + collapseShow);
       } else {
+        //Collapse Origin
         collapsibleChildren = children.slice(collapseShow);
       }
 
@@ -303,10 +307,12 @@ export var StackedBlockList = /*#__PURE__*/function (_React$PureComponent3) {
       if (collapsibleChildrenLen > Math.min(collapseShow, 10)) {
         // Don't transition
         if (collapsibleCounter > 0) {
+          //Collapse Increment items for exp:(0,100)
           collapsibleChildrenElemsList = /*#__PURE__*/React.createElement("div", {
             className: "collapsible-s-block-ext"
           }, children.slice(0, collapsibleCounter));
         } else {
+          //Origin collapse Full items
           collapsibleChildrenElemsList = collapsed ? null : /*#__PURE__*/React.createElement("div", {
             className: "collapsible-s-block-ext"
           }, collapsibleChildren);
@@ -319,11 +325,11 @@ export var StackedBlockList = /*#__PURE__*/function (_React$PureComponent3) {
         }, collapsibleChildren));
       }
 
-      var calculateCollapseCounter = children.length - collapsibleChildren <= 100 ? children.length : collapsibleCounter;
+      var calculateCollapseCounter = children.length - collapsibleChildren <= collapseItemsIncrement ? children.length : collapsibleCounter;
       var collapseType = null;
       var title;
 
-      if (children.length - collapsibleChildren.length <= 100) {
+      if (children.length - collapsibleChildren.length <= collapseItemsIncrement) {
         title = "Show ".concat(children.length - collapsibleChildren.length, " More Files");
       } else {
         title = "Show 100 More Files (Total ".concat(children.length - collapsibleChildren.length, " Files to Show)");
@@ -333,11 +339,21 @@ export var StackedBlockList = /*#__PURE__*/function (_React$PureComponent3) {
         collapseType = children.length > collapseShowMoreLimit && children.length - collapsibleCounter > 0 ? /*#__PURE__*/React.createElement("div", {
           className: "view-more-button",
           onClick: function onClick() {
-            _this3.handleCollapseMoreThanClick(calculateCollapseCounter);
+            _this3.handleCollapseMoreThanClick(calculateCollapseCounter + collapseItemsIncrement);
           }
         }, /*#__PURE__*/React.createElement("i", {
           className: "mr-1 icon fas icon-plus"
-        }), /*#__PURE__*/React.createElement("span", null, " ", title, " ")) : null;
+        }), /*#__PURE__*/React.createElement("span", null, " ", title, " ")) :
+        /*#__PURE__*/
+        //Collapse Fewer files
+        React.createElement("div", {
+          className: "view-more-button",
+          onClick: function onClick() {
+            _this3.handleCollapseMoreLessClick(collapseShow);
+          }
+        }, /*#__PURE__*/React.createElement("i", {
+          className: "icon fas icon-minus mr-1 ml-02 small"
+        }), /*#__PURE__*/React.createElement("span", null, " ", 'Show Fewer Files '));
       } else {
         collapseType = /*#__PURE__*/React.createElement(StackedBlockListViewMoreButton, _extends({}, this.props, {
           collapsibleChildren: collapsibleChildren,
@@ -350,14 +366,7 @@ export var StackedBlockList = /*#__PURE__*/function (_React$PureComponent3) {
         className: cls,
         "data-count-collapsed": collapsibleChildren.length,
         style: useStyle
-      }, collapsibleCounter > collapseShow ? /*#__PURE__*/React.createElement("div", {
-        className: "view-more-button",
-        onClick: function onClick() {
-          _this3.handleCollapseMoreLessClick(calculateCollapseCounter - 100);
-        }
-      }, /*#__PURE__*/React.createElement("i", {
-        className: "icon fas icon-minus mr-1 ml-02 small"
-      }), /*#__PURE__*/React.createElement("span", null, " ", 'Show Fewer Files ')) : null, children.slice(0, collapseShow), collapsibleChildrenElemsList, collapseType);
+      }, children.slice(0, collapseShow), collapsibleChildrenElemsList, collapseType);
     }
   }]);
 
@@ -374,7 +383,8 @@ _defineProperty(StackedBlockList, "propTypes", {
   'defaultCollapsed': PropTypes.bool,
   'children': PropTypes.arrayOf(PropTypes.node),
   'stackDepth': PropTypes.number,
-  'collapseShowMoreLimit': PropTypes.number
+  'collapseShowMoreLimit': PropTypes.number,
+  'collapseItemsIncrement': PropTypes.number
 });
 
 export var StackedBlock = /*#__PURE__*/function (_React$PureComponent4) {
@@ -670,6 +680,7 @@ _defineProperty(StackedBlockTable, "defaultProps", {
   'preventExpand': false,
   'collapseLongLists': true,
   'collapseShowMoreLimit': 100,
+  'collapseItemsIncrement': 100,
   'defaultCollapsed': true
 });
 

--- a/es/components/browse/components/StackedBlockTable.js
+++ b/es/components/browse/components/StackedBlockTable.js
@@ -265,6 +265,7 @@ export var StackedBlockList = /*#__PURE__*/function (_React$PureComponent3) {
           className = _this$props4.className,
           colWidthStyles = _this$props4.colWidthStyles,
           columnClass = _this$props4.columnClass,
+          preventExpand = _this$props4.preventExpand,
           incrementalExpandLimit = _this$props4.incrementalExpandLimit,
           incrementalExpandStep = _this$props4.incrementalExpandStep;
       var _this$state = this.state,
@@ -283,7 +284,7 @@ export var StackedBlockList = /*#__PURE__*/function (_React$PureComponent3) {
         }, children);
       }
 
-      var isIncrementalExpand = children.length > incrementalExpandLimit;
+      var isIncrementalExpand = children.length > incrementalExpandLimit && !preventExpand;
       var collapsibleChildren = !isIncrementalExpand ? children.slice(collapseShow) : children.slice(collapseShow, incrementalExpandVisibleCount);
       var collapsibleChildrenLen = collapsibleChildren.length;
       var collapsibleChildrenElemsList;
@@ -352,6 +353,7 @@ _defineProperty(StackedBlockList, "propTypes", {
   'defaultCollapsed': PropTypes.bool,
   'children': PropTypes.arrayOf(PropTypes.node),
   'stackDepth': PropTypes.number,
+  'preventExpand': PropTypes.bool,
   'incrementalExpandLimit': PropTypes.number,
   'incrementalExpandStep': PropTypes.number
 });

--- a/es/components/util/analytics.js
+++ b/es/components/util/analytics.js
@@ -734,7 +734,7 @@ function shouldTrack(itemList) {
   }
 
   if (itemList && Array.isArray(itemList) && itemList.length > 50) {
-    console.info("Google Analytics do not respond well when items count exceeds 50. Tracking is disabled since list has (".concat(itemList.length, " items."));
+    console.info("Google Analytics do not respond well when items count exceeds 50. Tracking is disabled since list has ".concat(itemList.length, " items."));
     return false;
   } // 2. TODO: Check if User wants to be excluded from tracking
   // 2. TODO: Make sure not logged in as admin on a production site.

--- a/src/components/browse/components/StackedBlockTable.js
+++ b/src/components/browse/components/StackedBlockTable.js
@@ -105,7 +105,7 @@ export class StackedBlockListViewMoreButton extends React.PureComponent {
             return (
                 <div className="view-more-button">
                     <i className="icon fas icon-plus mr-1 ml-02 small"/>
-                    {collapsibleChildrenLen + " More" + (title ? ' ' + title : '')}
+                    { collapsibleChildrenLen + " More" + (title ? ' ' + title : '') }
                     { showMoreExtTitle ? <span className="ext text-400"> { showMoreExtTitle }</span> : null }
                 </div>
             );
@@ -143,7 +143,8 @@ export class StackedBlockList extends React.PureComponent {
         'defaultCollapsed'          : PropTypes.bool,
         'children'                  : PropTypes.arrayOf(PropTypes.node),
         'stackDepth'                : PropTypes.number,
-        'incrementalExpandLimit': PropTypes.number,
+        'preventExpand'             : PropTypes.bool,
+        'incrementalExpandLimit'    : PropTypes.number,
         'incrementalExpandStep'     : PropTypes.number
     };
 
@@ -194,7 +195,7 @@ export class StackedBlockList extends React.PureComponent {
     }
 
     render(){
-        const { collapseLongLists, stackDepth, collapseLimit, collapseShow, title = 'Items', className, colWidthStyles, columnClass, incrementalExpandLimit, incrementalExpandStep } = this.props;
+        const { collapseLongLists, stackDepth, collapseLimit, collapseShow, title = 'Items', className, colWidthStyles, columnClass, preventExpand, incrementalExpandLimit, incrementalExpandStep } = this.props;
         const { collapsed, incrementalExpandVisibleCount } = this.state;
         const children = this.adjustedChildren();
         const useStyle = colWidthStyles["list:" + columnClass]; // columnClass here is of parent StackedBlock, not of its children.
@@ -205,7 +206,7 @@ export class StackedBlockList extends React.PureComponent {
             return <div className={cls} style={useStyle}>{ children }</div>;
         }
 
-        const isIncrementalExpand = children.length > incrementalExpandLimit;
+        const isIncrementalExpand = (children.length > incrementalExpandLimit) && !preventExpand;
 
         const collapsibleChildren = !isIncrementalExpand ? children.slice(collapseShow) : children.slice(collapseShow, incrementalExpandVisibleCount);
         const collapsibleChildrenLen =  collapsibleChildren.length;

--- a/src/components/browse/components/StackedBlockTable.js
+++ b/src/components/browse/components/StackedBlockTable.js
@@ -228,10 +228,10 @@ export class StackedBlockList extends React.PureComponent {
                 titleStr = `Show Fewer ${title}`;
                 nextCount = collapseShow;
             } else if (incrementalExpandVisibleCount + incrementalExpandStep > children.length) {
-                titleStr = `Show ${children.length - collapsibleChildren.length} More ${title}`;
+                titleStr = `Show ${children.length - collapsibleChildren.length - collapseShow} More ${title}`;
                 nextCount = children.length;
             } else {
-                titleStr = `Show ${incrementalExpandStep} More ${title} (Total ${children.length - collapsibleChildren.length} ${title} to Show)`;
+                titleStr = `Show ${incrementalExpandStep} More ${title} (Total ${children.length - collapsibleChildren.length - collapseShow} ${title} to Show)`;
                 nextCount = incrementalExpandVisibleCount + incrementalExpandStep;
             }
             viewMoreButton = (

--- a/src/components/browse/components/StackedBlockTable.js
+++ b/src/components/browse/components/StackedBlockTable.js
@@ -136,14 +136,15 @@ export class StackedBlockList extends React.PureComponent {
     static ViewMoreButton = StackedBlockListViewMoreButton;
 
     static propTypes = {
-        'showMoreExtTitle'    : PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
-        'collapseLimit'       : PropTypes.number,
-        'collapseShow'        : PropTypes.number,
-        'collapseLongLists'   : PropTypes.bool,
-        'defaultCollapsed'    : PropTypes.bool,
-        'children'            : PropTypes.arrayOf(PropTypes.node),
-        'stackDepth'          : PropTypes.number,
-        'collapseShowMoreLimit':PropTypes.number
+        'showMoreExtTitle'      : PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+        'collapseLimit'         : PropTypes.number,
+        'collapseShow'          : PropTypes.number,
+        'collapseLongLists'     : PropTypes.bool,
+        'defaultCollapsed'      : PropTypes.bool,
+        'children'              : PropTypes.arrayOf(PropTypes.node),
+        'stackDepth'            : PropTypes.number,
+        'collapseShowMoreLimit' :PropTypes.number,
+        'collapseItemsIncrement':PropTypes.number
     };
 
     constructor(props){
@@ -152,7 +153,6 @@ export class StackedBlockList extends React.PureComponent {
         this.handleCollapseToggle = this.handleCollapseToggle.bind(this);
         this.handleCollapseMoreThanClick =this.handleCollapseMoreThanClick.bind(this);
         this.handleCollapseMoreLessClick =this.handleCollapseMoreLessClick.bind(this);
-
         this.state = { 'collapsed': props.defaultCollapsed, 'collapsibleCounter': 0 };
     }
 
@@ -190,7 +190,7 @@ export class StackedBlockList extends React.PureComponent {
     }
 
     handleCollapseMoreThanClick(count){
-        this.setState({ 'collapsibleCounter' : count + 100 });
+        this.setState({ 'collapsibleCounter' : count });
     }
 
     handleCollapseMoreLessClick(count){
@@ -198,7 +198,7 @@ export class StackedBlockList extends React.PureComponent {
     }
 
     render(){
-        const { collapseLongLists, stackDepth, collapseLimit, collapseShow, className, colWidthStyles, columnClass, collapseShowMoreLimit } = this.props;
+        const { collapseLongLists, stackDepth, collapseLimit, collapseShow, className, colWidthStyles, columnClass, collapseShowMoreLimit, collapseItemsIncrement } = this.props;
         const { collapsed, collapsibleCounter } = this.state;
         const children = this.adjustedChildren();
         const useStyle = colWidthStyles["list:" + columnClass]; // columnClass here is of parent StackedBlock, not of its children.
@@ -212,21 +212,25 @@ export class StackedBlockList extends React.PureComponent {
         let collapsibleChildren;
         //More than collapse calculate
         if (children.length > collapseShowMoreLimit) {
-            collapsibleChildren = children.slice(0, collapsibleCounter+collapseShow);
+            //collapse Item Increment total lenght calculate.
+            //collapseShow first child items.
+            collapsibleChildren = children.slice(0, collapsibleCounter + collapseShow);
         }
         else {
+            //Collapse Origin
             collapsibleChildren = children.slice(collapseShow);
         }
         const collapsibleChildrenLen =  collapsibleChildren.length;
 
 
         var collapsibleChildrenElemsList;
-
         if (collapsibleChildrenLen > Math.min(collapseShow, 10)) { // Don't transition
             if (collapsibleCounter > 0) {
+                //Collapse Increment items for exp:(0,100)
                 collapsibleChildrenElemsList= <div className="collapsible-s-block-ext">{children.slice(0, collapsibleCounter)}</div>;
             }
             else {
+                //Origin collapse Full items
                 collapsibleChildrenElemsList = collapsed ? null : <div className="collapsible-s-block-ext">{collapsibleChildren}</div>;
             }
         } else {
@@ -236,11 +240,11 @@ export class StackedBlockList extends React.PureComponent {
                 </Collapse>
             );
         }
-        const calculateCollapseCounter = children.length - collapsibleChildren <= 100 ? children.length : collapsibleCounter;
+        const calculateCollapseCounter = children.length - collapsibleChildren <= collapseItemsIncrement ? children.length : collapsibleCounter;
 
         let collapseType=null;
         let title;
-        if (children.length - collapsibleChildren.length <= 100) {
+        if (children.length - collapsibleChildren.length <= collapseItemsIncrement) {
             title = `Show ${children.length - collapsibleChildren.length} More Files`;
         } else {
             title = `Show 100 More Files (Total ${children.length - collapsibleChildren.length} Files to Show)`;
@@ -248,11 +252,18 @@ export class StackedBlockList extends React.PureComponent {
         if (children.length > collapseShowMoreLimit) {
             collapseType = (children.length > collapseShowMoreLimit && children.length - collapsibleCounter > 0 ?
                 <div className="view-more-button" onClick={(evt) => {
-                    this.handleCollapseMoreThanClick(calculateCollapseCounter);
+                    this.handleCollapseMoreThanClick(calculateCollapseCounter + collapseItemsIncrement);
                 }}>
                     <i className="mr-1 icon fas icon-plus" />
                     {<span> {title} </span>}
-                </div> : null);
+                </div> :
+                //Collapse Fewer files
+                <div className="view-more-button" onClick={(evt) => {
+                    this.handleCollapseMoreLessClick(collapseShow);
+                }}>
+                    <i className="icon fas icon-minus mr-1 ml-02 small" />
+                    {<span> {'Show Fewer Files '}</span>}
+                </div>);
         }
         else {
             collapseType = (
@@ -262,15 +273,6 @@ export class StackedBlockList extends React.PureComponent {
         }
         return (
             <div className={cls} data-count-collapsed={collapsibleChildren.length} style={useStyle}>
-                {collapsibleCounter > collapseShow ?
-                    <div className="view-more-button" onClick={(evt) => {
-                        this.handleCollapseMoreLessClick(calculateCollapseCounter-100);
-                    }}>
-                        <i className="icon fas icon-minus mr-1 ml-02 small" />
-                        {<span> {'Show Fewer Files '}</span>}
-                    </div>
-                    : null}
-
                 { children.slice(0, collapseShow)}
                 { collapsibleChildrenElemsList}
                 { collapseType }
@@ -437,6 +439,7 @@ export class StackedBlockTable extends React.PureComponent {
         'preventExpand'     : false,
         'collapseLongLists' : true,
         'collapseShowMoreLimit':100,
+        'collapseItemsIncrement':100,
         'defaultCollapsed'  : true
     };
 

--- a/src/components/util/analytics.js
+++ b/src/components/util/analytics.js
@@ -638,7 +638,7 @@ function shouldTrack(itemList){
     }
 
     if (itemList && Array.isArray(itemList) && itemList.length > 50) {
-        console.info(`Google Analytics do not respond well when items count exceeds 50. Tracking is disabled since list has (${itemList.length} items.`);
+        console.info(`Google Analytics do not respond well when items count exceeds 50. Tracking is disabled since list has ${itemList.length} items.`);
         return false;
     }
 

--- a/src/components/util/analytics.js
+++ b/src/components/util/analytics.js
@@ -476,10 +476,15 @@ export function productClick(item, extraData = {}, callback = null, context = nu
  * Does _NOT_ also send a GA event. This must be done outside of func.
  */
 export function productsAddToCart(items, extraData = {}){
-    if (!shouldTrack()) return false;
-    const count = addProductsEE(items, extraData);
-    console.info(`Adding ${count} items to cart.`);
-    ga2('ec:setAction', 'add');
+    if (items.length < 50) {
+        if (!shouldTrack()) return false;
+        const count = addProductsEE(items, extraData);
+        console.info(`Adding ${count} items to cart.`);
+        ga2('ec:setAction', 'add');
+    }
+    else{
+        console.info(`We do not run analystic because the number of files is high ${items.length} items.`);
+    }
 }
 
 export function productsRemoveFromCart(items, extraData = {}){
@@ -494,11 +499,16 @@ export function productsRemoveFromCart(items, extraData = {}){
  * Does _NOT_ also send a GA event. This must be done outside of func.
  */
 export function productsCheckout(items, extraData = {}){
-    if (!shouldTrack()) return false;
-    const { step = 1, option = null, ...extData } = extraData || {};
-    const count = addProductsEE(items, extData);
-    ga2('ec:setAction', 'checkout', { step, option });
-    console.info(`Checked out ${count} items.`);
+    if (items.length < 50){
+        if (!shouldTrack()) return false;
+        const { step = 1, option = null, ...extData } = extraData || {};
+        const count = addProductsEE(items, extData);
+        ga2('ec:setAction', 'checkout', { step, option });
+        console.info(`Checked out ${count} items.`);
+    }
+    else{
+        console.info(`We do not run analystic because the number of files is high ${items.length} items.`);
+    }
 }
 
 export function productAddDetailViewed(item, context = null, extraData = {}){
@@ -724,42 +734,47 @@ function addProductsEE(items, extData = {}){
  * @returns {Object[]} Representation of what was sent.
  */
 export function impressionListOfItems(itemList, href = null, listName = null, context = null){
-    if (!shouldTrack()) return false;
-    context = context || (state && state.reduxStore && state.reduxStore.getState().context) || null;
-    var from = 0;
-    if (typeof href === 'string'){ // Convert to URL parts.
-        href = url.parse(href, true);
-        if (!isNaN(parseInt(href.query.from))) from = parseInt(href.query.from);
-    }
+    if (itemList.length < 50){
+        if (!shouldTrack()) return false;
+        context = context || (state && state.reduxStore && state.reduxStore.getState().context) || null;
+        var from = 0;
+        if (typeof href === 'string'){ // Convert to URL parts.
+            href = url.parse(href, true);
+            if (!isNaN(parseInt(href.query.from))) from = parseInt(href.query.from);
+        }
 
-    href = href || window.location.href;
+        href = href || window.location.href;
 
-    const commonProductObj = { "list" : listName || (href && hrefToListName(href)) };
+        const commonProductObj = { "list" : listName || (href && hrefToListName(href)) };
 
-    if (context && context.filters && state.dimensionNameMap.currentFilters) {
-        commonProductObj["dimension" + state.dimensionNameMap.currentFilters] = getStringifiedCurrentFilters(context.filters);
-    }
+        if (context && context.filters && state.dimensionNameMap.currentFilters) {
+            commonProductObj["dimension" + state.dimensionNameMap.currentFilters] = getStringifiedCurrentFilters(context.filters);
+        }
 
-    const resultsImpressioned = itemList.filter(function(item){
-        // Ensure we have permissions, can get product SKU, etc.
-        const { display_title, '@id': id, error = null, '@type' : itemType } = item;
-        if (!id || !display_title || !Array.isArray(itemType)) {
-            if (error) {
-                // Likely no view permissions, ok.
+        const resultsImpressioned = itemList.filter(function(item){
+            // Ensure we have permissions, can get product SKU, etc.
+            const { display_title, '@id': id, error = null, '@type' : itemType } = item;
+            if (!id || !display_title || !Array.isArray(itemType)) {
+                if (error) {
+                    // Likely no view permissions, ok.
+                    return false;
+                }
+                const errMsg = "Analytics Product Tracking: Could not access necessary product/item fields";
+                exception(errMsg);
+                console.error(errMsg, item);
                 return false;
             }
-            const errMsg = "Analytics Product Tracking: Could not access necessary product/item fields";
-            exception(errMsg);
-            console.error(errMsg, item);
-            return false;
-        }
-        return true;
-    }).map(function(item, i){
-        const pObj = _.extend(itemToProductTransform(item), commonProductObj, { 'position' : from + i + 1 });
-        ga2('ec:addImpression', pObj);
-        return pObj;
-    });
+            return true;
+        }).map(function(item, i){
+            const pObj = _.extend(itemToProductTransform(item), commonProductObj, { 'position' : from + i + 1 });
+            ga2('ec:addImpression', pObj);
+            return pObj;
+        });
 
-    console.info(`Impressioned ${resultsImpressioned.length} items starting at position ${from + 1} in list "${commonProductObj.list}"`);
-    return resultsImpressioned;
+        console.info(`Impressioned ${resultsImpressioned.length} items starting at position ${from + 1} in list "${commonProductObj.list}"`);
+        return resultsImpressioned;
+    }
+    else {
+        return false;
+    }
 }


### PR DESCRIPTION
Please handle this PR w/ https://github.com/4dn-dcic/fourfront/pull/1500

Trello: https://trello.com/c/oTpFC5hx

- Google Analytics lib does not respond well and makes the page crashing when there are too many files to be logged simultaneously. So we only track if the items are below a certain limit. (50)
- Instead of a collapsable panel that shows all items at once in stacked tables, we add an option to allow expanding the items in multiple steps. (https://t.gyazo.com/teams/ff-4dn/ab213aafe782e1536fa477c1cb0d7e3c.mp4) `incrementalExpandLimit` and `incrementalExpandStep` are introduced as new props.