### PR TITLE
Smaht UI updates

### DIFF
--- a/es/components/forms/components/DragAndDropUpload.js
+++ b/es/components/forms/components/DragAndDropUpload.js
@@ -68,40 +68,41 @@ export var DragAndDropFileUploadController = /*#__PURE__*/function (_React$Compo
         var fileLimit = multiselect ? files.length : 1;
         // Populate an array with all of the new files
         var _loop = function _loop() {
-            var attachment = {};
-            var file = files[i];
+          var attachment = {};
+          var file = files[i];
 
-            // Check that file type is in schema (TODO: Is this too strict? MIME-types can get complicated...)
-            var acceptableFileTypes = fileSchema.properties.attachment.properties.type["enum"];
-            if (_.indexOf(acceptableFileTypes, file.type) === -1) {
-              var listOfTypes = acceptableFileTypes.toString();
-              alert("FILE NOT ADDED: File \"".concat(file.name, "\" is not of the correct file type for this field.\n\nMust be of type: ").concat(listOfTypes, "."));
-              return 1; // continue
-            }
-            attachment.type = file.type;
+          // Check that file type is in schema (TODO: Is this too strict? MIME-types can get complicated...)
+          var acceptableFileTypes = fileSchema.properties.attachment.properties.type["enum"];
+          if (_.indexOf(acceptableFileTypes, file.type) === -1) {
+            var listOfTypes = acceptableFileTypes.toString();
+            alert("FILE NOT ADDED: File \"".concat(file.name, "\" is not of the correct file type for this field.\n\nMust be of type: ").concat(listOfTypes, "."));
+            return "continue";
+          }
+          attachment.type = file.type;
 
-            // TODO: Figure out how best to check/limit file size pre-attachment...
-            if (file.size) {
-              attachment.size = file.size;
+          // TODO: Figure out how best to check/limit file size pre-attachment...
+          if (file.size) {
+            attachment.size = file.size;
+          }
+          if (file.name) {
+            attachment.download = file.name;
+          }
+          fileReader = new window.FileReader();
+          fileReader.readAsDataURL(file);
+          fileReader.onloadend = function (e) {
+            if (e.target.result) {
+              attachment.href = e.target.result;
+            } else {
+              alert('ERROR: There was a problem reading the given file. Please try again.');
+              return;
             }
-            if (file.name) {
-              attachment.download = file.name;
-            }
-            fileReader = new window.FileReader();
-            fileReader.readAsDataURL(file);
-            fileReader.onloadend = function (e) {
-              if (e.target.result) {
-                attachment.href = e.target.result;
-              } else {
-                alert('ERROR: There was a problem reading the given file. Please try again.');
-                return;
-              }
-            }.bind(_this2);
-            fileArr.push(attachment);
-          },
-          fileReader;
+          }.bind(_this2);
+          fileArr.push(attachment);
+        };
         for (var i = 0; i < fileLimit; i++) {
-          if (_loop()) continue;
+          var fileReader;
+          var _ret = _loop();
+          if (_ret === "continue") continue;
         }
 
         // Concat with previous files

--- a/es/components/static-pages/StaticPageBase.js
+++ b/es/components/static-pages/StaticPageBase.js
@@ -23,7 +23,7 @@ import { layout, console } from './../util';
  * Converts links to other files into links to sections from a React element and its children (recursively).
  *
  * @param {*} elem                                      A high-level React element representation of some content which might have relative links.
- * @param {{ content: { name: string }}} context        Backend-provided data.
+ * @param {{ content: { name: string }}} context        Backend-provided data. (Note: "name" has been renamed to "identifier" on SMaHT; seems OK now, but may need double check for future edits)
  * @param {number} [depth=0]                            Current depth.
  * @returns {JSX.Element} Copy of original 'elem' param with corrected links.
  */
@@ -261,7 +261,7 @@ export var StaticPageBase = /*#__PURE__*/function (_React$PureComponent2) {
         return null;
       }
       return _.map(parsedContent.content, function (section) {
-        return renderMethod(section.id || section.name, section, props);
+        return renderMethod(section.id || section.name || section.identifier, section, props);
       });
     }
   }]);

--- a/es/components/static-pages/StaticPageBase.js
+++ b/es/components/static-pages/StaticPageBase.js
@@ -219,7 +219,8 @@ export var StaticPageBase = /*#__PURE__*/function (_React$PureComponent2) {
       var _this$props2 = this.props,
         context = _this$props2.context,
         entryRenderFxn = _this$props2.entryRenderFxn,
-        contentParseFxn = _this$props2.contentParseFxn;
+        contentParseFxn = _this$props2.contentParseFxn,
+        CustomWrapper = _this$props2.CustomWrapper;
       var parsedContent = null;
       try {
         parsedContent = contentParseFxn(context);
@@ -237,7 +238,15 @@ export var StaticPageBase = /*#__PURE__*/function (_React$PureComponent2) {
         });
       }
       var tableOfContents = parsedContent && parsedContent['table-of-contents'] && parsedContent['table-of-contents'].enabled ? parsedContent['table-of-contents'] : false;
-      return /*#__PURE__*/React.createElement(Wrapper, _extends({}, _.pick(this.props, 'navigate', 'windowWidth', 'windowHeight', 'registerWindowOnScrollHandler', 'href', 'fixedPositionBreakpoint'), {
+      if (!CustomWrapper) {
+        return /*#__PURE__*/React.createElement(Wrapper, _extends({}, _.pick(this.props, 'navigate', 'windowWidth', 'windowHeight', 'registerWindowOnScrollHandler', 'href', 'fixedPositionBreakpoint'), {
+          key: "page-wrapper",
+          title: parsedContent.title,
+          tableOfContents: tableOfContents,
+          context: parsedContent
+        }), StaticPageBase.renderSections(entryRenderFxn, parsedContent, this.props));
+      }
+      return /*#__PURE__*/React.createElement(CustomWrapper, _extends({}, _.pick(this.props, 'navigate', 'windowWidth', 'windowHeight', 'registerWindowOnScrollHandler', 'href', 'fixedPositionBreakpoint'), {
         key: "page-wrapper",
         title: parsedContent.title,
         tableOfContents: tableOfContents,
@@ -300,5 +309,6 @@ _defineProperty(StaticPageBase, "propTypes", {
   }).isRequired,
   'entryRenderFxn': PropTypes.func.isRequired,
   'contentParseFxn': PropTypes.func.isRequired,
-  'href': PropTypes.string
+  'href': PropTypes.string,
+  'CustomWrapper': PropTypes.element
 });

--- a/es/components/static-pages/TableOfContents.js
+++ b/es/components/static-pages/TableOfContents.js
@@ -7,7 +7,6 @@ import _inherits from "@babel/runtime/helpers/inherits";
 import _possibleConstructorReturn from "@babel/runtime/helpers/possibleConstructorReturn";
 import _getPrototypeOf from "@babel/runtime/helpers/getPrototypeOf";
 import _defineProperty from "@babel/runtime/helpers/defineProperty";
-var _class2;
 function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); enumerableOnly && (symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; })), keys.push.apply(keys, symbols); } return keys; }
 function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = null != arguments[i] ? arguments[i] : {}; i % 2 ? ownKeys(Object(source), !0).forEach(function (key) { _defineProperty(target, key, source[key]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)) : ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } return target; }
 function _createSuper(Derived) { var hasNativeReflectConstruct = _isNativeReflectConstruct(); return function () { var Super = _getPrototypeOf(Derived), result; if (hasNativeReflectConstruct) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
@@ -359,12 +358,11 @@ var TableEntryChildren = /*#__PURE__*/function (_React$Component2) {
   }]);
   return TableEntryChildren;
 }(React.Component);
-_class2 = TableEntryChildren;
 _defineProperty(TableEntryChildren, "getHeadersFromContent", memoize(function (jsxContent, maxHeaderDepth, currentDepth) {
   if (Array.isArray(jsxContent)) {
     // As of html-react-parser v1.2.8, we may get back array of content, including "\n" or similar.
     return jsxContent.reduce(function (m, c) {
-      var res = _class2.getHeadersFromContent(c, maxHeaderDepth, currentDepth);
+      var res = TableEntryChildren.getHeadersFromContent(c, maxHeaderDepth, currentDepth);
       m.childDepth = Math.max(res.childDepth, m.childDepth);
       m.childrenForDepth = m.childrenForDepth.concat(res.childrenForDepth);
       return m;
@@ -559,8 +557,9 @@ export var TableOfContents = /*#__PURE__*/function (_React$Component3) {
       var renderedSections = _.sortBy(context.content, function (s) {
         return s.order || 99;
       }).map(function (section, i, all) {
-        var name = section.name;
-        var link = TableOfContents.elementIDFromSectionName(name);
+        var name = section.name,
+          identifier = section.identifier;
+        var link = TableOfContents.elementIDFromSectionName(name || identifier);
         if (previousEncounteredSection) {
           previousEncounteredSection.nextHeader = link;
         }
@@ -822,7 +821,7 @@ export var NextPreviousPageSection = /*#__PURE__*/React.memo(function (props) {
   }), " ", previousTitle), /*#__PURE__*/React.createElement("h6", {
     className: "text-500 mt-0"
   }, /*#__PURE__*/React.createElement("a", {
-    href: previous['@id'] || '/' + previous.name
+    href: previous['@id'] || '/' + (previous.name || previous.identifier)
   }, previous.display_title))) : null, next ? /*#__PURE__*/React.createElement("div", {
     className: "next-section col-" + colSize
   }, /*#__PURE__*/React.createElement("h6", {
@@ -832,7 +831,7 @@ export var NextPreviousPageSection = /*#__PURE__*/React.memo(function (props) {
   })), /*#__PURE__*/React.createElement("h6", {
     className: "text-500 mt-0"
   }, /*#__PURE__*/React.createElement("a", {
-    href: next['@id'] || '/' + next.name
+    href: next['@id'] || '/' + (next.name || previous.identifier)
   }, next.display_title))) : null));
 });
 NextPreviousPageSection.defaultProps = {

--- a/es/components/util/object.js
+++ b/es/components/util/object.js
@@ -52,7 +52,7 @@ export function linkFromItem(item) {
   var elementProps = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : {};
   var suppressErrors = arguments.length > 4 && arguments[4] !== undefined ? arguments[4] : true;
   var href = atIdFromObject(item),
-    title = item && _typeof(item) === 'object' && (propertyForTitle && item[propertyForTitle] || item.display_title || item.title || item.name || href);
+    title = item && _typeof(item) === 'object' && (propertyForTitle && item[propertyForTitle] || item.display_title || item.title || item.name || item.identifier || href);
   if (!href || !title) {
     if (item && _typeof(item) === 'object' && typeof item.error === 'string') {
       return /*#__PURE__*/React.createElement("em", null, item.error);
@@ -751,7 +751,7 @@ export var itemUtil = {
    * @returns {string} The title.
    */
   getTitleStringFromContext: function getTitleStringFromContext(context) {
-    return context.display_title || context.title || context.name || context.download || context.accession || context.uuid || (typeof context['@id'] === 'string' ? context['@id'] : null //: 'No title found'
+    return context.display_title || context.title || context.name || context.identifier || context.download || context.accession || context.uuid || (typeof context['@id'] === 'string' ? context['@id'] : null //: 'No title found'
     );
   },
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@hms-dbmi-bgm/shared-portal-components",
-    "version": "0.1.71",
+    "version": "0.1.73",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hms-dbmi-bgm/shared-portal-components",
-    "version": "0.1.71",
+    "version": "0.1.73",
     "description": "Shared components used for DBMI/BGM portal(s).",
     "repository": {
         "type": "git",

--- a/src/components/static-pages/StaticPageBase.js
+++ b/src/components/static-pages/StaticPageBase.js
@@ -248,11 +248,12 @@ export class StaticPageBase extends React.PureComponent {
         }).isRequired,
         'entryRenderFxn' : PropTypes.func.isRequired,
         'contentParseFxn' : PropTypes.func.isRequired,
-        'href' : PropTypes.string
+        'href' : PropTypes.string,
+        'CustomWrapper': PropTypes.element
     };
 
     render(){
-        const { context, entryRenderFxn, contentParseFxn } = this.props;
+        const { context, entryRenderFxn, contentParseFxn, CustomWrapper } = this.props;
         let parsedContent = null;
         try {
             parsedContent = contentParseFxn(context);
@@ -270,13 +271,24 @@ export class StaticPageBase extends React.PureComponent {
             }] };
         }
         const tableOfContents = (parsedContent && parsedContent['table-of-contents'] && parsedContent['table-of-contents'].enabled) ? parsedContent['table-of-contents'] : false;
+
+        if (!CustomWrapper) {
+            return (
+                <Wrapper
+                    {..._.pick(this.props, 'navigate', 'windowWidth', 'windowHeight', 'registerWindowOnScrollHandler', 'href', 'fixedPositionBreakpoint')}
+                    key="page-wrapper" title={parsedContent.title}
+                    tableOfContents={tableOfContents} context={parsedContent}>
+                    { StaticPageBase.renderSections(entryRenderFxn, parsedContent, this.props) }
+                </Wrapper>
+            );
+        }
         return (
-            <Wrapper
+            <CustomWrapper
                 {..._.pick(this.props, 'navigate', 'windowWidth', 'windowHeight', 'registerWindowOnScrollHandler', 'href', 'fixedPositionBreakpoint')}
                 key="page-wrapper" title={parsedContent.title}
                 tableOfContents={tableOfContents} context={parsedContent}>
                 { StaticPageBase.renderSections(entryRenderFxn, parsedContent, this.props) }
-            </Wrapper>
+            </CustomWrapper>
         );
     }
 }

--- a/src/components/static-pages/StaticPageBase.js
+++ b/src/components/static-pages/StaticPageBase.js
@@ -13,7 +13,7 @@ import { layout, console } from './../util';
  * Converts links to other files into links to sections from a React element and its children (recursively).
  *
  * @param {*} elem                                      A high-level React element representation of some content which might have relative links.
- * @param {{ content: { name: string }}} context        Backend-provided data.
+ * @param {{ content: { name: string }}} context        Backend-provided data. (Note: "name" has been renamed to "identifier" on SMaHT; seems OK now, but may need double check for future edits)
  * @param {number} [depth=0]                            Current depth.
  * @returns {JSX.Element} Copy of original 'elem' param with corrected links.
  */
@@ -202,7 +202,7 @@ export class StaticPageBase extends React.PureComponent {
         return _.map(
             parsedContent.content,
             function(section){
-                return renderMethod(section.id || section.name, section, props);
+                return renderMethod(section.id || section.name || section.identifier, section, props);
             }
         );
     }

--- a/src/components/static-pages/TableOfContents.js
+++ b/src/components/static-pages/TableOfContents.js
@@ -578,8 +578,8 @@ export class TableOfContents extends React.Component {
         const excludeSectionsFromTOC = context.content.filter(function(section){ return section.title || section['toc-title']; }).length < 2;
         const renderedSections = _.sortBy(context.content, function(s){ return s.order || 99; })
             .map(function(section, i, all){
-                const { name } = section;
-                const link = TableOfContents.elementIDFromSectionName(name);
+                const { name, identifier } = section;
+                const link = TableOfContents.elementIDFromSectionName(name || identifier);
                 if (previousEncounteredSection){
                     previousEncounteredSection.nextHeader = link;
                 }
@@ -683,13 +683,13 @@ export const NextPreviousPageSection = React.memo(function NextPreviousPageSecti
                 { previous ?
                     <div className={"previous-section text-right col-" + colSize}>
                         <h6 className="text-400 mb-02 mt-12"><i className="icon icon-fw fas icon-angle-left"/> { previousTitle }</h6>
-                        <h6 className="text-500 mt-0"><a href={previous['@id'] || '/' + previous.name}>{ previous.display_title }</a></h6>
+                        <h6 className="text-500 mt-0"><a href={previous['@id'] || '/' + (previous.name || previous.identifier)}>{ previous.display_title }</a></h6>
                     </div>
                     : null }
                 { next ?
                     <div className={"next-section col-" + colSize}>
                         <h6 className="text-400 mb-02 mt-12">{ nextTitle } <i className="icon fas icon-fw icon-angle-right"/></h6>
-                        <h6 className="text-500 mt-0"><a href={next['@id'] || '/' + next.name}>{ next.display_title }</a></h6>
+                        <h6 className="text-500 mt-0"><a href={next['@id'] || '/' + (next.name || previous.identifier)}>{ next.display_title }</a></h6>
                     </div>
                     : null }
             </div>

--- a/src/components/util/object.js
+++ b/src/components/util/object.js
@@ -36,7 +36,7 @@ export function atIdFromObject(o){
 
 export function linkFromItem(item, addDescriptionTip = true, propertyForTitle = 'display_title', elementProps = {}, suppressErrors = true){
     var href = atIdFromObject(item),
-        title =  item && typeof item === 'object' && ((propertyForTitle && item[propertyForTitle]) || item.display_title || item.title || item.name || href);
+        title =  item && typeof item === 'object' && ((propertyForTitle && item[propertyForTitle]) || item.display_title || item.title || item.name || item.identifier || href);
 
     if (!href || !title){
         if (item && typeof item === 'object' && typeof item.error === 'string'){
@@ -742,6 +742,7 @@ export const itemUtil = {
             context.display_title   ||
             context.title           ||
             context.name            ||
+            context.identifier      ||
             context.download        ||
             context.accession       ||
             context.uuid            ||


### PR DESCRIPTION
### Changelog
- Add `CustomWrapper` prop to StaticPageBase
- Fix issue with rendering static pages and TOC caused by rename of `static_section.name` and `page.name` to `identifier` on SMaHT
- Additional support for `identifier` in `object.js` (probably not 100% necessary due to presence of `title`, but good to have)