### PR TITLE
Sv UI 2 - Allow hiding multicolumn sort in AboveTableControlsBase/RightButtonsSection

### DIFF
--- a/es/components/browse/components/above-table-controls/AboveTableControlsBase.js
+++ b/es/components/browse/components/above-table-controls/AboveTableControlsBase.js
@@ -219,7 +219,7 @@ export var AboveTableControlsBase = /*#__PURE__*/function (_React$PureComponent)
         className: "above-results-table-row"
       }, /*#__PURE__*/React.createElement("div", {
         className: "row align-items-center"
-      }, extendedChildren, /*#__PURE__*/React.createElement(RightButtonsSection, _extends({}, _.pick(this.props, 'isFullscreen', 'windowWidth', 'toggleFullScreen'), {
+      }, extendedChildren, /*#__PURE__*/React.createElement(RightButtonsSection, _extends({}, _.pick(this.props, 'isFullscreen', 'windowWidth', 'toggleFullScreen', 'showMultiColumnSort'), {
         currentOpenPanel: open || reallyOpen,
         onColumnsBtnClick: this.panelToggleFxns.customColumns,
         onMultiColumnSortBtnClick: this.panelToggleFxns.multiColumnSort

--- a/es/components/browse/components/above-table-controls/RightButtonsSection.js
+++ b/es/components/browse/components/above-table-controls/RightButtonsSection.js
@@ -32,16 +32,18 @@ export var RightButtonsSection = /*#__PURE__*/React.memo(function (props) {
       onMultiColumnSortBtnClick = props.onMultiColumnSortBtnClick,
       windowWidth = props.windowWidth,
       isFullscreen = props.isFullscreen,
-      toggleFullScreen = props.toggleFullScreen;
+      toggleFullScreen = props.toggleFullScreen,
+      _props$showMultiColum = props.showMultiColumnSort,
+      showMultiColumnSort = _props$showMultiColum === void 0 ? true : _props$showMultiColum;
   return /*#__PURE__*/React.createElement("div", {
     className: "right-buttons col-auto"
   }, /*#__PURE__*/React.createElement(ConfigureVisibleColumnsButton, {
     onClick: onColumnsBtnClick,
     open: currentOpenPanel === "customColumns"
-  }), /*#__PURE__*/React.createElement(MultiColumnSortButton, {
+  }), showMultiColumnSort ? /*#__PURE__*/React.createElement(MultiColumnSortButton, {
     onClick: onMultiColumnSortBtnClick,
     open: currentOpenPanel === "multiColumnSort"
-  }), typeof windowWidth === 'number' && typeof isFullscreen === 'boolean' && typeof toggleFullScreen === 'function' ? /*#__PURE__*/React.createElement(ToggleLayoutButton, {
+  }) : null, typeof windowWidth === 'number' && typeof isFullscreen === 'boolean' && typeof toggleFullScreen === 'function' ? /*#__PURE__*/React.createElement(ToggleLayoutButton, {
     windowWidth: windowWidth,
     isFullscreen: isFullscreen,
     toggleFullScreen: toggleFullScreen

--- a/package-lock.json
+++ b/package-lock.json
@@ -7596,7 +7596,7 @@
         },
         "deep-extend": {
             "version": "0.6.0",
-            "resolved": false,
+            "resolved": "",
             "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
             "dev": true,
             "optional": true
@@ -7735,7 +7735,7 @@
         },
         "detect-libc": {
             "version": "1.0.3",
-            "resolved": false,
+            "resolved": "",
             "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
             "dev": true,
             "optional": true
@@ -9669,7 +9669,7 @@
             "dependencies": {
                 "is-fullwidth-code-point": {
                     "version": "1.0.0",
-                    "resolved": false,
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                     "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                     "requires": {
                         "number-is-nan": "^1.0.0"
@@ -9677,17 +9677,17 @@
                 },
                 "minimist": {
                     "version": "0.0.8",
-                    "resolved": false,
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                     "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
                 },
                 "ms": {
                     "version": "2.1.1",
-                    "resolved": false,
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
                     "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
                 },
                 "nopt": {
                     "version": "4.0.1",
-                    "resolved": false,
+                    "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
                     "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
                     "requires": {
                         "abbrev": "1",
@@ -9696,17 +9696,17 @@
                 },
                 "sax": {
                     "version": "1.2.4",
-                    "resolved": false,
+                    "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
                     "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
                 },
                 "semver": {
                     "version": "5.7.0",
-                    "resolved": false,
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
                     "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
                 },
                 "tar": {
                     "version": "4.4.8",
-                    "resolved": false,
+                    "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
                     "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
                     "requires": {
                         "chownr": "^1.1.1",
@@ -9720,7 +9720,7 @@
                 },
                 "yallist": {
                     "version": "3.0.3",
-                    "resolved": false,
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
                     "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
                 }
             }
@@ -10473,7 +10473,7 @@
         },
         "ignore-walk": {
             "version": "3.0.1",
-            "resolved": false,
+            "resolved": "",
             "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
             "dev": true,
             "optional": true,
@@ -16588,7 +16588,7 @@
         },
         "needle": {
             "version": "2.3.0",
-            "resolved": false,
+            "resolved": "",
             "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
             "dev": true,
             "optional": true,
@@ -16817,7 +16817,7 @@
         },
         "node-pre-gyp": {
             "version": "0.12.0",
-            "resolved": false,
+            "resolved": "",
             "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
             "dev": true,
             "optional": true,
@@ -16979,14 +16979,14 @@
         },
         "npm-bundled": {
             "version": "1.0.6",
-            "resolved": false,
+            "resolved": "",
             "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
             "dev": true,
             "optional": true
         },
         "npm-packlist": {
             "version": "1.4.1",
-            "resolved": false,
+            "resolved": "",
             "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
             "dev": true,
             "optional": true,
@@ -17911,7 +17911,7 @@
         },
         "rc": {
             "version": "1.2.8",
-            "resolved": false,
+            "resolved": "",
             "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
             "dev": true,
             "optional": true,

--- a/src/components/browse/components/above-table-controls/AboveTableControlsBase.js
+++ b/src/components/browse/components/above-table-controls/AboveTableControlsBase.js
@@ -139,7 +139,7 @@ export class AboveTableControlsBase extends React.PureComponent {
             <div className="above-results-table-row">
                 <div className="row align-items-center">
                     { extendedChildren }
-                    <RightButtonsSection {..._.pick(this.props, 'isFullscreen', 'windowWidth', 'toggleFullScreen')}
+                    <RightButtonsSection {..._.pick(this.props, 'isFullscreen', 'windowWidth', 'toggleFullScreen', 'showMultiColumnSort')}
                         currentOpenPanel={open || reallyOpen} onColumnsBtnClick={this.panelToggleFxns.customColumns} onMultiColumnSortBtnClick={this.panelToggleFxns.multiColumnSort} />
                 </div>
                 { panelDefinition ?

--- a/src/components/browse/components/above-table-controls/RightButtonsSection.js
+++ b/src/components/browse/components/above-table-controls/RightButtonsSection.js
@@ -8,12 +8,12 @@ import { SearchResultTable } from './../SearchResultTable';
 
 
 export const RightButtonsSection = React.memo(function RightButtonsSection(props){
-    const { currentOpenPanel, onColumnsBtnClick, onMultiColumnSortBtnClick, windowWidth, isFullscreen, toggleFullScreen } = props;
+    const { currentOpenPanel, onColumnsBtnClick, onMultiColumnSortBtnClick, windowWidth, isFullscreen, toggleFullScreen, showMultiColumnSort = true } = props;
     const showToggleLayoutBtn = (typeof windowWidth === 'number' && typeof isFullscreen === 'boolean' && typeof toggleFullScreen === 'function');
     return (
         <div className="right-buttons col-auto">
             <ConfigureVisibleColumnsButton onClick={onColumnsBtnClick} open={currentOpenPanel === "customColumns"} />
-            <MultiColumnSortButton onClick={onMultiColumnSortBtnClick} open={currentOpenPanel === "multiColumnSort"} />
+            { showMultiColumnSort ? <MultiColumnSortButton onClick={onMultiColumnSortBtnClick} open={currentOpenPanel === "multiColumnSort"} /> : null}
             { showToggleLayoutBtn ? <ToggleLayoutButton {...{ windowWidth, isFullscreen, toggleFullScreen }} /> : null }
         </div>
     );


### PR DESCRIPTION
**Changelog**
- Adds a prop for hiding `MultiColumnSort` button in `AboveTableControlsBase`.
  - Default behavior remains to show this by default, so shouldn't impact current implementations/usages of the component.
  - Default value is specified in `RightButtonsSection`
- Some random package-lock updates that generated post-symlink

Relevant CGAP PR: https://github.com/dbmi-bgm/cgap-portal/pull/460