### PR TITLE
Add hide_from_view to Filter Facets

### DIFF
--- a/es/components/browse/EmbeddedSearchView.js
+++ b/es/components/browse/EmbeddedSearchView.js
@@ -52,9 +52,13 @@ export var EmbeddedSearchView = /*#__PURE__*/function (_React$PureComponent) {
     value: function filterFacetFxn(facet) {
       var _this$props$hideFacet = this.props.hideFacets,
         hideFacets = _this$props$hideFacet === void 0 ? null : _this$props$hideFacet;
+      var _ref = facet || {},
+        field = _ref.field,
+        _ref$hide_from_view = _ref.hide_from_view,
+        hide_from_view = _ref$hide_from_view === void 0 ? false : _ref$hide_from_view;
       if (!hideFacets) return true;
       var idMap = this.memoized.listToObj(hideFacets);
-      if (idMap[facet.field]) return false;
+      if (idMap[field] || hide_from_view) return false;
       return true;
     }
 

--- a/es/components/browse/SearchView.js
+++ b/es/components/browse/SearchView.js
@@ -53,9 +53,13 @@ export var SearchView = /*#__PURE__*/function (_React$PureComponent) {
     value: function filterFacetFxn(facet) {
       var _this$props$hideFacet = this.props.hideFacets,
         hideFacets = _this$props$hideFacet === void 0 ? null : _this$props$hideFacet;
+      var _ref = facet || {},
+        field = _ref.field,
+        _ref$hide_from_view = _ref.hide_from_view,
+        hide_from_view = _ref$hide_from_view === void 0 ? false : _ref$hide_from_view;
       if (!hideFacets) return true;
       var idMap = this.memoized.listToObj(hideFacets);
-      if (idMap[facet.field]) return false;
+      if (idMap[field] || hide_from_view) return false;
       return true;
     }
 

--- a/es/components/browse/components/ControlsAndResults.js
+++ b/es/components/browse/components/ControlsAndResults.js
@@ -2,14 +2,25 @@ import _extends from "@babel/runtime/helpers/extends";
 import _defineProperty from "@babel/runtime/helpers/defineProperty";
 import _classCallCheck from "@babel/runtime/helpers/classCallCheck";
 import _createClass from "@babel/runtime/helpers/createClass";
-import _assertThisInitialized from "@babel/runtime/helpers/assertThisInitialized";
-import _inherits from "@babel/runtime/helpers/inherits";
 import _possibleConstructorReturn from "@babel/runtime/helpers/possibleConstructorReturn";
 import _getPrototypeOf from "@babel/runtime/helpers/getPrototypeOf";
+import _assertThisInitialized from "@babel/runtime/helpers/assertThisInitialized";
+import _inherits from "@babel/runtime/helpers/inherits";
 function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); enumerableOnly && (symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; })), keys.push.apply(keys, symbols); } return keys; }
 function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = null != arguments[i] ? arguments[i] : {}; i % 2 ? ownKeys(Object(source), !0).forEach(function (key) { _defineProperty(target, key, source[key]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)) : ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } return target; }
-function _createSuper(Derived) { var hasNativeReflectConstruct = _isNativeReflectConstruct(); return function () { var Super = _getPrototypeOf(Derived), result; if (hasNativeReflectConstruct) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
+function _callSuper(_this, derived, args) {
+  derived = _getPrototypeOf(derived);
+  return _possibleConstructorReturn(_this, function () {
+    if (typeof Reflect === "undefined" || !Reflect.construct) return false;
+    if (Reflect.construct.sham) return false;
+    if (typeof Proxy === "function") return true;
+    try {
+      return !Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {}));
+    } catch (e) {
+      return false;
+    }
+  }() ? Reflect.construct(derived, args || [], _getPrototypeOf(_this).constructor) : derived.apply(_this, args));
+}
 import React from 'react';
 import memoize from 'memoize-one';
 import { isSelectAction } from './../../util/misc';
@@ -22,11 +33,10 @@ import { SearchResultDetailPane } from './SearchResultDetailPane';
 import { SelectStickyFooter } from './SelectedItemsController';
 export var ControlsAndResults = /*#__PURE__*/function (_React$PureComponent) {
   _inherits(ControlsAndResults, _React$PureComponent);
-  var _super = _createSuper(ControlsAndResults);
   function ControlsAndResults(props) {
     var _this;
     _classCallCheck(this, ControlsAndResults);
-    _this = _super.call(this, props);
+    _this = _callSuper(this, ControlsAndResults, [props]);
     _this.onClearFiltersClick = _this.onClearFiltersClick.bind(_assertThisInitialized(_this));
     _this.renderSearchDetailPane = _this.renderSearchDetailPane.bind(_assertThisInitialized(_this));
     _this.memoized = {
@@ -267,7 +277,7 @@ function DefaultFacetListComponent(props) {
     return /*#__PURE__*/React.createElement("div", {
       className: "facets-container with-header-bg"
     }, /*#__PURE__*/React.createElement(FacetListHeader, {
-      compound: true
+      hideToggle: true
     }), /*#__PURE__*/React.createElement("div", {
       className: "p-4"
     }, /*#__PURE__*/React.createElement("h4", {

--- a/es/components/browse/components/FacetList/index.js
+++ b/es/components/browse/components/FacetList/index.js
@@ -4,15 +4,26 @@ import _toConsumableArray from "@babel/runtime/helpers/toConsumableArray";
 import _toArray from "@babel/runtime/helpers/toArray";
 import _classCallCheck from "@babel/runtime/helpers/classCallCheck";
 import _createClass from "@babel/runtime/helpers/createClass";
-import _assertThisInitialized from "@babel/runtime/helpers/assertThisInitialized";
-import _inherits from "@babel/runtime/helpers/inherits";
 import _possibleConstructorReturn from "@babel/runtime/helpers/possibleConstructorReturn";
 import _getPrototypeOf from "@babel/runtime/helpers/getPrototypeOf";
+import _assertThisInitialized from "@babel/runtime/helpers/assertThisInitialized";
+import _inherits from "@babel/runtime/helpers/inherits";
 import _defineProperty from "@babel/runtime/helpers/defineProperty";
 function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); enumerableOnly && (symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; })), keys.push.apply(keys, symbols); } return keys; }
 function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = null != arguments[i] ? arguments[i] : {}; i % 2 ? ownKeys(Object(source), !0).forEach(function (key) { _defineProperty(target, key, source[key]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)) : ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } return target; }
-function _createSuper(Derived) { var hasNativeReflectConstruct = _isNativeReflectConstruct(); return function () { var Super = _getPrototypeOf(Derived), result; if (hasNativeReflectConstruct) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
+function _callSuper(_this, derived, args) {
+  derived = _getPrototypeOf(derived);
+  return _possibleConstructorReturn(_this, function () {
+    if (typeof Reflect === "undefined" || !Reflect.construct) return false;
+    if (Reflect.construct.sham) return false;
+    if (typeof Proxy === "function") return true;
+    try {
+      return !Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {}));
+    } catch (e) {
+      return false;
+    }
+  }() ? Reflect.construct(derived, args || [], _getPrototypeOf(_this).constructor) : derived.apply(_this, args));
+}
 import React from 'react';
 import memoize from 'memoize-one';
 import PropTypes from 'prop-types';
@@ -123,11 +134,10 @@ export function generateNextHref(currentHref, contextFilters, facet, term) {
 }
 export var FacetList = /*#__PURE__*/function (_React$PureComponent) {
   _inherits(FacetList, _React$PureComponent);
-  var _super = _createSuper(FacetList);
   function FacetList(props) {
     var _this;
     _classCallCheck(this, FacetList);
-    _this = _super.call(this, props);
+    _this = _callSuper(this, FacetList, [props]);
     console.log("FacetList props,", props);
     _this.onFilterExtended = _this.onFilterExtended.bind(_assertThisInitialized(_this));
     _this.onFilterMultipleExtended = _this.onFilterMultipleExtended.bind(_assertThisInitialized(_this));
@@ -492,7 +502,9 @@ export var FacetList = /*#__PURE__*/function (_React$PureComponent) {
         _this$props6$maxBodyH = _this$props6.maxBodyHeight,
         maxHeight = _this$props6$maxBodyH === void 0 ? null : _this$props6$maxBodyH,
         _this$props6$isContex = _this$props6.isContextLoading,
-        isContextLoading = _this$props6$isContex === void 0 ? false : _this$props6$isContex;
+        isContextLoading = _this$props6$isContex === void 0 ? false : _this$props6$isContex,
+        _this$props6$hideHead = _this$props6.hideHeaderToggle,
+        hideHeaderToggle = _this$props6$hideHead === void 0 ? false : _this$props6$hideHead;
       var _this$state3 = this.state,
         openFacets = _this$state3.openFacets,
         openPopover = _this$state3.openPopover,
@@ -526,6 +538,7 @@ export var FacetList = /*#__PURE__*/function (_React$PureComponent) {
         onClearFilters: onClearFilters,
         showClearFiltersButton: showClearFiltersButton,
         including: including,
+        hideToggle: hideHeaderToggle,
         onToggleIncluding: this.onToggleIncluding,
         onCollapseFacets: this.handleCollapseAllFacets
       }), /*#__PURE__*/React.createElement("div", bodyProps, selectableFacetElements, staticFacetElements.length > 0 ? /*#__PURE__*/React.createElement("div", {
@@ -851,7 +864,10 @@ _defineProperty(FacetList, "propTypes", {
   'maxBodyHeight': PropTypes.number,
   'useRadioIcon': PropTypes.bool.isRequired,
   // Show either checkbox (False) or radio icon (True) for term component - it is only for styling, not intended to implement single selection (radio) or multiple selection (checkbox)
-  'persistSelectedTerms': PropTypes.bool.isRequired // if True selected/omitted terms are escalated to top, otherwise each term is rendered in regular order. Moreover, inline search options are not displayed if it is False.
+  'persistSelectedTerms': PropTypes.bool.isRequired,
+  // if True selected/omitted terms are escalated to top, otherwise each term is rendered in regular order. Moreover, inline search options are not displayed if it is False.
+  'isContextLoading': PropTypes.bool,
+  'hideHeaderToggle': PropTypes.bool.isRequired // if True hide Include/Exclude Properties toggle on Facet List header
 });
 _defineProperty(FacetList, "defaultProps", {
   /**
@@ -902,14 +918,15 @@ _defineProperty(FacetList, "defaultProps", {
     return term;
   },
   'useRadioIcon': false,
-  'persistSelectedTerms': true
+  'persistSelectedTerms': true,
+  'hideHeaderToggle': false
 });
 export var FacetListHeader = /*#__PURE__*/React.memo(function (props) {
   var _props$including = props.including,
     including = _props$including === void 0 ? true : _props$including,
     onToggleIncluding = props.onToggleIncluding,
-    _props$compound = props.compound,
-    compound = _props$compound === void 0 ? false : _props$compound,
+    _props$hideToggle = props.hideToggle,
+    hideToggle = _props$hideToggle === void 0 ? false : _props$hideToggle,
     _props$title = props.title,
     title = _props$title === void 0 ? "Properties" : _props$title,
     _props$openFacets = props.openFacets,
@@ -925,7 +942,7 @@ export var FacetListHeader = /*#__PURE__*/React.memo(function (props) {
     "data-excluding": !including
   }, /*#__PURE__*/React.createElement("div", {
     className: "col facets-title-column text-truncate"
-  }, !compound && /*#__PURE__*/React.createElement(React.Fragment, null, /*#__PURE__*/React.createElement(IconToggle, {
+  }, !hideToggle && /*#__PURE__*/React.createElement(React.Fragment, null, /*#__PURE__*/React.createElement(IconToggle, {
     activeIdx: including ? 0 : 1,
     options: [{
       title: /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement(FontAwesomeV6Icons, {
@@ -942,11 +959,11 @@ export var FacetListHeader = /*#__PURE__*/React.memo(function (props) {
     }]
   }), /*#__PURE__*/React.createElement("h4", {
     className: "facets-title"
-  }, "".concat(including ? "Included" : "Excluded", " ").concat(title))), compound && /*#__PURE__*/React.createElement(React.Fragment, null, /*#__PURE__*/React.createElement("i", {
+  }, "".concat(including ? "Included" : "Excluded", " ").concat(title))), hideToggle && /*#__PURE__*/React.createElement(React.Fragment, null, /*#__PURE__*/React.createElement("i", {
     className: "icon icon-fw icon-filter fas"
   }), "\xA0", /*#__PURE__*/React.createElement("h4", {
     className: "facets-title"
-  }, title)))), !compound && /*#__PURE__*/React.createElement("div", {
+  }, title)))), !hideToggle && /*#__PURE__*/React.createElement("div", {
     className: "row facets-controls"
   }, /*#__PURE__*/React.createElement("div", {
     className: "col"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@hms-dbmi-bgm/shared-portal-components",
-    "version": "0.1.76",
+    "version": "0.1.78",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@hms-dbmi-bgm/shared-portal-components",
-            "version": "0.1.76",
+            "version": "0.1.78",
             "license": "MIT",
             "dependencies": {
                 "@4dn-dcic/react-infinite": "github:4dn-dcic/react-infinite#1.1.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hms-dbmi-bgm/shared-portal-components",
-    "version": "0.1.76",
+    "version": "0.1.78",
     "description": "Shared components used for DBMI/BGM portal(s).",
     "repository": {
         "type": "git",

--- a/src/components/browse/EmbeddedSearchView.js
+++ b/src/components/browse/EmbeddedSearchView.js
@@ -95,9 +95,10 @@ export class EmbeddedSearchView extends React.PureComponent {
 
     filterFacetFxn(facet){
         const { hideFacets = null } = this.props;
+        const { field, hide_from_view = false } = facet || {};
         if (!hideFacets) return true;
         const idMap = this.memoized.listToObj(hideFacets);
-        if (idMap[facet.field]) return false;
+        if (idMap[field] || hide_from_view) return false;
         return true;
     }
 

--- a/src/components/browse/SearchView.js
+++ b/src/components/browse/SearchView.js
@@ -90,9 +90,10 @@ export class SearchView extends React.PureComponent {
 
     filterFacetFxn(facet){
         const { hideFacets = null } = this.props;
+        const { field, hide_from_view = false } = facet || {};
         if (!hideFacets) return true;
         const idMap = this.memoized.listToObj(hideFacets);
-        if (idMap[facet.field]) return false;
+        if (idMap[field] || hide_from_view) return false;
         return true;
     }
 

--- a/src/components/browse/components/ControlsAndResults.js
+++ b/src/components/browse/components/ControlsAndResults.js
@@ -195,7 +195,7 @@ function DefaultFacetListComponent(props){
         // 'real' (multiple filter blocks) compound search used, FacetList UI cannot be used -
         return (
             <div className="facets-container with-header-bg">
-                <FacetListHeader compound />
+                <FacetListHeader hideToggle />
                 <div className="p-4">
                     <h4 className="text-400">Compound Filter</h4>
                     <p>Select a single filter block to edit its properties</p>

--- a/src/components/browse/components/FacetList/index.js
+++ b/src/components/browse/components/FacetList/index.js
@@ -141,7 +141,9 @@ export class FacetList extends React.PureComponent {
         'separateSingleTermFacets' : PropTypes.bool,
         'maxBodyHeight' : PropTypes.number,
         'useRadioIcon': PropTypes.bool.isRequired, // Show either checkbox (False) or radio icon (True) for term component - it is only for styling, not intended to implement single selection (radio) or multiple selection (checkbox)
-        'persistSelectedTerms': PropTypes.bool.isRequired // if True selected/omitted terms are escalated to top, otherwise each term is rendered in regular order. Moreover, inline search options are not displayed if it is False.
+        'persistSelectedTerms': PropTypes.bool.isRequired, // if True selected/omitted terms are escalated to top, otherwise each term is rendered in regular order. Moreover, inline search options are not displayed if it is False.
+        'isContextLoading': PropTypes.bool,
+        'hideHeaderToggle': PropTypes.bool.isRequired // if True hide Include/Exclude Properties toggle on Facet List header
     };
 
     static defaultProps = {
@@ -186,7 +188,8 @@ export class FacetList extends React.PureComponent {
             return term;
         },
         'useRadioIcon': false,
-        'persistSelectedTerms': true
+        'persistSelectedTerms': true,
+        'hideHeaderToggle': false
     };
 
     /** Remove any duplicates, merge in filters without selections as terms */
@@ -729,7 +732,8 @@ export class FacetList extends React.PureComponent {
             onClearFilters = null,
             showClearFiltersButton = false,
             maxBodyHeight: maxHeight = null,
-            isContextLoading = false
+            isContextLoading = false,
+            hideHeaderToggle = false
         } = this.props;
         const { openFacets, openPopover, including } = this.state;
         const { popover: popoverJSX, ref: popoverTargetRef } = openPopover || {};
@@ -752,7 +756,7 @@ export class FacetList extends React.PureComponent {
         return (
             <React.Fragment>
                 <div className="facets-container facets with-header-bg" data-context-loading={isContextLoading}>
-                    <FacetListHeader {...{ openFacets, title, onClearFilters, showClearFiltersButton, including }}
+                    <FacetListHeader {...{ openFacets, title, onClearFilters, showClearFiltersButton, including, hideToggle: hideHeaderToggle }}
                         onToggleIncluding={this.onToggleIncluding} onCollapseFacets={this.handleCollapseAllFacets} />
                     <div {...bodyProps}>
                         { selectableFacetElements }
@@ -781,7 +785,7 @@ export const FacetListHeader = React.memo(function FacetListHeader(props){
     const {
         including = true,
         onToggleIncluding,
-        compound = false,
+        hideToggle = false,
         title = "Properties", // @TODO: Is this actually in use anywhere?
         openFacets = {},
         showClearFiltersButton = false, // @Deprecated
@@ -794,7 +798,7 @@ export const FacetListHeader = React.memo(function FacetListHeader(props){
             <div className="row facets-header" data-excluding={!including}>
                 <div className="col facets-title-column text-truncate">
                     {
-                        !compound &&
+                        !hideToggle &&
                             <>
                                 <IconToggle activeIdx={including ? 0 : 1} options={[
                                     {
@@ -809,7 +813,7 @@ export const FacetListHeader = React.memo(function FacetListHeader(props){
                                 <h4 className="facets-title">{`${including ? "Included" : "Excluded"} ${title}`}</h4>
                             </>
                     }
-                    { compound &&
+                    { hideToggle &&
                         <>
                             <i className="icon icon-fw icon-filter fas"></i>
                             &nbsp;
@@ -818,7 +822,7 @@ export const FacetListHeader = React.memo(function FacetListHeader(props){
                     }
                 </div>
             </div>
-            { !compound &&
+            { !hideToggle &&
             <div className="row facets-controls">
                 <div className="col">
                     <div className="properties-controls d-flex py-1 w-100" role="group" aria-label="Properties Controls">


### PR DESCRIPTION
1. **Trello:** https://trello.com/c/7JecO63N

`Background:` the simple representation of facet item in schema is like:

```json
    "facets": {
        "type": {
            "title": "Data Type",
            "description": "Some description of facet item"
            "default_hidden": false // not required, boolean, the default value is false
            "disabled": false // not required, boolean, the default value is false
            "hide_from_view":  false // not required, boolean, the default value is false
        }
    },
```

Here, `default_hidden` and `disabled` work alike, where both are calculated by ES but not included in `context` returned to UI: https://github.com/4dn-dcic/snovault/blob/9af0fc33225dee56bf53ecb242e89c9150bccbf8/snovault/search/search.py#L634-L636

On the other hand, `hide_from_view` (introduced by AlexB but never actively used) is UI-oriented; it is like any other facet item included in `context` returned to UI.

This PR fixes facets rendering: filters out `hide_from_view = True` ones.

2. **Trello**: https://trello.com/c/YqhAeHAn

Add new `hideHeaderToggle` prop to `FacetList` component to make Included/Excluded toggle optional in facet list header.