### PR TITLE
html-react-parser Upgrade and defaultExpanded Schema Updates

### DIFF
--- a/es/components/static-pages/StaticPageBase.js
+++ b/es/components/static-pages/StaticPageBase.js
@@ -1,16 +1,26 @@
 import _classCallCheck from "@babel/runtime/helpers/classCallCheck";
 import _createClass from "@babel/runtime/helpers/createClass";
-import _assertThisInitialized from "@babel/runtime/helpers/assertThisInitialized";
-import _inherits from "@babel/runtime/helpers/inherits";
 import _possibleConstructorReturn from "@babel/runtime/helpers/possibleConstructorReturn";
 import _getPrototypeOf from "@babel/runtime/helpers/getPrototypeOf";
+import _inherits from "@babel/runtime/helpers/inherits";
 import _defineProperty from "@babel/runtime/helpers/defineProperty";
 import _extends from "@babel/runtime/helpers/extends";
 import _typeof from "@babel/runtime/helpers/typeof";
 function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); enumerableOnly && (symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; })), keys.push.apply(keys, symbols); } return keys; }
 function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = null != arguments[i] ? arguments[i] : {}; i % 2 ? ownKeys(Object(source), !0).forEach(function (key) { _defineProperty(target, key, source[key]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)) : ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } return target; }
-function _createSuper(Derived) { var hasNativeReflectConstruct = _isNativeReflectConstruct(); return function () { var Super = _getPrototypeOf(Derived), result; if (hasNativeReflectConstruct) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
+function _callSuper(_this, derived, args) {
+  derived = _getPrototypeOf(derived);
+  return _possibleConstructorReturn(_this, function () {
+    if (typeof Reflect === "undefined" || !Reflect.construct) return false;
+    if (Reflect.construct.sham) return false;
+    if (typeof Proxy === "function") return true;
+    try {
+      return !Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {}));
+    } catch (e) {
+      return false;
+    }
+  }() ? Reflect.construct(derived, args || [], _getPrototypeOf(_this).constructor) : derived.apply(_this, args));
+}
 import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'underscore';
@@ -74,6 +84,7 @@ var Wrapper = /*#__PURE__*/React.memo(function (props) {
   var toc = context && context['table-of-contents'] || (tableOfContents && _typeof(tableOfContents) === 'object' ? tableOfContents : null);
   var pageTitle = title || context && context.title || null;
   var tocExists = toc && toc.enabled !== false;
+  var tocDefaultExpanded = toc && toc.expanded === true || undefined;
   return /*#__PURE__*/React.createElement("div", {
     className: "container",
     id: "content"
@@ -86,7 +97,8 @@ var Wrapper = /*#__PURE__*/React.memo(function (props) {
   }, /*#__PURE__*/React.createElement(TableOfContents, _extends({
     pageTitle: pageTitle,
     fixedGridWidth: 3,
-    maxHeaderDepth: toc['header-depth'] || 6
+    maxHeaderDepth: toc['header-depth'] || 6,
+    defaultExpanded: tocDefaultExpanded
   }, _.pick(props, 'navigate', 'windowWidth', 'windowHeight', 'context', 'href', 'registerWindowOnScrollHandler', 'fixedPositionBreakpoint')))) : null, /*#__PURE__*/React.createElement("div", {
     key: "main-column",
     className: "order-2 col-12 col-xl-" + (tocExists ? '9' : '12')
@@ -104,24 +116,23 @@ Wrapper.defaultProps = {
   'tocListStyles': ['decimal', 'lower-alpha', 'lower-roman']
 };
 export var StaticEntry = /*#__PURE__*/function (_React$PureComponent) {
-  _inherits(StaticEntry, _React$PureComponent);
-  var _super = _createSuper(StaticEntry);
   function StaticEntry(props) {
-    var _this;
+    var _this2;
     _classCallCheck(this, StaticEntry);
-    _this = _super.call(this, props);
-    _this.toggleOpen = _.throttle(_this.toggleOpen.bind(_assertThisInitialized(_this)), 1000);
+    _this2 = _callSuper(this, StaticEntry, [props]);
+    _this2.toggleOpen = _.throttle(_this2.toggleOpen.bind(_this2), 1000);
     var options = props.section && props.section.options || {};
-    _this.state = {
+    _this2.state = {
       'open': options.default_open,
       'closing': false
     };
-    return _this;
+    return _this2;
   }
-  _createClass(StaticEntry, [{
+  _inherits(StaticEntry, _React$PureComponent);
+  return _createClass(StaticEntry, [{
     key: "toggleOpen",
     value: function toggleOpen(open) {
-      var _this2 = this;
+      var _this3 = this;
       this.setState(function (currState) {
         if (typeof open !== 'boolean') {
           open = !currState.open;
@@ -133,7 +144,7 @@ export var StaticEntry = /*#__PURE__*/function (_React$PureComponent) {
         };
       }, function () {
         setTimeout(function () {
-          _this2.setState(function (currState) {
+          _this3.setState(function (currState) {
             if (!currState.open && currState.closing) {
               return {
                 'closing': false
@@ -189,7 +200,6 @@ export var StaticEntry = /*#__PURE__*/function (_React$PureComponent) {
       }, section.title) : null, renderedChildComponent);
     }
   }]);
-  return StaticEntry;
 }(React.PureComponent);
 
 /**
@@ -207,13 +217,12 @@ _defineProperty(StaticEntry, "propTypes", {
   'childComponent': PropTypes.elementType
 });
 export var StaticPageBase = /*#__PURE__*/function (_React$PureComponent2) {
-  _inherits(StaticPageBase, _React$PureComponent2);
-  var _super2 = _createSuper(StaticPageBase);
   function StaticPageBase() {
     _classCallCheck(this, StaticPageBase);
-    return _super2.apply(this, arguments);
+    return _callSuper(this, StaticPageBase, arguments);
   }
-  _createClass(StaticPageBase, [{
+  _inherits(StaticPageBase, _React$PureComponent2);
+  return _createClass(StaticPageBase, [{
     key: "render",
     value: function render() {
       var _this$props2 = this.props,
@@ -265,7 +274,6 @@ export var StaticPageBase = /*#__PURE__*/function (_React$PureComponent2) {
       });
     }
   }]);
-  return StaticPageBase;
 }(React.PureComponent);
 _defineProperty(StaticPageBase, "Wrapper", Wrapper);
 _defineProperty(StaticPageBase, "defaultProps", {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@hms-dbmi-bgm/shared-portal-components",
-    "version": "0.1.80",
+    "version": "0.1.81",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@hms-dbmi-bgm/shared-portal-components",
-            "version": "0.1.80",
+            "version": "0.1.81",
             "license": "MIT",
             "dependencies": {
                 "@4dn-dcic/react-infinite": "github:4dn-dcic/react-infinite#1.1.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
                 "date-fns-tz": "^1.3.0",
                 "dom-helpers": "^5.2.1",
                 "dompurify": "^2.3.6",
-                "html-react-parser": "^1.2.8",
+                "html-react-parser": "^5.1.10",
                 "js-md5": "^0.7.3",
                 "jsdom": "^19.0.0",
                 "jsonwebtoken": ">=7.4.0",
@@ -7127,24 +7127,16 @@
             }
         },
         "node_modules/dom-serializer": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
-            "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+            "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
             "dependencies": {
-                "domelementtype": "^2.0.1",
-                "domhandler": "^4.2.0",
-                "entities": "^2.0.0"
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.2",
+                "entities": "^4.2.0"
             },
             "funding": {
                 "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-            }
-        },
-        "node_modules/dom-serializer/node_modules/entities": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-            "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-            "funding": {
-                "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
         "node_modules/domain-browser": {
@@ -7180,11 +7172,11 @@
             }
         },
         "node_modules/domhandler": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
-            "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+            "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
             "dependencies": {
-                "domelementtype": "^2.2.0"
+                "domelementtype": "^2.3.0"
             },
             "engines": {
                 "node": ">= 4"
@@ -7199,13 +7191,13 @@
             "integrity": "sha512-jggCCd+8Iqp4Tsz0nIvpcb22InKEBrGz5dw3EQJMs8HPJDsKbFIO3STYtAvCfDx26Muevn1MHVI0XxjgFfmiSA=="
         },
         "node_modules/domutils": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
-            "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+            "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
             "dependencies": {
-                "dom-serializer": "^1.0.1",
-                "domelementtype": "^2.2.0",
-                "domhandler": "^4.2.0"
+                "dom-serializer": "^2.0.0",
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.3"
             },
             "funding": {
                 "url": "https://github.com/fb55/domutils?sponsor=1"
@@ -7347,9 +7339,9 @@
             }
         },
         "node_modules/entities": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
-            "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
             "engines": {
                 "node": ">=0.12"
             },
@@ -9848,12 +9840,12 @@
             "dev": true
         },
         "node_modules/html-dom-parser": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-1.2.0.tgz",
-            "integrity": "sha512-2HIpFMvvffsXHFUFjso0M9LqM+1Lm22BF+Df2ba+7QHJXjk63pWChEnI6YG27eaWqUdfnh5/Vy+OXrNTtepRsg==",
+            "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-5.0.8.tgz",
+            "integrity": "sha512-vuWiX9EXgu8CJ5m9EP5c7bvBmNSuQVnrY8tl0z0ZX96Uth1IPlYH/8W8VZ/hBajFf18EN+j2pukbCNd01HEd1w==",
             "dependencies": {
-                "domhandler": "4.3.1",
-                "htmlparser2": "7.2.0"
+                "domhandler": "5.0.3",
+                "htmlparser2": "9.1.0"
             }
         },
         "node_modules/html-encoding-sniffer": {
@@ -9874,23 +9866,29 @@
             "dev": true
         },
         "node_modules/html-react-parser": {
-            "version": "1.4.14",
-            "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-1.4.14.tgz",
-            "integrity": "sha512-pxhNWGie8Y+DGDpSh8cTa0k3g8PsDcwlfolA+XxYo1AGDeB6e2rdlyv4ptU9bOTiZ2i3fID+6kyqs86MN0FYZQ==",
+            "version": "5.1.10",
+            "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-5.1.10.tgz",
+            "integrity": "sha512-gV22PvLij4wdEdtrZbGVC7Zy2OVWnQ0bYhX63S196ZRSx4+K0TuutCreHSXr+saUia8KeKB+2TYziVfijpH4Tw==",
             "dependencies": {
-                "domhandler": "4.3.1",
-                "html-dom-parser": "1.2.0",
-                "react-property": "2.0.0",
-                "style-to-js": "1.1.1"
+                "domhandler": "5.0.3",
+                "html-dom-parser": "5.0.8",
+                "react-property": "2.0.2",
+                "style-to-js": "1.1.12"
             },
             "peerDependencies": {
+                "@types/react": "17 || 18",
                 "react": "0.14 || 15 || 16 || 17 || 18"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
             }
         },
         "node_modules/htmlparser2": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
-            "integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
+            "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
             "funding": [
                 "https://github.com/fb55/htmlparser2?sponsor=1",
                 {
@@ -9899,10 +9897,10 @@
                 }
             ],
             "dependencies": {
-                "domelementtype": "^2.0.1",
-                "domhandler": "^4.2.2",
-                "domutils": "^2.8.0",
-                "entities": "^3.0.1"
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.3",
+                "domutils": "^3.1.0",
+                "entities": "^4.5.0"
             }
         },
         "node_modules/http-proxy-agent": {
@@ -10107,9 +10105,9 @@
             "dev": true
         },
         "node_modules/inline-style-parser": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
-            "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q=="
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.3.tgz",
+            "integrity": "sha512-qlD8YNDqyTKTyuITrDOffsl6Tdhv+UC4hcdAVuQsK4IMQ99nSgd1MIA/Q+jQYoh9r3hVUXhYh7urSRmXPkW04g=="
         },
         "node_modules/internal-slot": {
             "version": "1.0.5",
@@ -16792,9 +16790,9 @@
             }
         },
         "node_modules/react-property": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.0.tgz",
-            "integrity": "sha512-kzmNjIgU32mO4mmH5+iUyrqlpFQhF8K2k7eZ4fdLSOPFrD1XgEuSBv9LDEgxRXTMBqMd8ppT0x6TIzqE5pdGdw=="
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.2.tgz",
+            "integrity": "sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug=="
         },
         "node_modules/react-tooltip": {
             "version": "5.10.5",
@@ -18345,19 +18343,19 @@
             }
         },
         "node_modules/style-to-js": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.1.tgz",
-            "integrity": "sha512-RJ18Z9t2B02sYhZtfWKQq5uplVctgvjTfLWT7+Eb1zjUjIrWzX5SdlkwLGQozrqarTmEzJJ/YmdNJCUNI47elg==",
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.12.tgz",
+            "integrity": "sha512-tv+/FkgNYHI2fvCoBMsqPHh5xovwiw+C3X0Gfnss/Syau0Nr3IqGOJ9XiOYXoPnToHVbllKFf5qCNFJGwFg5mg==",
             "dependencies": {
-                "style-to-object": "0.3.0"
+                "style-to-object": "1.0.6"
             }
         },
         "node_modules/style-to-object": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.3.0.tgz",
-            "integrity": "sha512-CzFnRRXhzWIdItT3OmF8SQfWyahHhjq3HwcMNCNLn+N7klOOqPjMeG/4JSu77D7ypZdGvSzvkrbyeTMizz2VrA==",
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.6.tgz",
+            "integrity": "sha512-khxq+Qm3xEyZfKd/y9L3oIWQimxuc4STrQKtQn8aSDRHb8mFgpukgX1hdzfrMEW6JCjyJ8p89x+IUMVnCBI1PA==",
             "dependencies": {
-                "inline-style-parser": "0.1.1"
+                "inline-style-parser": "0.2.3"
             }
         },
         "node_modules/superagent": {
@@ -26225,20 +26223,13 @@
             }
         },
         "dom-serializer": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
-            "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+            "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
             "requires": {
-                "domelementtype": "^2.0.1",
-                "domhandler": "^4.2.0",
-                "entities": "^2.0.0"
-            },
-            "dependencies": {
-                "entities": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-                    "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
-                }
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.2",
+                "entities": "^4.2.0"
             }
         },
         "domain-browser": {
@@ -26261,11 +26252,11 @@
             }
         },
         "domhandler": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
-            "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+            "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
             "requires": {
-                "domelementtype": "^2.2.0"
+                "domelementtype": "^2.3.0"
             }
         },
         "dompurify": {
@@ -26274,13 +26265,13 @@
             "integrity": "sha512-jggCCd+8Iqp4Tsz0nIvpcb22InKEBrGz5dw3EQJMs8HPJDsKbFIO3STYtAvCfDx26Muevn1MHVI0XxjgFfmiSA=="
         },
         "domutils": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
-            "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+            "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
             "requires": {
-                "dom-serializer": "^1.0.1",
-                "domelementtype": "^2.2.0",
-                "domhandler": "^4.2.0"
+                "dom-serializer": "^2.0.0",
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.3"
             }
         },
         "duplexer": {
@@ -26408,9 +26399,9 @@
             }
         },
         "entities": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
-            "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q=="
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
         },
         "errno": {
             "version": "0.1.8",
@@ -28375,12 +28366,12 @@
             "dev": true
         },
         "html-dom-parser": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-1.2.0.tgz",
-            "integrity": "sha512-2HIpFMvvffsXHFUFjso0M9LqM+1Lm22BF+Df2ba+7QHJXjk63pWChEnI6YG27eaWqUdfnh5/Vy+OXrNTtepRsg==",
+            "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-5.0.8.tgz",
+            "integrity": "sha512-vuWiX9EXgu8CJ5m9EP5c7bvBmNSuQVnrY8tl0z0ZX96Uth1IPlYH/8W8VZ/hBajFf18EN+j2pukbCNd01HEd1w==",
             "requires": {
-                "domhandler": "4.3.1",
-                "htmlparser2": "7.2.0"
+                "domhandler": "5.0.3",
+                "htmlparser2": "9.1.0"
             }
         },
         "html-encoding-sniffer": {
@@ -28398,25 +28389,25 @@
             "dev": true
         },
         "html-react-parser": {
-            "version": "1.4.14",
-            "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-1.4.14.tgz",
-            "integrity": "sha512-pxhNWGie8Y+DGDpSh8cTa0k3g8PsDcwlfolA+XxYo1AGDeB6e2rdlyv4ptU9bOTiZ2i3fID+6kyqs86MN0FYZQ==",
+            "version": "5.1.10",
+            "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-5.1.10.tgz",
+            "integrity": "sha512-gV22PvLij4wdEdtrZbGVC7Zy2OVWnQ0bYhX63S196ZRSx4+K0TuutCreHSXr+saUia8KeKB+2TYziVfijpH4Tw==",
             "requires": {
-                "domhandler": "4.3.1",
-                "html-dom-parser": "1.2.0",
-                "react-property": "2.0.0",
-                "style-to-js": "1.1.1"
+                "domhandler": "5.0.3",
+                "html-dom-parser": "5.0.8",
+                "react-property": "2.0.2",
+                "style-to-js": "1.1.12"
             }
         },
         "htmlparser2": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
-            "integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
+            "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
             "requires": {
-                "domelementtype": "^2.0.1",
-                "domhandler": "^4.2.2",
-                "domutils": "^2.8.0",
-                "entities": "^3.0.1"
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.3",
+                "domutils": "^3.1.0",
+                "entities": "^4.5.0"
             }
         },
         "http-proxy-agent": {
@@ -28582,9 +28573,9 @@
             "dev": true
         },
         "inline-style-parser": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
-            "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q=="
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.3.tgz",
+            "integrity": "sha512-qlD8YNDqyTKTyuITrDOffsl6Tdhv+UC4hcdAVuQsK4IMQ99nSgd1MIA/Q+jQYoh9r3hVUXhYh7urSRmXPkW04g=="
         },
         "internal-slot": {
             "version": "1.0.5",
@@ -33814,9 +33805,9 @@
             }
         },
         "react-property": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.0.tgz",
-            "integrity": "sha512-kzmNjIgU32mO4mmH5+iUyrqlpFQhF8K2k7eZ4fdLSOPFrD1XgEuSBv9LDEgxRXTMBqMd8ppT0x6TIzqE5pdGdw=="
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.2.tgz",
+            "integrity": "sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug=="
         },
         "react-tooltip": {
             "version": "5.10.5",
@@ -35051,19 +35042,19 @@
             "dev": true
         },
         "style-to-js": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.1.tgz",
-            "integrity": "sha512-RJ18Z9t2B02sYhZtfWKQq5uplVctgvjTfLWT7+Eb1zjUjIrWzX5SdlkwLGQozrqarTmEzJJ/YmdNJCUNI47elg==",
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.12.tgz",
+            "integrity": "sha512-tv+/FkgNYHI2fvCoBMsqPHh5xovwiw+C3X0Gfnss/Syau0Nr3IqGOJ9XiOYXoPnToHVbllKFf5qCNFJGwFg5mg==",
             "requires": {
-                "style-to-object": "0.3.0"
+                "style-to-object": "1.0.6"
             }
         },
         "style-to-object": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.3.0.tgz",
-            "integrity": "sha512-CzFnRRXhzWIdItT3OmF8SQfWyahHhjq3HwcMNCNLn+N7klOOqPjMeG/4JSu77D7ypZdGvSzvkrbyeTMizz2VrA==",
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.6.tgz",
+            "integrity": "sha512-khxq+Qm3xEyZfKd/y9L3oIWQimxuc4STrQKtQn8aSDRHb8mFgpukgX1hdzfrMEW6JCjyJ8p89x+IUMVnCBI1PA==",
             "requires": {
-                "inline-style-parser": "0.1.1"
+                "inline-style-parser": "0.2.3"
             }
         },
         "superagent": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hms-dbmi-bgm/shared-portal-components",
-    "version": "0.1.80",
+    "version": "0.1.81",
     "description": "Shared components used for DBMI/BGM portal(s).",
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
         "date-fns-tz": "^1.3.0",
         "dom-helpers": "^5.2.1",
         "dompurify": "^2.3.6",
-        "html-react-parser": "^1.2.8",
+        "html-react-parser": "^5.1.10",
         "js-md5": "^0.7.3",
         "jsdom": "^19.0.0",
         "jsonwebtoken": ">=7.4.0",

--- a/src/components/static-pages/StaticPageBase.js
+++ b/src/components/static-pages/StaticPageBase.js
@@ -73,13 +73,14 @@ const Wrapper = React.memo(function Wrapper(props){
     const toc = (context && context['table-of-contents']) || (tableOfContents && typeof tableOfContents === 'object' ? tableOfContents : null);
     const pageTitle = title || (context && context.title) || null;
     const tocExists = toc && toc.enabled !== false;
+    const tocDefaultExpanded = (toc && toc.expanded === true) || undefined;
 
     return (
         <div className="container" id="content">
             <div className="static-page row" key="wrapper">
                 { tocExists ? (
                     <div key="toc-wrapper" className="col-12 col-xl-3 order-1 order-xl-3">
-                        <TableOfContents pageTitle={pageTitle} fixedGridWidth={3} maxHeaderDepth={toc['header-depth'] || 6}
+                        <TableOfContents pageTitle={pageTitle} fixedGridWidth={3} maxHeaderDepth={toc['header-depth'] || 6} defaultExpanded={tocDefaultExpanded}
                             {..._.pick(props, 'navigate', 'windowWidth', 'windowHeight', 'context', 'href', 'registerWindowOnScrollHandler', 'fixedPositionBreakpoint')}
                             // skipDepth={1} includeTop={toc['include-top-link']} listStyleTypes={['none'].concat((toc && toc['list-styles']) || this.props.tocListStyles)}
                         />


### PR DESCRIPTION
- `html-react-parser` npm package upgrade from v1 to v5
- updates relevant TOC components for `page.json` schema [change](https://github.com/4dn-dcic/fourfront/commit/c5f53b830f905818d527631230d8dae4ec326973)