### PR TITLE
Make LocalizedTime proptypes match date-fns-tz doc

### DIFF
--- a/es/components/ui/LocalizedTime.js
+++ b/es/components/ui/LocalizedTime.js
@@ -8,7 +8,7 @@ function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _d
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); Object.defineProperty(subClass, "prototype", { writable: false }); if (superClass) _setPrototypeOf(subClass, superClass); }
 
-function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function (o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf ? Object.setPrototypeOf.bind() : function (o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
 function _createSuper(Derived) { var hasNativeReflectConstruct = _isNativeReflectConstruct(); return function () { var Super = _getPrototypeOf(Derived), result; if (hasNativeReflectConstruct) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
 
@@ -18,7 +18,7 @@ function _assertThisInitialized(self) { if (self === void 0) { throw new Referen
 
 function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
 
-function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function (o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf.bind() : function (o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
 import React from 'react';
 import PropTypes from 'prop-types';
@@ -41,6 +41,7 @@ export var LocalizedTime = /*#__PURE__*/function (_React$Component) {
     _this.memoized = {
       getDateFns: memoize(function (dateFnsDate, timestamp) {
         var parsedTime = zonedTimeToUtc(timestamp);
+        console.log("parsedTime", parsedTime);
         if (dateFnsDate) return dateFnsDate;
         if (timestamp) return parsedTime;
         return new Date();
@@ -93,8 +94,8 @@ LocalizedTime.propTypes = {
       return new Error("dateFnsDate must be an instance of date-fns.");
     }
   },
-  timestamp: PropTypes.string,
-  localize: PropTypes.bool,
+  // Timestamp can be any of the following according to: https://github.com/marnusw/date-fns-tz#zonedtimetoutc
+  timestamp: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.instanceOf(Date)]),
   formatType: PropTypes.string,
   dateTimeSeparator: PropTypes.string,
   customOutputFormat: PropTypes.string,

--- a/src/components/ui/LocalizedTime.js
+++ b/src/components/ui/LocalizedTime.js
@@ -13,6 +13,7 @@ export class LocalizedTime extends React.Component {
         this.memoized = {
             getDateFns: memoize(function(dateFnsDate, timestamp) {
                 const parsedTime = zonedTimeToUtc(timestamp);
+                console.log("parsedTime", parsedTime);
                 if (dateFnsDate) return dateFnsDate;
                 if (timestamp) return parsedTime;
                 return new Date();
@@ -58,8 +59,8 @@ LocalizedTime.propTypes = {
             return new Error("dateFnsDate must be an instance of date-fns.");
         }
     },
-    timestamp : PropTypes.string,
-    localize: PropTypes.bool,
+    // Timestamp can be any of the following according to: https://github.com/marnusw/date-fns-tz#zonedtimetoutc
+    timestamp : PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.instanceOf(Date)]),
     formatType : PropTypes.string,
     dateTimeSeparator : PropTypes.string,
     customOutputFormat : PropTypes.string,


### PR DESCRIPTION
Small update to proptypes for LocalizedTime component, since some date-fns-tz methods actually accept more values than we're currently allowing in our code: https://github.com/marnusw/date-fns-tz#zonedtimetoutc.

Also fixes a proptype warning caused by this: https://github.com/dbmi-bgm/cgap-portal/pull/623