### PR TITLE
Minor button styling adjustments

### DIFF
--- a/es/components/browse/components/FacetList/FacetOfFacets.js
+++ b/es/components/browse/components/FacetList/FacetOfFacets.js
@@ -92,15 +92,16 @@ export var FacetOfFacets = /*#__PURE__*/function (_React$PureComponent) {
       return /*#__PURE__*/React.createElement("div", {
         className: "facet" + (facetOpen || anySelections ? ' open' : ' closed'),
         "data-group": title
-      }, /*#__PURE__*/React.createElement("h5", {
-        className: "facet-title",
+      }, /*#__PURE__*/React.createElement("button", {
+        type: "button",
+        className: "btn facet-title",
         onClick: this.handleOpenToggleClick
       }, /*#__PURE__*/React.createElement("span", {
         className: "expand-toggle col-auto px-0"
       }, /*#__PURE__*/React.createElement("i", {
         className: "icon icon-fw icon-" + (anySelections ? "dot-circle far" : facetOpen ? "minus fas" : "plus fas")
       })), /*#__PURE__*/React.createElement("div", {
-        className: "col px-0 line-height-1"
+        className: "col px-0 text-left"
       }, /*#__PURE__*/React.createElement("span", {
         "data-tip": tooltip,
         "data-place": "right"

--- a/es/components/browse/components/FacetList/FacetTermsList.js
+++ b/es/components/browse/components/FacetList/FacetTermsList.js
@@ -420,15 +420,16 @@ export var FacetTermsList = /*#__PURE__*/function (_React$PureComponent2) {
       return /*#__PURE__*/React.createElement("div", {
         className: "facet" + (facetOpen || allTermsSelected ? ' open' : ' closed'),
         "data-field": facet.field
-      }, /*#__PURE__*/React.createElement("h5", {
-        className: "facet-title",
+      }, /*#__PURE__*/React.createElement("button", {
+        type: "button",
+        className: "btn facet-title",
         onClick: this.handleOpenToggleClick
       }, /*#__PURE__*/React.createElement("span", {
         className: "expand-toggle col-auto px-0"
       }, /*#__PURE__*/React.createElement("i", {
         className: "icon icon-fw icon-" + (allTermsSelected ? "dot-circle far" : (facetOpen ? "minus" : "plus") + " fas")
       })), /*#__PURE__*/React.createElement("div", {
-        className: "col px-0 line-height-1"
+        className: "col px-0 text-left"
       }, /*#__PURE__*/React.createElement("span", {
         "data-tip": facetSchemaDescription || fieldSchemaDescription,
         "data-html": true,

--- a/es/components/browse/components/FacetList/FacetTermsList.js
+++ b/es/components/browse/components/FacetList/FacetTermsList.js
@@ -618,20 +618,6 @@ var ListOfTerms = /*#__PURE__*/React.memo(function (props) {
   }
 
   if (Array.isArray(collapsibleTerms)) {
-    var expandButtonTitle;
-
-    if (expanded) {
-      expandButtonTitle = /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement("i", {
-        className: "icon icon-fw icon-minus fas"
-      }), " Collapse");
-    } else {
-      expandButtonTitle = /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement("i", {
-        className: "icon icon-fw icon-plus fas"
-      }), " View ", collapsibleTermsCount, " More", /*#__PURE__*/React.createElement("span", {
-        className: "pull-right"
-      }, collapsibleTermsItemCount));
-    }
-
     return /*#__PURE__*/React.createElement("div", commonProps, /*#__PURE__*/React.createElement(PartialList, {
       className: "mb-0 active-terms-pl",
       open: facetOpen,
@@ -643,10 +629,12 @@ var ListOfTerms = /*#__PURE__*/React.memo(function (props) {
         collapsible: collapsibleTerms
       }), /*#__PURE__*/React.createElement("div", {
         className: "pt-08 pb-0"
-      }, /*#__PURE__*/React.createElement("div", {
-        className: "view-more-button",
-        onClick: onToggleExpanded
-      }, expandButtonTitle)))
+      }, /*#__PURE__*/React.createElement(ViewMoreExpandButton, {
+        expanded: expanded,
+        collapsibleTermsCount: collapsibleTermsCount,
+        collapsibleTermsItemCount: collapsibleTermsItemCount,
+        onToggle: onToggleExpanded
+      })))
     }));
   } else {
     return /*#__PURE__*/React.createElement("div", commonProps, /*#__PURE__*/React.createElement(PartialList, {
@@ -657,6 +645,36 @@ var ListOfTerms = /*#__PURE__*/React.memo(function (props) {
     }));
   }
 });
+export function ViewMoreExpandButton(props) {
+  var _props$expanded = props.expanded,
+      expanded = _props$expanded === void 0 ? false : _props$expanded,
+      onToggle = props.onToggle,
+      collapsibleTermsCount = props.collapsibleTermsCount,
+      collapsibleTermsItemCount = props.collapsibleTermsItemCount;
+  var expandButtonTitle;
+
+  if (expanded) {
+    expandButtonTitle = /*#__PURE__*/React.createElement(React.Fragment, null, /*#__PURE__*/React.createElement("i", {
+      className: "icon icon-fw icon-minus fas mr-06"
+    }), /*#__PURE__*/React.createElement("span", {
+      className: "flex-grow-1 text-left"
+    }, "Collapse"));
+  } else {
+    expandButtonTitle = /*#__PURE__*/React.createElement(React.Fragment, null, /*#__PURE__*/React.createElement("i", {
+      className: "icon icon-fw icon-plus fas mr-06"
+    }), /*#__PURE__*/React.createElement("span", {
+      className: "flex-grow-1 text-left"
+    }, "View ", collapsibleTermsCount, " More"), /*#__PURE__*/React.createElement("span", {
+      className: "pull-right"
+    }, collapsibleTermsItemCount));
+  }
+
+  return /*#__PURE__*/React.createElement("button", {
+    type: "button",
+    className: "btn view-more-button d-flex align-items-center",
+    onClick: onToggle
+  }, expandButtonTitle);
+}
 export var CountIndicator = /*#__PURE__*/React.memo(function (props) {
   var _props$count = props.count,
       count = _props$count === void 0 ? 1 : _props$count,

--- a/es/components/browse/components/FacetList/RangeFacet.js
+++ b/es/components/browse/components/FacetList/RangeFacet.js
@@ -457,15 +457,16 @@ export var RangeFacet = /*#__PURE__*/function (_React$PureComponent) {
       return /*#__PURE__*/React.createElement("div", {
         className: "facet range-facet" + (facetOpen ? ' open' : ' closed'),
         "data-field": facet.field
-      }, /*#__PURE__*/React.createElement("h5", {
-        className: "facet-title",
+      }, /*#__PURE__*/React.createElement("button", {
+        type: "button",
+        className: "btn facet-title",
         onClick: this.handleOpenToggleClick
       }, /*#__PURE__*/React.createElement("span", {
         className: "expand-toggle col-auto px-0"
       }, /*#__PURE__*/React.createElement("i", {
         className: "icon icon-fw icon-" + (facetOpen ? "minus fas" : "plus fas")
       })), /*#__PURE__*/React.createElement("div", {
-        className: "col px-0 line-height-1"
+        className: "col px-0 text-left"
       }, /*#__PURE__*/React.createElement("span", {
         "data-tip": facetSchemaDescription || fieldSchemaDescription,
         "data-place": "right"

--- a/es/components/browse/components/FacetList/RangeFacet.js
+++ b/es/components/browse/components/FacetList/RangeFacet.js
@@ -54,7 +54,7 @@ import { PartialList } from './../../../ui/PartialList';
 import { decorateNumberWithCommas } from './../../../util/value-transforms';
 import { getSchemaProperty } from './../../../util/schema-transforms';
 import { patchedConsoleInstance as console } from './../../../util/patched-console';
-import { segmentComponentsByStatus } from './FacetTermsList';
+import { segmentComponentsByStatus, ViewMoreExpandButton } from './FacetTermsList';
 import { ExtendedDescriptionPopoverIcon } from './ExtendedDescriptionPopoverIcon';
 
 function getRangeStatus(range, toVal, fromVal) {
@@ -784,20 +784,6 @@ var ListOfRanges = /*#__PURE__*/React.memo(function (props) {
   };
 
   if (Array.isArray(collapsibleTerms) && collapsibleTerms.length > 0) {
-    var expandButtonTitle;
-
-    if (expanded) {
-      expandButtonTitle = /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement("i", {
-        className: "icon icon-fw icon-minus fas"
-      }), " Collapse");
-    } else {
-      expandButtonTitle = /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement("i", {
-        className: "icon icon-fw icon-plus fas"
-      }), " View ", collapsibleTermsCount, " More", /*#__PURE__*/React.createElement("span", {
-        className: "pull-right"
-      }, collapsibleTermsItemCount));
-    }
-
     return /*#__PURE__*/React.createElement("div", commonProps, /*#__PURE__*/React.createElement(PartialList, {
       className: "mb-0 active-terms-pl",
       open: facetOpen,
@@ -809,10 +795,12 @@ var ListOfRanges = /*#__PURE__*/React.memo(function (props) {
         collapsible: collapsibleTerms
       }), /*#__PURE__*/React.createElement("div", {
         className: "pt-08 pb-0"
-      }, /*#__PURE__*/React.createElement("div", {
-        className: "view-more-button",
-        onClick: onToggleExpanded
-      }, expandButtonTitle)))
+      }, /*#__PURE__*/React.createElement(ViewMoreExpandButton, {
+        expanded: expanded,
+        collapsibleTermsCount: collapsibleTermsCount,
+        collapsibleTermsItemCount: collapsibleTermsItemCount,
+        onToggle: onToggleExpanded
+      })))
     }));
   } else {
     return /*#__PURE__*/React.createElement("div", commonProps, /*#__PURE__*/React.createElement(PartialList, {

--- a/es/components/browse/components/FacetList/index.js
+++ b/es/components/browse/components/FacetList/index.js
@@ -981,14 +981,14 @@ export var FacetListHeader = /*#__PURE__*/React.memo(function (props) {
     "aria-label": "Properties Controls"
   }, anyFacetsOpen ? /*#__PURE__*/React.createElement("button", {
     type: "button",
-    className: "btn btn-outline-light",
+    className: "btn btn-outline-light fixed-height",
     onClick: onCollapseFacets,
     "data-tip": "Collapse all facets below"
   }, /*#__PURE__*/React.createElement("i", {
     className: "icon icon-fw icon-minus fas"
   })) : null, showClearFiltersButton && typeof onClearFilters === "function" ? /*#__PURE__*/React.createElement("button", {
     type: "button",
-    className: "btn btn-outline-light",
+    className: "btn btn-outline-light fixed-height",
     onClick: onClearFilters,
     "data-tip": "Clear all filters"
   }, /*#__PURE__*/React.createElement("i", {

--- a/es/components/browse/components/above-table-controls/AboveSearchViewTableControls.js
+++ b/es/components/browse/components/above-table-controls/AboveSearchViewTableControls.js
@@ -37,12 +37,12 @@ export var AboveSearchViewTableControls = /*#__PURE__*/React.memo(function (prop
 
     if (addAction && typeof addAction.href === 'string') {
       addButton = /*#__PURE__*/React.createElement("a", {
-        className: "btn btn-primary btn-xs" + (total ? " ml-1" : ""),
+        className: "btn btn-primary btn-xs d-flex align-items-center" + (total ? " ml-1" : ""),
         href: addAction.href,
         "data-skiprequest": "true"
       }, /*#__PURE__*/React.createElement("i", {
         className: "icon icon-fw icon-plus fas mr-03 fas"
-      }), "Create New \xA0");
+      }), /*#__PURE__*/React.createElement("span", null, "Create New\xA0"));
     }
   }
 

--- a/es/components/browse/components/above-table-controls/RightButtonsSection.js
+++ b/es/components/browse/components/above-table-controls/RightButtonsSection.js
@@ -53,14 +53,15 @@ export var ConfigureVisibleColumnsButton = /*#__PURE__*/React.memo(function (_re
   var open = _ref.open,
       onClick = _ref.onClick,
       className = _ref.className;
+  var cls = (className ? " " + className : "") + (open ? " active" : "");
   return /*#__PURE__*/React.createElement("button", {
     type: "button",
     key: "toggle-visible-columns",
     "data-tip": "Configure visible columns",
     "data-event-off": "click",
-    active: open.toString(),
+    active: !!open,
     onClick: onClick,
-    className: (className || "") + (open ? " active" : "")
+    className: cls
   }, /*#__PURE__*/React.createElement("i", {
     className: "icon icon-fw icon-table fas"
   }), /*#__PURE__*/React.createElement("i", {
@@ -68,20 +69,21 @@ export var ConfigureVisibleColumnsButton = /*#__PURE__*/React.memo(function (_re
   }));
 });
 ConfigureVisibleColumnsButton.defaultProps = {
-  "className": "btn btn-outline-primary"
+  "className": "btn btn-outline-primary fixed-height"
 };
 export var MultiColumnSortButton = /*#__PURE__*/React.memo(function (_ref2) {
   var open = _ref2.open,
       onClick = _ref2.onClick,
       className = _ref2.className;
+  var cls = (className ? " " + className : "") + (open ? " active" : "");
   return /*#__PURE__*/React.createElement("button", {
     type: "button",
     key: "toggle-visible-columns",
     "data-tip": "Sort multiple columns",
     "data-event-off": "click",
-    active: open.toString(),
+    active: !!open,
     onClick: onClick,
-    className: (className || "") + (open ? " active" : "")
+    className: cls
   }, /*#__PURE__*/React.createElement("i", {
     className: "icon icon-fw icon-sort fas"
   }), /*#__PURE__*/React.createElement("i", {
@@ -89,7 +91,7 @@ export var MultiColumnSortButton = /*#__PURE__*/React.memo(function (_ref2) {
   }));
 });
 MultiColumnSortButton.defaultProps = {
-  "className": "btn btn-outline-primary"
+  "className": "btn btn-outline-primary fixed-height"
 };
 /** Toggles between regular & full screen views */
 

--- a/scss/facet-list.scss
+++ b/scss/facet-list.scss
@@ -616,6 +616,10 @@ $facetlist-term-block-height: default !default;
                 padding: 2px 6px 1px;
                 line-height: 20px;
                 border-radius: 2px;
+                background: transparent;
+                width: 100%;
+                font-weight: 400;
+
                 &:hover {
                     border-color: #000;
                 }
@@ -623,7 +627,7 @@ $facetlist-term-block-height: default !default;
                 i.icon {
                     font-size: 0.8rem;
                     position: relative;
-                    left: -2px;
+                    line-height: inherit;
                 }
             }
 

--- a/scss/facet-list.scss
+++ b/scss/facet-list.scss
@@ -252,11 +252,17 @@ $facetlist-term-block-height: default !default;
             }
         }
 
-        h5.facet-title {
+        button.facet-title {
             margin: 0 0 3px;
             font-weight: 500;
             line-height: inherit;
             height: 40px;
+            border: none;
+            background: transparent;
+            width: 100%;
+            padding: 0;
+            display: flex;
+            align-items: center;
             @include font-size($facetlist-facet-font-size);
 
             > i.icon-info-circle {
@@ -281,7 +287,7 @@ $facetlist-term-block-height: default !default;
         &:not(.static) {
             transition: padding-bottom .35s ease, background-color .35s ease;
             background-color: transparent;
-            h5.facet-title {
+            button.facet-title {
                 
                 margin : 0;
                 border-top: 1px solid transparent;
@@ -289,11 +295,11 @@ $facetlist-term-block-height: default !default;
                 border-bottom: 1px solid #f8f8f8;
                 
                 cursor: pointer;
-                display: flex;
-                align-items: center;
+                
                 > span.expand-toggle > i.icon {
                     font-size: 0.7rem;
                     margin-right: 7px;
+                    transition: color .35s ease-out;
                 }
 
                 .closed-terms-count {
@@ -349,7 +355,14 @@ $facetlist-term-block-height: default !default;
                     }
                 }
 
-                &:hover {
+                &:hover, &:focus {
+                    box-shadow: none; // Unset default .btn focus styling
+
+                    > span.expand-toggle > i.icon {
+                        color: #000;
+                        text-shadow: 0 0;
+                    }
+
                     .closed-terms-count {
 
                         &.show {

--- a/src/components/browse/components/FacetList/FacetOfFacets.js
+++ b/src/components/browse/components/FacetList/FacetOfFacets.js
@@ -55,11 +55,11 @@ export class FacetOfFacets extends React.PureComponent {
 
         return (
             <div className={"facet" + (facetOpen || anySelections ? ' open' : ' closed')} data-group={title}>
-                <h5 className="facet-title" onClick={this.handleOpenToggleClick}>
+                <button type="button" className="btn facet-title" onClick={this.handleOpenToggleClick}>
                     <span className="expand-toggle col-auto px-0">
                         <i className={"icon icon-fw icon-" + (anySelections ? "dot-circle far" : (facetOpen ? "minus fas" : "plus fas"))}/>
                     </span>
-                    <div className="col px-0 line-height-1">
+                    <div className="col px-0 text-left">
                         <span data-tip={tooltip} data-place="right">{ title }</span>
                     </div>
                     <Fade in={!facetOpen && !anySelections}>
@@ -68,7 +68,7 @@ export class FacetOfFacets extends React.PureComponent {
                             <i className="icon fas icon-layer-group" />
                         </span>
                     </Fade>
-                </h5>
+                </button>
                 <Collapse in={facetOpen || anySelections}>
                     <div className="facet-group-list-container">
                         { extendedFacets }

--- a/src/components/browse/components/FacetList/FacetTermsList.js
+++ b/src/components/browse/components/FacetList/FacetTermsList.js
@@ -404,23 +404,6 @@ const ListOfTerms = React.memo(function ListOfTerms(props){
     }
 
     if (Array.isArray(collapsibleTerms)) {
-        let expandButtonTitle;
-
-        if (expanded){
-            expandButtonTitle = (
-                <span>
-                    <i className="icon icon-fw icon-minus fas"/> Collapse
-                </span>
-            );
-        } else {
-            expandButtonTitle = (
-                <span>
-                    <i className="icon icon-fw icon-plus fas"/> View { collapsibleTermsCount } More
-                    <span className="pull-right">{ collapsibleTermsItemCount }</span>
-                </span>
-            );
-        }
-
         return (
             <div {...commonProps}>
                 <PartialList className="mb-0 active-terms-pl" open={facetOpen} persistent={activeTermComponents} collapsible={
@@ -428,7 +411,7 @@ const ListOfTerms = React.memo(function ListOfTerms(props){
                         {facetSearch}
                         <PartialList className="mb-0" open={expanded} persistent={persistentTerms} collapsible={collapsibleTerms} />
                         <div className="pt-08 pb-0">
-                            <div className="view-more-button" onClick={onToggleExpanded}>{expandButtonTitle}</div>
+                            <ViewMoreExpandButton {...{ expanded, collapsibleTermsCount, collapsibleTermsItemCount }} onToggle={onToggleExpanded} />
                         </div>
                     </React.Fragment>
                 } />
@@ -447,6 +430,32 @@ const ListOfTerms = React.memo(function ListOfTerms(props){
         );
     }
 });
+
+export function ViewMoreExpandButton (props) {
+    const { expanded = false, onToggle, collapsibleTermsCount, collapsibleTermsItemCount } = props;
+    let expandButtonTitle;
+    if (expanded){
+        expandButtonTitle = (
+            <React.Fragment>
+                <i className="icon icon-fw icon-minus fas mr-06"/>
+                <span className="flex-grow-1 text-left">Collapse</span>
+            </React.Fragment>
+        );
+    } else {
+        expandButtonTitle = (
+            <React.Fragment>
+                <i className="icon icon-fw icon-plus fas mr-06"/>
+                <span className="flex-grow-1 text-left">View { collapsibleTermsCount } More</span>
+                <span className="pull-right">{ collapsibleTermsItemCount }</span>
+            </React.Fragment>
+        );
+    }
+    return (
+        <button type="button" className="btn view-more-button d-flex align-items-center" onClick={onToggle}>
+            { expandButtonTitle }
+        </button>
+    );
+}
 
 
 export const CountIndicator = React.memo(function CountIndicator(props){

--- a/src/components/browse/components/FacetList/FacetTermsList.js
+++ b/src/components/browse/components/FacetList/FacetTermsList.js
@@ -276,16 +276,16 @@ export class FacetTermsList extends React.PureComponent {
         // List of terms
         return (
             <div className={"facet" + (facetOpen || allTermsSelected ? ' open' : ' closed')} data-field={facet.field}>
-                <h5 className="facet-title" onClick={this.handleOpenToggleClick}>
+                <button type="button" className="btn facet-title" onClick={this.handleOpenToggleClick}>
                     <span className="expand-toggle col-auto px-0">
                         <i className={"icon icon-fw icon-" + (allTermsSelected ? "dot-circle far" : (facetOpen ? "minus" : "plus") + " fas")}/>
                     </span>
-                    <div className="col px-0 line-height-1">
+                    <div className="col px-0 text-left">
                         <span data-tip={facetSchemaDescription || fieldSchemaDescription} data-html data-place="right">{ title }</span>
                         <ExtendedDescriptionPopoverIcon {...{ fieldSchema, facet, openPopover, setOpenPopover }} />
                     </div>
                     { indicator }
-                </h5>
+                </button>
                 <ListOfTerms
                     {...{ facet, facetOpen, terms, onTermClick, expanded, getTermStatus, termTransformFxn, searchText, schemas, persistentCount, defaultBasicSearchAutoDisplayThreshold, filteringFieldTerm }}
                     onSaytTermSearch={this.handleSaytTermSearch} onBasicTermSearch={this.handleBasicTermSearch} onToggleExpanded={this.handleExpandListToggleClick} />

--- a/src/components/browse/components/FacetList/RangeFacet.js
+++ b/src/components/browse/components/FacetList/RangeFacet.js
@@ -14,7 +14,7 @@ import { PartialList } from './../../../ui/PartialList';
 import { decorateNumberWithCommas } from './../../../util/value-transforms';
 import { getSchemaProperty } from './../../../util/schema-transforms';
 import { patchedConsoleInstance as console } from './../../../util/patched-console';
-import { segmentComponentsByStatus } from './FacetTermsList';
+import { segmentComponentsByStatus, ViewMoreExpandButton } from './FacetTermsList';
 
 import { ExtendedDescriptionPopoverIcon } from './ExtendedDescriptionPopoverIcon';
 
@@ -620,31 +620,13 @@ const ListOfRanges = React.memo(function ListOfRanges(props){
     };
 
     if (Array.isArray(collapsibleTerms) && collapsibleTerms.length > 0){
-
-        let expandButtonTitle;
-
-        if (expanded){
-            expandButtonTitle = (
-                <span>
-                    <i className="icon icon-fw icon-minus fas"/> Collapse
-                </span>
-            );
-        } else {
-            expandButtonTitle = (
-                <span>
-                    <i className="icon icon-fw icon-plus fas"/> View { collapsibleTermsCount } More
-                    <span className="pull-right">{ collapsibleTermsItemCount }</span>
-                </span>
-            );
-        }
-
         return (
             <div {...commonProps}>
                 <PartialList className="mb-0 active-terms-pl" open={facetOpen} persistent={activeTermComponents} collapsible={
                     <React.Fragment>
                         <PartialList className="mb-0" open={expanded} persistent={persistentTerms} collapsible={collapsibleTerms} />
                         <div className="pt-08 pb-0">
-                            <div className="view-more-button" onClick={onToggleExpanded}>{ expandButtonTitle }</div>
+                            <ViewMoreExpandButton {...{ expanded, collapsibleTermsCount, collapsibleTermsItemCount }} onToggle={onToggleExpanded} />
                         </div>
                     </React.Fragment>
                 } />

--- a/src/components/browse/components/FacetList/RangeFacet.js
+++ b/src/components/browse/components/FacetList/RangeFacet.js
@@ -465,11 +465,11 @@ export class RangeFacet extends React.PureComponent {
 
         return (
             <div className={"facet range-facet" + (facetOpen ? ' open' : ' closed')} data-field={facet.field}>
-                <h5 className="facet-title" onClick={this.handleOpenToggleClick}>
+                <button type="button" className="btn facet-title" onClick={this.handleOpenToggleClick}>
                     <span className="expand-toggle col-auto px-0">
                         <i className={"icon icon-fw icon-" + (facetOpen ? "minus fas" : "plus fas")}/>
                     </span>
-                    <div className="col px-0 line-height-1">
+                    <div className="col px-0 text-left">
                         <span data-tip={facetSchemaDescription || fieldSchemaDescription} data-place="right">{ title }</span>
                         <ExtendedDescriptionPopoverIcon {...{ fieldSchema, facet, openPopover, setOpenPopover }} />
                     </div>
@@ -481,7 +481,7 @@ export class RangeFacet extends React.PureComponent {
                                 : <i className="icon icon-fw icon-greater-than-equal fas" /> }
                         </span>
                     </Fade>
-                </h5>
+                </button>
                 <div className="facet-list" data-open={facetOpen} data-any-active={(savedFromVal || savedToVal) ? true : false}>
                     <PartialList className="inner-panel" open={facetOpen}
                         persistent={[

--- a/src/components/browse/components/FacetList/index.js
+++ b/src/components/browse/components/FacetList/index.js
@@ -737,12 +737,12 @@ export const FacetListHeader = React.memo(function FacetListHeader(props){
             <div className="col-auto">
                 <div className="btn-group btn-group-sm properties-controls" role="group" aria-label="Properties Controls">
                     { anyFacetsOpen ?
-                        <button type="button" className="btn btn-outline-light" onClick={onCollapseFacets} data-tip="Collapse all facets below">
+                        <button type="button" className="btn btn-outline-light fixed-height" onClick={onCollapseFacets} data-tip="Collapse all facets below">
                             <i className="icon icon-fw icon-minus fas"/>
                         </button>
                         : null }
                     { showClearFiltersButton && typeof onClearFilters === "function" ?
-                        <button type="button" className="btn btn-outline-light" onClick={onClearFilters} data-tip="Clear all filters">
+                        <button type="button" className="btn btn-outline-light fixed-height" onClick={onClearFilters} data-tip="Clear all filters">
                             <i className="icon icon-fw icon-times fas"/>
                         </button>
                         : null }

--- a/src/components/browse/components/above-table-controls/AboveSearchViewTableControls.js
+++ b/src/components/browse/components/above-table-controls/AboveSearchViewTableControls.js
@@ -29,10 +29,9 @@ export const AboveSearchViewTableControls = React.memo(function AboveSearchViewT
         const addAction = _.findWhere(context.actions, { 'name' : 'add' });
         if (addAction && typeof addAction.href === 'string'){
             addButton = (
-                <a className={"btn btn-primary btn-xs" + (total ? " ml-1" : "")} href={addAction.href} data-skiprequest="true">
+                <a className={"btn btn-primary btn-xs d-flex align-items-center" + (total ? " ml-1" : "")} href={addAction.href} data-skiprequest="true">
                     <i className="icon icon-fw icon-plus fas mr-03 fas"/>
-                    Create New
-                    &nbsp;
+                    <span>Create New&nbsp;</span>
                 </a>
             );
         }

--- a/src/components/browse/components/above-table-controls/RightButtonsSection.js
+++ b/src/components/browse/components/above-table-controls/RightButtonsSection.js
@@ -22,29 +22,31 @@ export const RightButtonsSection = React.memo(function RightButtonsSection(props
 
 
 export const ConfigureVisibleColumnsButton = React.memo(function ConfigureVisibleColumnsButton({ open, onClick, className }){
+    const cls = (className ? " " + className : "") + (open ? " active" : "");
     return (
         <button type="button" key="toggle-visible-columns" data-tip="Configure visible columns" data-event-off="click"
-            active={open.toString()} onClick={onClick} className={(className || "") + (open ? " active" : "")}>
+            active={!!open} onClick={onClick} className={cls}>
             <i className="icon icon-fw icon-table fas" />
             <i className="icon icon-fw icon-angle-down ml-03 fas"/>
         </button>
     );
 });
 ConfigureVisibleColumnsButton.defaultProps = {
-    "className" : "btn btn-outline-primary"
+    "className" : "btn btn-outline-primary fixed-height"
 };
 
 export const MultiColumnSortButton = React.memo(function MultiColumnSortButton({ open, onClick, className }){
+    const cls = (className ? " " + className : "") + (open ? " active" : "");
     return (
         <button type="button" key="toggle-visible-columns" data-tip="Sort multiple columns" data-event-off="click"
-            active={open.toString()} onClick={onClick} className={(className || "") + (open ? " active" : "")}>
+            active={!!open} onClick={onClick} className={cls}>
             <i className="icon icon-fw icon-sort fas" />
             <i className="icon icon-fw icon-angle-down ml-03 fas"/>
         </button>
     );
 });
 MultiColumnSortButton.defaultProps = {
-    "className" : "btn btn-outline-primary"
+    "className" : "btn btn-outline-primary fixed-height"
 };
 
 /** Toggles between regular & full screen views */


### PR DESCRIPTION
- Changes some things in FacetList to be literal buttons (+ styling updates for it), such as the 'view more' buttons and facets' titles for better accessibility (i.e. ability to use keyboard interaction ([shift+]tab/enter/space) w. it).

- (No Effect) Adds 'fixed-height' class to some buttons which only have icon(s) as child (and no text); not used right now / may come back to later. On 4DN, there's a style rule in bootstrap_overrides.scss that sets >i:only-child to have line-height: inherit; this seems to work decently (but not perfectly; not used if 2+ icons in same button..) which could use some testing on CGAP-side.