### PR TITLE
Default Open Facets Update

### DIFF
--- a/es/components/browse/components/FacetList/FacetTermsList.js
+++ b/es/components/browse/components/FacetList/FacetTermsList.js
@@ -434,7 +434,7 @@ export var FacetTermsList = /*#__PURE__*/function (_React$PureComponent2) {
       }, /*#__PURE__*/React.createElement("span", {
         className: "expand-toggle col-auto px-0"
       }, /*#__PURE__*/React.createElement("i", {
-        className: "icon icon-fw icon-" + (allTermsSelected ? "dot-circle far" : (facetOpen ? "minus" : "plus") + " fas")
+        className: "icon icon-fw icon-" + (allTermsSelected && useRadioIcon === false ? "dot-circle far" : (facetOpen ? "minus" : "plus") + " fas")
       })), /*#__PURE__*/React.createElement("div", {
         className: "col px-0 line-height-1"
       }, /*#__PURE__*/React.createElement("span", {

--- a/es/components/browse/components/FacetList/index.js
+++ b/es/components/browse/components/FacetList/index.js
@@ -241,7 +241,12 @@ export var FacetList = /*#__PURE__*/function (_React$PureComponent) {
           windowWidth = _this$props.windowWidth,
           facets = _this$props.facets,
           _this$props$persisten = _this$props.persistentCount,
-          persistentCount = _this$props$persisten === void 0 ? 10 : _this$props$persisten;
+          persistentCount = _this$props$persisten === void 0 ? 10 : _this$props$persisten,
+          _this$props$persistSe = _this$props.persistSelectedTerms,
+          persistSelectedTerms = _this$props$persistSe === void 0 ? true : _this$props$persistSe,
+          _this$props$context = _this$props.context;
+      _this$props$context = _this$props$context === void 0 ? {} : _this$props$context;
+      var filters = _this$props$context.filters;
       var rgs = responsiveGridState(windowWidth || null);
 
       var _this$renderFacetComp = this.renderFacetComponents(),
@@ -250,6 +255,21 @@ export var FacetList = /*#__PURE__*/function (_React$PureComponent) {
 
       if (rgs === "xs") {
         ReactTooltip.rebuild();
+        return;
+      } //default open facets for selected terms are not persistent case
+
+
+      if (persistSelectedTerms === false && filters && filters.length > 0) {
+        var openFacets = filters.reduce(function (m, v) {
+          if (v && v.field) {
+            m[v.field] = true;
+          }
+
+          return m;
+        }, {});
+        this.setState({
+          openFacets: openFacets
+        });
         return;
       } // Skip if we have many facets. We're simply reusing persistentCount variable here
       // but could really be any number/value (8 ? windowHeight // 100 ?)

--- a/src/components/browse/components/FacetList/FacetTermsList.js
+++ b/src/components/browse/components/FacetList/FacetTermsList.js
@@ -285,7 +285,7 @@ export class FacetTermsList extends React.PureComponent {
             <div className={"facet" + (facetOpen || allTermsSelected ? ' open' : ' closed')} data-field={facet.field}>
                 <h5 className="facet-title" onClick={this.handleOpenToggleClick}>
                     <span className="expand-toggle col-auto px-0">
-                        <i className={"icon icon-fw icon-" + (allTermsSelected ? "dot-circle far" : (facetOpen ? "minus" : "plus") + " fas")}/>
+                        <i className={"icon icon-fw icon-" + (allTermsSelected && useRadioIcon === false ? "dot-circle far" : (facetOpen ? "minus" : "plus") + " fas")}/>
                     </span>
                     <div className="col px-0 line-height-1">
                         <span data-tip={facetSchemaDescription || fieldSchemaDescription} data-html data-place="right">{ title }</span>

--- a/src/components/browse/components/FacetList/index.js
+++ b/src/components/browse/components/FacetList/index.js
@@ -463,12 +463,24 @@ export class FacetList extends React.PureComponent {
     }
 
     componentDidMount(){
-        const { windowHeight, windowWidth, facets, persistentCount = 10 } = this.props;
+        const { windowHeight, windowWidth, facets, persistentCount = 10, persistSelectedTerms = true, context: { filters } = {} } = this.props;
         const rgs = responsiveGridState(windowWidth || null);
         const { selectableFacetElements } = this.renderFacetComponents(); // Internally memoized - should be performant.
 
         if (rgs === "xs") {
             ReactTooltip.rebuild();
+            return;
+        }
+
+        //default open facets for selected terms are not persistent case
+        if (persistSelectedTerms === false && filters && filters.length > 0) {
+            const openFacets = filters.reduce(function (m, v) {
+                if (v && v.field) {
+                    m[v.field] = true;
+                }
+                return m;
+            }, {});
+            this.setState({ openFacets: openFacets });
             return;
         }
 


### PR DESCRIPTION
Trello: https://trello.com/c/sNhlMjbn

PS: Handle this PR with the [FF PR](https://github.com/4dn-dcic/fourfront/pull/1571) please.

The updates are mostly for the MicroMeta hardware summary table to display initial term selection as expanded. 

1. The current implementation takes window height and terms count into account to determine whether the facet is open. This feature remains as before, none of the browse/search pages are affected. We just extend it for `persistSelectedTerms` is `false` case that is currently default setting for MicroMeta hardware summary facets.

2. if `useRadioIcon` is `true` and all terms selected, we'll display `"+"`/`"-"` icon instead of `dot-circle`.

New: https://i.gyazo.com/b43d79bde6c1677cb624815bf439b457.gif

Old: https://i.gyazo.com/26491f55d4810c087eb02eb96726c1f2.gif
