### PR TITLE
Child Popup Window Updates

### DIFF
--- a/es/components/browse/SearchView.js
+++ b/es/components/browse/SearchView.js
@@ -5,7 +5,7 @@ import _inherits from "@babel/runtime/helpers/inherits";
 import _possibleConstructorReturn from "@babel/runtime/helpers/possibleConstructorReturn";
 import _getPrototypeOf from "@babel/runtime/helpers/getPrototypeOf";
 import _defineProperty from "@babel/runtime/helpers/defineProperty";
-var _excluded = ["href", "context", "showClearFiltersButton", "schemas", "currentAction", "facets", "navigate", "columns", "columnExtensionMap", "placeholderReplacementFxn", "windowWidth"];
+var _excluded = ["href", "context", "showClearFiltersButton", "schemas", "currentAction", "facets", "navigate", "columns", "columnExtensionMap", "placeholderReplacementFxn", "keepSelectionInStorage", "windowWidth"];
 
 function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); enumerableOnly && (symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; })), keys.push.apply(keys, symbols); } return keys; }
 
@@ -79,6 +79,7 @@ export var SearchView = /*#__PURE__*/function (_React$PureComponent) {
           _this$props$columnExt = _this$props.columnExtensionMap,
           columnExtensionMap = _this$props$columnExt === void 0 ? basicColumnExtensionMap : _this$props$columnExt,
           placeholderReplacementFxn = _this$props.placeholderReplacementFxn,
+          keepSelectionInStorage = _this$props.keepSelectionInStorage,
           windowWidth = _this$props.windowWidth,
           passProps = _objectWithoutProperties(_this$props, _excluded);
 
@@ -117,7 +118,8 @@ export var SearchView = /*#__PURE__*/function (_React$PureComponent) {
         // though if desired.
         React.createElement(SelectedItemsController, {
           columnExtensionMap: columnExtensionMap,
-          currentAction: currentAction
+          currentAction: currentAction,
+          keepSelectionInStorage: keepSelectionInStorage
         }, controllersAndView);
       }
 
@@ -150,8 +152,9 @@ _defineProperty(SearchView, "propTypes", {
   'showClearFiltersButton': PropTypes.bool,
   'isOwnPage': PropTypes.bool,
   'schemas': PropTypes.object,
-  'placeholderReplacementFxn': PropTypes.func // Passed down to AboveSearchTablePanel StaticSection
-
+  'placeholderReplacementFxn': PropTypes.func,
+  // Passed down to AboveSearchTablePanel StaticSection
+  'keepSelectionInStorage': PropTypes.bool
 });
 
 _defineProperty(SearchView, "defaultProps", {
@@ -163,5 +166,6 @@ _defineProperty(SearchView, "defaultProps", {
   'currentAction': null,
   'columnExtensionMap': basicColumnExtensionMap,
   'separateSingleTermFacets': true,
-  'isOwnPage': true
+  'isOwnPage': true,
+  'keepSelectionInStorage': false
 });

--- a/es/components/browse/components/SelectedItemsController.js
+++ b/es/components/browse/components/SelectedItemsController.js
@@ -26,6 +26,7 @@ function _createSuper(Derived) { var hasNativeReflectConstruct = _isNativeReflec
 function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
 
 import React, { useMemo, useCallback } from 'react';
+import PropTypes from 'prop-types';
 import _ from 'underscore';
 import { Alerts } from './../../ui/Alerts';
 import { itemUtil } from './../../util/object';
@@ -351,24 +352,40 @@ export var SelectStickyFooter = /*#__PURE__*/React.memo(function (props) {
     className: "icon icon-fw fas icon-times"
   }), "\xA0 Cancel"))));
 });
-export var BackNavigationStickyFooter = /*#__PURE__*/React.memo(function () {
+export var BackNavigationStickyFooter = /*#__PURE__*/React.memo(function (props) {
+  var text = props.text,
+      tooltip = props.tooltip,
+      navigateToInitialPage = props.navigateToInitialPage;
+  var onBackButtonClick = useCallback(function () {
+    if (window.history.length === 0) {
+      return;
+    }
+
+    history.go(navigateToInitialPage === true ? -(window.history.length - 1) : -1);
+  });
   return /*#__PURE__*/React.createElement(StickyFooter, null, /*#__PURE__*/React.createElement("div", {
-    className: "row selection-controls-footer"
+    className: "row selection-controls-footer pull-right"
   }, /*#__PURE__*/React.createElement("div", {
-    className: "col mb-05 mt-05"
-  }, "\xA0"), /*#__PURE__*/React.createElement("div", {
     className: "col-12 col-md-auto"
   }, /*#__PURE__*/React.createElement("button", {
     type: "button",
     className: "btn btn-outline-warning ml-1",
-    onClick: function onClick() {
-      return history.go(-(window.history.length - 1));
-    },
-    "data-tip": "Go to selection page"
+    onClick: onBackButtonClick,
+    "data-tip": tooltip || ''
   }, /*#__PURE__*/React.createElement("i", {
     className: "icon icon-fw fas icon-arrow-left"
-  }), "\xA0 Return to Selection List"))));
+  }), "\xA0 ", text || ''))));
 });
+BackNavigationStickyFooter.propTypes = {
+  'text': PropTypes.string,
+  'tooltip': PropTypes.string,
+  'navigateToInitialPage': PropTypes.bool
+};
+BackNavigationStickyFooter.defaultProps = {
+  'text': 'Return to Selection List',
+  'tooltip': 'Go to selection page',
+  'navigateToInitialPage': true
+};
 /**
  * General purpose sticky footer component
  * TODO: Component can be moved to a separate file.

--- a/es/components/browse/components/SelectedItemsController.js
+++ b/es/components/browse/components/SelectedItemsController.js
@@ -29,7 +29,7 @@ import React, { useMemo, useCallback } from 'react';
 import _ from 'underscore';
 import { Alerts } from './../../ui/Alerts';
 import { itemUtil } from './../../util/object';
-import { isSelectAction } from './../../util/misc';
+import { isSelectAction, storeExists } from './../../util/misc';
 import * as logger from '../../util/logger';
 import { DisplayTitleColumnWrapper, DisplayTitleColumnDefault } from './../../browse/components/table-commons/basicColumnExtensionMap';
 import { getSchemaTypeFromSearchContext, getTitleForType } from './../../util/schema-transforms';
@@ -87,15 +87,29 @@ export var SelectedItemsController = /*#__PURE__*/function (_React$PureComponent
     };
     return _this;
   }
-  /**
-   * This function add/or removes the selected item into an Map in state,
-   * if `props.currentAction` is set to "multiselect" or "selection".
-   */
-
 
   _createClass(SelectedItemsController, [{
+    key: "componentDidMount",
+    value: function componentDidMount() {
+      var keepSelectionInStorage = this.props.keepSelectionInStorage;
+      this.setState(function () {
+        if (keepSelectionInStorage === true && storeExists() && localStorage.getItem("selected_items") !== null) {
+          var foundItems = JSON.parse(localStorage.getItem("selected_items"));
+          return {
+            selectedItems: new Map(foundItems)
+          };
+        }
+      });
+    }
+    /**
+     * This function add/or removes the selected item into an Map in state,
+     * if `props.currentAction` is set to "multiselect" or "selection".
+     */
+
+  }, {
     key: "handleSelectItem",
     value: function handleSelectItem(result, isMultiSelect) {
+      var keepSelectionInStorage = this.props.keepSelectionInStorage;
       this.setState(function (_ref) {
         var prevItems = _ref.selectedItems;
         var nextItems = new Map(prevItems);
@@ -123,6 +137,10 @@ export var SelectedItemsController = /*#__PURE__*/function (_React$PureComponent
 
             nextItems.set(resultAtID, result);
           }
+        }
+
+        if (keepSelectionInStorage && storeExists()) {
+          localStorage.setItem("selected_items", JSON.stringify(Array.from(nextItems.entries())));
         }
 
         return {

--- a/es/components/browse/components/SelectedItemsController.js
+++ b/es/components/browse/components/SelectedItemsController.js
@@ -333,6 +333,24 @@ export var SelectStickyFooter = /*#__PURE__*/React.memo(function (props) {
     className: "icon icon-fw fas icon-times"
   }), "\xA0 Cancel"))));
 });
+export var BackNavigationStickyFooter = /*#__PURE__*/React.memo(function () {
+  return /*#__PURE__*/React.createElement(StickyFooter, null, /*#__PURE__*/React.createElement("div", {
+    className: "row selection-controls-footer"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "col mb-05 mt-05"
+  }, "\xA0"), /*#__PURE__*/React.createElement("div", {
+    className: "col-12 col-md-auto"
+  }, /*#__PURE__*/React.createElement("button", {
+    type: "button",
+    className: "btn btn-outline-warning ml-1",
+    onClick: function onClick() {
+      return history.go(-(window.history.length - 1));
+    },
+    "data-tip": "Go to selection page"
+  }, /*#__PURE__*/React.createElement("i", {
+    className: "icon icon-fw fas icon-arrow-left"
+  }), "\xA0 Return to Selection List"))));
+});
 /**
  * General purpose sticky footer component
  * TODO: Component can be moved to a separate file.

--- a/es/components/forms/components/LinkToSelector.js
+++ b/es/components/forms/components/LinkToSelector.js
@@ -16,6 +16,7 @@ import _ from 'underscore';
 import url from 'url';
 import { patchedConsoleInstance as console } from './../../util/patched-console';
 import { itemUtil } from './../../util/object';
+import { storeExists } from '../../util/misc';
 /**
  * Global variable which holds reference to child window, if any.
  * Is re-used if one is open to prevent additional windows being created.
@@ -63,7 +64,11 @@ export var LinkToSelector = /*#__PURE__*/function (_React$PureComponent) {
     value: function componentDidMount() {
       this.manageChildWindow({
         'isSelecting': false
-      }, this.props);
+      }, this.props); //clear storage
+
+      if (storeExists()) {
+        localStorage.removeItem("selected_items");
+      }
     }
   }, {
     key: "componentDidUpdate",
@@ -238,6 +243,12 @@ export var LinkToSelector = /*#__PURE__*/function (_React$PureComponent) {
 
       if (!this || !this.windowObjectReference) {
         console.warn('Child window no longer available to unbind event handlers. Fine if closed.');
+        return;
+      } //clear storage
+
+
+      if (storeExists()) {
+        localStorage.removeItem("selected_items");
       }
     }
   }, {

--- a/es/components/util/json-web-token.js
+++ b/es/components/util/json-web-token.js
@@ -1,22 +1,11 @@
 import _ from 'underscore';
 import memoize from 'memoize-one';
-import { isServerSide } from './misc';
+import { isServerSide, storeExists } from './misc';
 import { patchedConsoleInstance as console } from './patched-console';
 import { getNestedProperty } from './object';
 /** Used for serverside */
 
 var dummyStorage = {};
-/**
- * Check to see if localStorage is supported by the browser or environment.
- *
- * @private
- * @returns {boolean} True if supported.
- */
-
-function storeExists() {
-  if (typeof Storage === 'undefined' || typeof localStorage === 'undefined' || !localStorage) return false;
-  return true;
-}
 /**
  * Checks to see if a JWT token is in proper
  * format. Does not validate it.
@@ -24,7 +13,6 @@ function storeExists() {
  * @public
  * @returns {boolean} True if looks well-formated.
  */
-
 
 export function maybeValid(jwtToken) {
   return typeof jwtToken === 'string' && jwtToken.length > 0 && jwtToken !== "null" && jwtToken !== "expired" ? true : false;

--- a/es/components/util/misc.js
+++ b/es/components/util/misc.js
@@ -23,6 +23,17 @@ export function isServerSide() {
   return false;
 }
 /**
+ * Check to see if localStorage is supported by the browser or environment.
+ *
+ * @private
+ * @returns {boolean} True if supported.
+ */
+
+export function storeExists() {
+  if (typeof Storage === 'undefined' || typeof localStorage === 'undefined' || !localStorage) return false;
+  return true;
+}
+/**
  * `url.parse`, but globally memoized for performance.
  * **ONLY** pass in the _current_ `props.href` here.
  * Use regular `url.parse` for e.g. `pastProps.href`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@hms-dbmi-bgm/shared-portal-components",
-    "version": "0.1.57",
+    "version": "0.1.58",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@hms-dbmi-bgm/shared-portal-components",
-            "version": "0.1.57",
+            "version": "0.1.58",
             "license": "MIT",
             "dependencies": {
                 "@4dn-dcic/react-infinite": "github:4dn-dcic/react-infinite#1.1.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hms-dbmi-bgm/shared-portal-components",
-    "version": "0.1.57",
+    "version": "0.1.58",
     "description": "Shared components used for DBMI/BGM portal(s).",
     "repository": {
         "type": "git",

--- a/src/components/browse/SearchView.js
+++ b/src/components/browse/SearchView.js
@@ -39,7 +39,8 @@ export class SearchView extends React.PureComponent {
         'showClearFiltersButton' : PropTypes.bool,
         'isOwnPage'     : PropTypes.bool,
         'schemas'       : PropTypes.object,
-        'placeholderReplacementFxn' : PropTypes.func // Passed down to AboveSearchTablePanel StaticSection
+        'placeholderReplacementFxn' : PropTypes.func, // Passed down to AboveSearchTablePanel StaticSection
+        'keepSelectionInStorage': PropTypes.bool,
     };
 
     /**
@@ -57,7 +58,8 @@ export class SearchView extends React.PureComponent {
         'currentAction' : null,
         'columnExtensionMap' : basicColumnExtensionMap,
         'separateSingleTermFacets' : true,
-        'isOwnPage'     : true
+        'isOwnPage'     : true,
+        'keepSelectionInStorage': false,
     };
 
     componentDidMount(){
@@ -80,6 +82,7 @@ export class SearchView extends React.PureComponent {
             columns = null,
             columnExtensionMap = basicColumnExtensionMap,
             placeholderReplacementFxn,
+            keepSelectionInStorage,
             //isOwnPage = true,
             windowWidth,
             ...passProps
@@ -121,7 +124,7 @@ export class SearchView extends React.PureComponent {
                 // SelectedItemsController must be above ColumnCombiner because it adjusts
                 // columnExtensionMap, rather than columnDefinitions. This can be easily changed
                 // though if desired.
-                <SelectedItemsController {...{ columnExtensionMap, currentAction }}>
+                <SelectedItemsController {...{ columnExtensionMap, currentAction, keepSelectionInStorage }}>
                     { controllersAndView }
                 </SelectedItemsController>
             );

--- a/src/components/browse/components/SelectedItemsController.js
+++ b/src/components/browse/components/SelectedItemsController.js
@@ -2,7 +2,7 @@ import React, { useMemo, useCallback } from 'react';
 import _ from 'underscore';
 import { Alerts } from './../../ui/Alerts';
 import { itemUtil } from './../../util/object';
-import { isSelectAction } from './../../util/misc';
+import { isSelectAction, storeExists } from './../../util/misc';
 import * as logger from '../../util/logger';
 import { DisplayTitleColumnWrapper, DisplayTitleColumnDefault } from './../../browse/components/table-commons/basicColumnExtensionMap';
 import { getSchemaTypeFromSearchContext, getTitleForType } from './../../util/schema-transforms';
@@ -52,11 +52,24 @@ export class SelectedItemsController extends React.PureComponent {
         this.state = { "selectedItems": new Map() };
     }
 
+    componentDidMount() {
+        const { keepSelectionInStorage } = this.props;
+
+        this.setState(function () {
+            if (keepSelectionInStorage === true && storeExists() && localStorage.getItem("selected_items") !== null) {
+                const foundItems = JSON.parse(localStorage.getItem("selected_items"));
+                return { selectedItems: new Map(foundItems) };
+            }
+        });
+    }
+
     /**
      * This function add/or removes the selected item into an Map in state,
      * if `props.currentAction` is set to "multiselect" or "selection".
      */
     handleSelectItem(result, isMultiSelect) {
+        const { keepSelectionInStorage } = this.props;
+
         this.setState(function({ selectedItems: prevItems }){
             const nextItems = new Map(prevItems);
 
@@ -82,6 +95,10 @@ export class SelectedItemsController extends React.PureComponent {
                     }
                     nextItems.set(resultAtID, result);
                 }
+            }
+
+            if (keepSelectionInStorage && storeExists()){
+                localStorage.setItem("selected_items", JSON.stringify(Array.from(nextItems.entries())));
             }
 
             return { selectedItems: nextItems };

--- a/src/components/browse/components/SelectedItemsController.js
+++ b/src/components/browse/components/SelectedItemsController.js
@@ -1,4 +1,5 @@
 import React, { useMemo, useCallback } from 'react';
+import PropTypes from 'prop-types';
 import _ from 'underscore';
 import { Alerts } from './../../ui/Alerts';
 import { itemUtil } from './../../util/object';
@@ -255,21 +256,39 @@ export const SelectStickyFooter = React.memo(function SelectStickyFooter(props){
 });
 
 export const BackNavigationStickyFooter = React.memo(function BackNavigationStickyFooter(props) {
+    const { text, tooltip, navigateToInitialPage } = props;
+
+    const onBackButtonClick = useCallback(function () {
+        if (window.history.length === 0) {
+            return;
+        }
+        history.go(navigateToInitialPage === true ? -(window.history.length - 1) : -1);
+    });
+
     return (
         <StickyFooter>
-            <div className="row selection-controls-footer">
-                <div className="col mb-05 mt-05">
-                    &nbsp;
-                </div>
+            <div className="row selection-controls-footer pull-right">
                 <div className="col-12 col-md-auto">
-                    <button type="button" className="btn btn-outline-warning ml-1" onClick={() => history.go(-(window.history.length - 1))} data-tip="Go to selection page">
-                        <i className="icon icon-fw fas icon-arrow-left"></i>&nbsp; Return to Selection List
+                    <button type="button" className="btn btn-outline-warning ml-1" onClick={onBackButtonClick} data-tip={tooltip || ''}>
+                        <i className="icon icon-fw fas icon-arrow-left"></i>&nbsp; {text || ''}
                     </button>
                 </div>
             </div>
         </StickyFooter>
     );
 });
+
+BackNavigationStickyFooter.propTypes = {
+    'text': PropTypes.string,
+    'tooltip': PropTypes.string,
+    'navigateToInitialPage': PropTypes.bool
+};
+
+BackNavigationStickyFooter.defaultProps = {
+    'text': 'Return to Selection List',
+    'tooltip': 'Go to selection page',
+    'navigateToInitialPage': true
+};
 
 /**
  * General purpose sticky footer component

--- a/src/components/browse/components/SelectedItemsController.js
+++ b/src/components/browse/components/SelectedItemsController.js
@@ -237,6 +237,23 @@ export const SelectStickyFooter = React.memo(function SelectStickyFooter(props){
     );
 });
 
+export const BackNavigationStickyFooter = React.memo(function BackNavigationStickyFooter(props) {
+    return (
+        <StickyFooter>
+            <div className="row selection-controls-footer">
+                <div className="col mb-05 mt-05">
+                    &nbsp;
+                </div>
+                <div className="col-12 col-md-auto">
+                    <button type="button" className="btn btn-outline-warning ml-1" onClick={() => history.go(-(window.history.length - 1))} data-tip="Go to selection page">
+                        <i className="icon icon-fw fas icon-arrow-left"></i>&nbsp; Return to Selection List
+                    </button>
+                </div>
+            </div>
+        </StickyFooter>
+    );
+});
+
 /**
  * General purpose sticky footer component
  * TODO: Component can be moved to a separate file.

--- a/src/components/forms/components/LinkToSelector.js
+++ b/src/components/forms/components/LinkToSelector.js
@@ -4,6 +4,7 @@ import _ from 'underscore';
 import url from 'url';
 import { patchedConsoleInstance as console } from './../../util/patched-console';
 import { itemUtil } from './../../util/object';
+import { storeExists } from '../../util/misc';
 
 /**
  * Global variable which holds reference to child window, if any.
@@ -86,6 +87,11 @@ export class LinkToSelector extends React.PureComponent {
 
     componentDidMount(){
         this.manageChildWindow({ 'isSelecting' : false }, this.props);
+
+        //clear storage
+        if (storeExists()) {
+            localStorage.removeItem("selected_items");
+        }
     }
 
     componentDidUpdate(pastProps){
@@ -237,6 +243,11 @@ export class LinkToSelector extends React.PureComponent {
         if (!this || !this.windowObjectReference) {
             console.warn('Child window no longer available to unbind event handlers. Fine if closed.');
             return;
+        }
+
+        //clear storage
+        if (storeExists()) {
+            localStorage.removeItem("selected_items");
         }
     }
 

--- a/src/components/util/json-web-token.js
+++ b/src/components/util/json-web-token.js
@@ -1,7 +1,7 @@
 
 import _ from 'underscore';
 import memoize from 'memoize-one';
-import { isServerSide } from './misc';
+import { isServerSide, storeExists } from './misc';
 import { patchedConsoleInstance as console } from './patched-console';
 import { getNestedProperty } from './object';
 
@@ -9,18 +9,6 @@ import { getNestedProperty } from './object';
 /** Used for serverside */
 const dummyStorage = {};
 
-
-
-/**
- * Check to see if localStorage is supported by the browser or environment.
- *
- * @private
- * @returns {boolean} True if supported.
- */
-function storeExists(){
-    if (typeof(Storage) === 'undefined' || typeof localStorage === 'undefined' || !localStorage) return false;
-    return true;
-}
 
 /**
  * Checks to see if a JWT token is in proper

--- a/src/components/util/misc.js
+++ b/src/components/util/misc.js
@@ -22,6 +22,17 @@ export function isServerSide(){
 }
 
 /**
+ * Check to see if localStorage is supported by the browser or environment.
+ *
+ * @private
+ * @returns {boolean} True if supported.
+ */
+export function storeExists(){
+    if (typeof(Storage) === 'undefined' || typeof localStorage === 'undefined' || !localStorage) return false;
+    return true;
+}
+
+/**
  * `url.parse`, but globally memoized for performance.
  * **ONLY** pass in the _current_ `props.href` here.
  * Use regular `url.parse` for e.g. `pastProps.href`.


### PR DESCRIPTION
**Trello:** https://trello.com/c/dJCyoEJ0

Draft release: https://github.com/4dn-dcic/shared-portal-components/releases/tag/0.1.58b3

**Issues:**
Child popup windows are used for single or multiple item(s) selections in the data portal. One good example of selection would be adding files to the `HiGlassViewConfig`.

As is explained in detail in the Trello card, the initial page (SearchView) in the child window has a footer showing the count of the selected items along with Apply/Cancel buttons; but the footer disappears if you navigate to other pages. Since the child window lacks a top bar, you cannot quickly turn back to the initial page. (the only way is keyboard shortcuts or context menu)

Another issue is even if you manage to return to the selection page, you'll see that all previous selections you made are lost.

The desired behavior would be to navigate easily without losing previous selections.

**Solution:**
Since both 4DN and CGAP depend on SPC, the following additions are optional; they will only affect the current look and feel if you pass the proper prop values. (Please take a look at the [FF PR](https://github.com/4dn-dcic/fourfront/pull/1766) for usage in 4DN) 

1. `<BackNavigationStickyFooter />` component (new)

<img width="1242" alt="Screen Shot 2023-01-11 at 00 18 42" src="https://user-images.githubusercontent.com/49978017/211664645-39fe4128-235e-40a1-9266-36a7899be9ac.png">

``` js
BackNavigationStickyFooter.propTypes = {
    'text': PropTypes.string,  // the text for the back button. Default value is 'Return to Selection List'.
    'tooltip': PropTypes.string, // the tooltip for the the back button. Default value is 'Go to selection page'.
    'navigateToInitialPage': PropTypes.bool //true: always returns to initial page, false: return to previous page. Default is true. 
};
```
2. New `keepSelectionInStorage` prop for `<SelectedItemsController />` component

`SelectedItemsController` is already in use for any selections in SearchView. The new `keepSelectionInStorage` prop makes storing selected items temporarily possible in localStorage (if available). Even if you navigate back-and-forths, selected items get restored when back to the selection page. The default value is false. In any case, `localStorage` get cleared right after child window is closed.

https://i.gyazo.com/7f2e1b0f51b9adab3e85820ebf221545.gif