### PR TITLE
Minor Static Page Updates

### DIFF
--- a/es/components/static-pages/TableOfContents.js
+++ b/es/components/static-pages/TableOfContents.js
@@ -2,15 +2,27 @@ import _typeof from "@babel/runtime/helpers/typeof";
 import _slicedToArray from "@babel/runtime/helpers/slicedToArray";
 import _classCallCheck from "@babel/runtime/helpers/classCallCheck";
 import _createClass from "@babel/runtime/helpers/createClass";
-import _assertThisInitialized from "@babel/runtime/helpers/assertThisInitialized";
-import _inherits from "@babel/runtime/helpers/inherits";
 import _possibleConstructorReturn from "@babel/runtime/helpers/possibleConstructorReturn";
 import _getPrototypeOf from "@babel/runtime/helpers/getPrototypeOf";
+import _assertThisInitialized from "@babel/runtime/helpers/assertThisInitialized";
+import _inherits from "@babel/runtime/helpers/inherits";
 import _defineProperty from "@babel/runtime/helpers/defineProperty";
+var _TableEntryChildren;
 function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); enumerableOnly && (symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; })), keys.push.apply(keys, symbols); } return keys; }
 function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = null != arguments[i] ? arguments[i] : {}; i % 2 ? ownKeys(Object(source), !0).forEach(function (key) { _defineProperty(target, key, source[key]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)) : ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } return target; }
-function _createSuper(Derived) { var hasNativeReflectConstruct = _isNativeReflectConstruct(); return function () { var Super = _getPrototypeOf(Derived), result; if (hasNativeReflectConstruct) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
+function _callSuper(_this, derived, args) {
+  derived = _getPrototypeOf(derived);
+  return _possibleConstructorReturn(_this, function () {
+    if (typeof Reflect === "undefined" || !Reflect.construct) return false;
+    if (Reflect.construct.sham) return false;
+    if (typeof Proxy === "function") return true;
+    try {
+      return !Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {}));
+    } catch (e) {
+      return false;
+    }
+  }() ? Reflect.construct(derived, args || [], _getPrototypeOf(_this).constructor) : derived.apply(_this, args));
+}
 import React from 'react';
 import * as d3 from 'd3';
 import _ from 'underscore';
@@ -22,11 +34,10 @@ import { isServerSide } from './../util/misc';
 import { CopyWrapper, itemUtil } from './../util/object';
 var TableEntry = /*#__PURE__*/function (_React$Component) {
   _inherits(TableEntry, _React$Component);
-  var _super = _createSuper(TableEntry);
   function TableEntry(props) {
     var _this;
     _classCallCheck(this, TableEntry);
-    _this = _super.call(this, props);
+    _this = _callSuper(this, TableEntry, [props]);
     _this.shouldComponentUpdate = _this.shouldComponentUpdate.bind(_assertThisInitialized(_this));
     _this.getTargetElement = _this.getTargetElement.bind(_assertThisInitialized(_this));
     _this.getNextHeaderElement = _this.getNextHeaderElement.bind(_assertThisInitialized(_this));
@@ -34,9 +45,12 @@ var TableEntry = /*#__PURE__*/function (_React$Component) {
     _this.determineIfActive = _this.determineIfActive.bind(_assertThisInitialized(_this));
     _this.toggleOpen = _this.toggleOpen.bind(_assertThisInitialized(_this));
     _this.targetElement = null; // Header element we scroll to is cached here. Not in state as does not change.
-    if (props.collapsible) {
+    var collapsible = props.collapsible,
+      defaultExpanded = props.defaultExpanded;
+    if (collapsible) {
+      var open = typeof defaultExpanded === 'boolean' ? defaultExpanded : false;
       _this.state = {
-        'open': false
+        'open': open
       };
     }
     return _this;
@@ -156,6 +170,7 @@ var TableEntry = /*#__PURE__*/function (_React$Component) {
         nextHeader = _this$props2.nextHeader,
         children = _this$props2.children,
         skipDepth = _this$props2.skipDepth,
+        defaultExpanded = _this$props2.defaultExpanded,
         className = _this$props2.className,
         propNavigate = _this$props2.navigate;
       var title = this.props.title;
@@ -211,7 +226,8 @@ var TableEntry = /*#__PURE__*/function (_React$Component) {
         link: link,
         maxHeaderDepth: maxHeaderDepth,
         skipDepth: skipDepth,
-        recurDepth: recurDepth
+        recurDepth: recurDepth,
+        defaultExpanded: defaultExpanded
       }))));
     }
   }]);
@@ -235,15 +251,15 @@ _defineProperty(TableEntry, "defaultProps", {
   'mounted': null,
   'content': null,
   'nextHeader': null,
-  'recurDepth': 1
+  'recurDepth': 1,
+  'defaultExpanded': undefined
 });
 var TableEntryChildren = /*#__PURE__*/function (_React$Component2) {
   _inherits(TableEntryChildren, _React$Component2);
-  var _super2 = _createSuper(TableEntryChildren);
   function TableEntryChildren(props) {
     var _this3;
     _classCallCheck(this, TableEntryChildren);
-    _this3 = _super2.call(this, props);
+    _this3 = _callSuper(this, TableEntryChildren, [props]);
     _this3.shouldComponentUpdate = _this3.shouldComponentUpdate.bind(_assertThisInitialized(_this3));
     _this3.getHeadersFromContent = _this3.getHeadersFromContent.bind(_assertThisInitialized(_this3));
     _this3.children = _this3.children.bind(_assertThisInitialized(_this3));
@@ -276,7 +292,7 @@ var TableEntryChildren = /*#__PURE__*/function (_React$Component2) {
         childHeaders = _this$getHeadersFromC.childHeaders,
         childDepth = _this$getHeadersFromC.childDepth;
       if (childHeaders && childHeaders.length) {
-        var opts = _.pick(this.props, 'maxHeaderDepth', 'pageScrollTop', 'listStyleTypes', 'skipDepth', 'nextHeader', 'mounted', 'recurDepth');
+        var opts = _.pick(this.props, 'maxHeaderDepth', 'pageScrollTop', 'listStyleTypes', 'skipDepth', 'defaultExpanded', 'nextHeader', 'mounted', 'recurDepth');
         return TableEntryChildren.renderChildrenElements(childHeaders, childDepth, content, opts);
       } else {
         return propChildren;
@@ -309,6 +325,7 @@ var TableEntryChildren = /*#__PURE__*/function (_React$Component2) {
       };
       var skipDepth = opts.skipDepth,
         maxHeaderDepth = opts.maxHeaderDepth,
+        defaultExpanded = opts.defaultExpanded,
         listStyleTypes = opts.listStyleTypes,
         pageScrollTop = opts.pageScrollTop,
         mounted = opts.mounted,
@@ -349,7 +366,8 @@ var TableEntryChildren = /*#__PURE__*/function (_React$Component2) {
             maxHeaderDepth: maxHeaderDepth,
             collapsible: currentDepth >= 1 + skipDepth,
             skipDepth: skipDepth,
-            recurDepth: (recurDepth || 0) + 1
+            recurDepth: (recurDepth || 0) + 1,
+            defaultExpanded: defaultExpanded
           });
         });
       }
@@ -358,11 +376,12 @@ var TableEntryChildren = /*#__PURE__*/function (_React$Component2) {
   }]);
   return TableEntryChildren;
 }(React.Component);
+_TableEntryChildren = TableEntryChildren;
 _defineProperty(TableEntryChildren, "getHeadersFromContent", memoize(function (jsxContent, maxHeaderDepth, currentDepth) {
   if (Array.isArray(jsxContent)) {
     // As of html-react-parser v1.2.8, we may get back array of content, including "\n" or similar.
     return jsxContent.reduce(function (m, c) {
-      var res = TableEntryChildren.getHeadersFromContent(c, maxHeaderDepth, currentDepth);
+      var res = _TableEntryChildren.getHeadersFromContent(c, maxHeaderDepth, currentDepth);
       m.childDepth = Math.max(res.childDepth, m.childDepth);
       m.childrenForDepth = m.childrenForDepth.concat(res.childrenForDepth);
       return m;
@@ -413,11 +432,10 @@ _defineProperty(TableEntryChildren, "getSubsequentChildHeaders", memoize(functio
 }));
 export var TableOfContents = /*#__PURE__*/function (_React$Component3) {
   _inherits(TableOfContents, _React$Component3);
-  var _super3 = _createSuper(TableOfContents);
   function TableOfContents(props) {
     var _this4;
     _classCallCheck(this, TableOfContents);
-    _this4 = _super3.call(this, props);
+    _this4 = _callSuper(this, TableOfContents, [props]);
     _this4.onPageScroll = _this4.onPageScroll.bind(_assertThisInitialized(_this4));
     _this4.onToggleWidthBound = _this4.onToggleWidthBound.bind(_assertThisInitialized(_this4));
     _this4.state = {
@@ -541,6 +559,7 @@ export var TableOfContents = /*#__PURE__*/function (_React$Component3) {
         windowHeight = _this$props5.windowHeight,
         maxHeight = _this$props5.maxHeight,
         propNavigate = _this$props5.navigate,
+        defaultExpanded = _this$props5.defaultExpanded,
         _this$props5$fixedPos = _this$props5.fixedPositionBreakpoint,
         fixedPositionBreakpoint = _this$props5$fixedPos === void 0 ? 1200 : _this$props5$fixedPos;
       var _this$state = this.state,
@@ -586,7 +605,8 @@ export var TableOfContents = /*#__PURE__*/function (_React$Component3) {
             childHeaders: childHeaders,
             maxHeaderDepth: maxHeaderDepth,
             listStyleTypes: listStyleTypes,
-            skipDepth: skipDepth
+            skipDepth: skipDepth,
+            defaultExpanded: defaultExpanded
           }, {
             mounted: mounted,
             nextHeader: nextHeader,
@@ -602,6 +622,7 @@ export var TableOfContents = /*#__PURE__*/function (_React$Component3) {
           nextHeader: nextHeader,
           skipDepth: skipDepth,
           maxHeaderDepth: maxHeaderDepth,
+          defaultExpanded: defaultExpanded,
           title: tocTitle || title || _.map(link.split('-'), function (w) {
             return w.charAt(0).toUpperCase() + w.slice(1);
           }).join(' '),
@@ -637,7 +658,8 @@ export var TableOfContents = /*#__PURE__*/function (_React$Component3) {
         navigate: propNavigate,
         nextHeader: firstSectionLink || null,
         maxHeaderDepth: maxHeaderDepth,
-        skipDepth: skipDepth || 0
+        skipDepth: skipDepth || 0,
+        defaultExpanded: defaultExpanded
       }, renderedSectionsFlattened));
       var marginTop = 0; // Account for test warning
       if (windowWidth) {
@@ -797,7 +819,8 @@ _defineProperty(TableOfContents, "defaultProps", {
   'includeTop': true,
   'includeNextPreviousPages': true,
   'listStyleTypes': ['none', 'decimal', 'lower-alpha', 'lower-roman'],
-  'maxHeaderDepth': 3
+  'maxHeaderDepth': 3,
+  'defaultExpanded': undefined
 });
 export var NextPreviousPageSection = /*#__PURE__*/React.memo(function (props) {
   var context = props.context,
@@ -844,11 +867,10 @@ NextPreviousPageSection.defaultProps = {
  */
 export var MarkdownHeading = /*#__PURE__*/function (_React$PureComponent) {
   _inherits(MarkdownHeading, _React$PureComponent);
-  var _super4 = _createSuper(MarkdownHeading);
   function MarkdownHeading(props) {
     var _this6;
     _classCallCheck(this, MarkdownHeading);
-    _this6 = _super4.call(this, props);
+    _this6 = _callSuper(this, MarkdownHeading, [props]);
     _this6.getID = _this6.getID.bind(_assertThisInitialized(_this6));
     return _this6;
   }
@@ -934,11 +956,10 @@ _defineProperty(MarkdownHeading, "defaultProps", {
 });
 export var HeaderWithLink = /*#__PURE__*/function (_React$PureComponent2) {
   _inherits(HeaderWithLink, _React$PureComponent2);
-  var _super5 = _createSuper(HeaderWithLink);
   function HeaderWithLink(props) {
     var _this7;
     _classCallCheck(this, HeaderWithLink);
-    _this7 = _super5.call(this, props);
+    _this7 = _callSuper(this, HeaderWithLink, [props]);
     _this7.handleLinkClick = _this7.handleLinkClick.bind(_assertThisInitialized(_this7));
     return _this7;
   }

--- a/es/components/util/object.js
+++ b/es/components/util/object.js
@@ -1,15 +1,26 @@
 import _toConsumableArray from "@babel/runtime/helpers/toConsumableArray";
 import _classCallCheck from "@babel/runtime/helpers/classCallCheck";
 import _createClass from "@babel/runtime/helpers/createClass";
-import _assertThisInitialized from "@babel/runtime/helpers/assertThisInitialized";
-import _inherits from "@babel/runtime/helpers/inherits";
 import _possibleConstructorReturn from "@babel/runtime/helpers/possibleConstructorReturn";
 import _getPrototypeOf from "@babel/runtime/helpers/getPrototypeOf";
+import _assertThisInitialized from "@babel/runtime/helpers/assertThisInitialized";
+import _inherits from "@babel/runtime/helpers/inherits";
 import _slicedToArray from "@babel/runtime/helpers/slicedToArray";
 import _extends from "@babel/runtime/helpers/extends";
 import _typeof from "@babel/runtime/helpers/typeof";
-function _createSuper(Derived) { var hasNativeReflectConstruct = _isNativeReflectConstruct(); return function () { var Super = _getPrototypeOf(Derived), result; if (hasNativeReflectConstruct) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
+function _callSuper(_this, derived, args) {
+  derived = _getPrototypeOf(derived);
+  return _possibleConstructorReturn(_this, function () {
+    if (typeof Reflect === "undefined" || !Reflect.construct) return false;
+    if (Reflect.construct.sham) return false;
+    if (typeof Proxy === "function") return true;
+    try {
+      return !Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {}));
+    } catch (e) {
+      return false;
+    }
+  }() ? Reflect.construct(derived, args || [], _getPrototypeOf(_this).constructor) : derived.apply(_this, args));
+}
 function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it["return"] != null) it["return"](); } finally { if (didErr) throw err; } } }; }
 function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
 function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
@@ -545,11 +556,10 @@ TooltipInfoIconContainerAuto.propTypes = {
  */
 export var CopyWrapper = /*#__PURE__*/function (_React$PureComponent) {
   _inherits(CopyWrapper, _React$PureComponent);
-  var _super = _createSuper(CopyWrapper);
   function CopyWrapper(props) {
     var _this;
     _classCallCheck(this, CopyWrapper);
-    _this = _super.call(this, props);
+    _this = _callSuper(this, CopyWrapper, [props]);
     _this.flashEffect = _this.flashEffect.bind(_assertThisInitialized(_this));
     if (typeof props.mounted !== 'boolean') {
       _this.state = {
@@ -615,14 +625,15 @@ export var CopyWrapper = /*#__PURE__*/function (_React$PureComponent) {
         iconProps = _this$props2.iconProps,
         includeIcon = _this$props2.includeIcon,
         className = _this$props2.className,
-        stopPropagation = _this$props2.stopPropagation;
+        stopPropagation = _this$props2.stopPropagation,
+        whitespace = _this$props2.whitespace;
       if (!value) return null;
 
       // eslint-disable-next-line react/destructuring-assignment
       var isMounted = mounted || this.state && this.state.mounted || false;
       var elemsToWrap = [];
       if (children) elemsToWrap.push(children);
-      if (children && isMounted) elemsToWrap.push(' ');
+      if (children && isMounted && whitespace) elemsToWrap.push(' ');
       if (isMounted && includeIcon) elemsToWrap.push( /*#__PURE__*/React.createElement("i", _extends({}, iconProps, {
         key: "copy-icon",
         className: "icon icon-fw icon-copy far",
@@ -703,6 +714,7 @@ CopyWrapper.defaultProps = {
   'flash': true,
   'iconProps': {},
   'includeIcon': true,
+  'whitespace': true,
   'flashActiveTransform': 'scale3d(1.2, 1.2, 1.2) translate3d(0, 0, 0)',
   'flashInactiveTransform': 'translate3d(0, 0, 0)'
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@hms-dbmi-bgm/shared-portal-components",
-    "version": "0.1.78",
+    "version": "0.1.79",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@hms-dbmi-bgm/shared-portal-components",
-            "version": "0.1.78",
+            "version": "0.1.79",
             "license": "MIT",
             "dependencies": {
                 "@4dn-dcic/react-infinite": "github:4dn-dcic/react-infinite#1.1.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hms-dbmi-bgm/shared-portal-components",
-    "version": "0.1.78",
+    "version": "0.1.79",
     "description": "Shared components used for DBMI/BGM portal(s).",
     "repository": {
         "type": "git",

--- a/src/components/static-pages/TableOfContents.js
+++ b/src/components/static-pages/TableOfContents.js
@@ -30,7 +30,8 @@ class TableEntry extends React.Component {
         'mounted' : null,
         'content' : null,
         'nextHeader' : null,
-        'recurDepth' : 1
+        'recurDepth' : 1,
+        'defaultExpanded': undefined,
     };
 
     constructor(props){
@@ -43,8 +44,10 @@ class TableEntry extends React.Component {
         this.toggleOpen = this.toggleOpen.bind(this);
 
         this.targetElement = null; // Header element we scroll to is cached here. Not in state as does not change.
-        if (props.collapsible){
-            this.state = { 'open' : false };
+        const { collapsible, defaultExpanded } = props;
+        if (collapsible) {
+            const open = typeof defaultExpanded === 'boolean' ? defaultExpanded : false;
+            this.state = { 'open': open };
         }
     }
 
@@ -147,7 +150,7 @@ class TableEntry extends React.Component {
     render(){
         const {
             recurDepth, link, content, maxHeaderDepth, depth, collapsible, mounted,
-            listStyleTypes, pageScrollTop, nextHeader, children, skipDepth, className,
+            listStyleTypes, pageScrollTop, nextHeader, children, skipDepth, defaultExpanded, className,
             navigate : propNavigate
         } = this.props;
         let { title } = this.props;
@@ -193,7 +196,7 @@ class TableEntry extends React.Component {
                     <div>
                         <TableEntryChildren navigate={propNavigate} parentClosed={this.state && !open}
                             {...{ active, content, childHeaders, depth, mounted, listStyleTypes,
-                                pageScrollTop, nextHeader, children, link, maxHeaderDepth, skipDepth, recurDepth }} />
+                                pageScrollTop, nextHeader, children, link, maxHeaderDepth, skipDepth, recurDepth, defaultExpanded }} />
                     </div>
                 </Collapse>
             </li>
@@ -265,7 +268,7 @@ class TableEntryChildren extends React.Component {
     });
 
     static renderChildrenElements(childHeaders, currentDepth, jsxContent, opts={ 'skipDepth' : 0, 'nextHeader' : null }){
-        const { skipDepth, maxHeaderDepth, listStyleTypes, pageScrollTop, mounted, nextHeader, recurDepth } = opts;
+        const { skipDepth, maxHeaderDepth, defaultExpanded, listStyleTypes, pageScrollTop, mounted, nextHeader, recurDepth } = opts;
 
         if (Array.isArray(childHeaders) && childHeaders.length > 0){
             return childHeaders.map(function(h, index){
@@ -309,6 +312,7 @@ class TableEntryChildren extends React.Component {
                         collapsible={collapsible}
                         skipDepth={skipDepth}
                         recurDepth={(recurDepth || 0) + 1}
+                        defaultExpanded={defaultExpanded}
                     />
                 );
             });
@@ -341,7 +345,7 @@ class TableEntryChildren extends React.Component {
         const { content, depth, children: propChildren } = this.props;
         const { childHeaders, childDepth } = this.getHeadersFromContent();
         if (childHeaders && childHeaders.length){
-            const opts = _.pick(this.props, 'maxHeaderDepth', 'pageScrollTop', 'listStyleTypes', 'skipDepth', 'nextHeader', 'mounted', 'recurDepth');
+            const opts = _.pick(this.props, 'maxHeaderDepth', 'pageScrollTop', 'listStyleTypes', 'skipDepth', 'defaultExpanded', 'nextHeader', 'mounted', 'recurDepth');
             return TableEntryChildren.renderChildrenElements(childHeaders, childDepth, content, opts);
         } else {
             return propChildren;
@@ -472,7 +476,8 @@ export class TableOfContents extends React.Component {
         'includeTop' : true,
         'includeNextPreviousPages' : true,
         'listStyleTypes' : ['none', 'decimal', 'lower-alpha', 'lower-roman'],
-        'maxHeaderDepth' : 3
+        'maxHeaderDepth' : 3,
+        'defaultExpanded': undefined
     };
 
     constructor(props){
@@ -566,7 +571,7 @@ export class TableOfContents extends React.Component {
     render(){
         const {
             context, maxHeaderDepth, includeTop, fixedGridWidth, includeNextPreviousPages, listStyleTypes,
-            windowWidth, windowHeight, maxHeight, navigate: propNavigate,
+            windowWidth, windowHeight, maxHeight, navigate: propNavigate, defaultExpanded,
             fixedPositionBreakpoint = 1200
         } = this.props;
         const { mounted, scrollTop, widthBound } = this.state;
@@ -595,13 +600,13 @@ export class TableOfContents extends React.Component {
                 if (excludeSectionsFromTOC){
                     skipDepth = 1;
                     const { childHeaders, childDepth } = TableEntryChildren.getHeadersFromContent(content, maxHeaderDepth, 1);
-                    const opts = _.extend({ childHeaders, maxHeaderDepth, listStyleTypes, skipDepth }, {
+                    const opts = _.extend({ childHeaders, maxHeaderDepth, listStyleTypes, skipDepth, defaultExpanded }, {
                         mounted, nextHeader, 'pageScrollTop' : scrollTop
                     });
                     return TableEntryChildren.renderChildrenElements(childHeaders, childDepth, content, opts);
                 }
                 return (
-                    <TableEntry {...{ link, content, listStyleTypes, mounted, nextHeader, skipDepth, maxHeaderDepth }}
+                    <TableEntry {...{ link, content, listStyleTypes, mounted, nextHeader, skipDepth, maxHeaderDepth, defaultExpanded }}
                         title={tocTitle || title || _.map(link.split('-'), function(w){ return w.charAt(0).toUpperCase() + w.slice(1); } ).join(' ') }
                         key={link} depth={1} pageScrollTop={scrollTop} navigate={propNavigate} />
                 );
@@ -624,7 +629,7 @@ export class TableOfContents extends React.Component {
                 key="top" depth={0} listStyleTypes={listStyleTypes}
                 pageScrollTop={scrollTop} mounted={mounted} navigate={propNavigate}
                 nextHeader={firstSectionLink || null}
-                maxHeaderDepth={maxHeaderDepth} skipDepth={skipDepth || 0}>
+                maxHeaderDepth={maxHeaderDepth} skipDepth={skipDepth || 0} defaultExpanded={defaultExpanded}>
                 { renderedSectionsFlattened }
             </TableEntry>
         );

--- a/src/components/util/object.js
+++ b/src/components/util/object.js
@@ -639,7 +639,7 @@ export class CopyWrapper extends React.PureComponent {
     }
 
     render(){
-        const { value, children, mounted, wrapperElement, iconProps, includeIcon, className, stopPropagation } = this.props;
+        const { value, children, mounted, wrapperElement, iconProps, includeIcon, className, stopPropagation, whitespace } = this.props;
         if (!value) return null;
 
         // eslint-disable-next-line react/destructuring-assignment
@@ -659,9 +659,9 @@ export class CopyWrapper extends React.PureComponent {
         };
 
         const elemsToWrap = [];
-        if (children)                   elemsToWrap.push(children);
-        if (children && isMounted)      elemsToWrap.push(' ');
-        if (isMounted && includeIcon)   elemsToWrap.push(<i {...iconProps} key="copy-icon" className="icon icon-fw icon-copy far" title="Copy to clipboard" />);
+        if (children)                               elemsToWrap.push(children);
+        if (children && isMounted && whitespace)    elemsToWrap.push(' ');
+        if (isMounted && includeIcon)               elemsToWrap.push(<i {...iconProps} key="copy-icon" className="icon icon-fw icon-copy far" title="Copy to clipboard" />);
 
         const wrapperProps = _.extend(
             {
@@ -682,6 +682,7 @@ CopyWrapper.defaultProps = {
     'flash' : true,
     'iconProps' : {},
     'includeIcon' : true,
+    'whitespace': true,
     'flashActiveTransform' : 'scale3d(1.2, 1.2, 1.2) translate3d(0, 0, 0)',
     'flashInactiveTransform' : 'translate3d(0, 0, 0)'
 };


### PR DESCRIPTION
- add `defaultExpanded` prop to display all items expanded in Table-of-Content
- add `whitespace` prop to make space between text and copy icon optional (default: true) in `CopyWrapper`.