### PR TITLE
Improve object.CopyWrapper Security

### DIFF
--- a/es/components/browse/components/StackedBlockTable.js
+++ b/es/components/browse/components/StackedBlockTable.js
@@ -1,13 +1,23 @@
 import _extends from "@babel/runtime/helpers/extends";
-import _assertThisInitialized from "@babel/runtime/helpers/assertThisInitialized";
 import _classCallCheck from "@babel/runtime/helpers/classCallCheck";
 import _createClass from "@babel/runtime/helpers/createClass";
-import _inherits from "@babel/runtime/helpers/inherits";
 import _possibleConstructorReturn from "@babel/runtime/helpers/possibleConstructorReturn";
 import _getPrototypeOf from "@babel/runtime/helpers/getPrototypeOf";
+import _inherits from "@babel/runtime/helpers/inherits";
 import _defineProperty from "@babel/runtime/helpers/defineProperty";
-function _createSuper(Derived) { var hasNativeReflectConstruct = _isNativeReflectConstruct(); return function () { var Super = _getPrototypeOf(Derived), result; if (hasNativeReflectConstruct) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
+function _callSuper(_this, derived, args) {
+  derived = _getPrototypeOf(derived);
+  return _possibleConstructorReturn(_this, function () {
+    if (typeof Reflect === "undefined" || !Reflect.construct) return false;
+    if (Reflect.construct.sham) return false;
+    if (typeof Proxy === "function") return true;
+    try {
+      return !Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {}));
+    } catch (e) {
+      return false;
+    }
+  }() ? Reflect.construct(derived, args || [], _getPrototypeOf(_this).constructor) : derived.apply(_this, args));
+}
 import React from 'react';
 import PropTypes from 'prop-types';
 import memoize from 'memoize-one';
@@ -43,7 +53,9 @@ export function StackedBlockNameLabel(props) {
     className: "ext" + (accession ? ' is-accession' : '')
   }, accession ? /*#__PURE__*/React.createElement(object.CopyWrapper, {
     value: accession,
-    key: "copy-accession"
+    key: "copy-accession",
+    analyticsOnCopy: true,
+    maskAnalyticsValue: false
   }, accession || subtitle) : subtitle) : null);
 }
 StackedBlockNameLabel.propTypes = {
@@ -58,13 +70,12 @@ StackedBlockNameLabel.propTypes = {
 
 /** Name element to be put inside of StackedBlocks as the first child. */
 export var StackedBlockName = /*#__PURE__*/function (_React$PureComponent) {
-  _inherits(StackedBlockName, _React$PureComponent);
-  var _super = _createSuper(StackedBlockName);
   function StackedBlockName() {
     _classCallCheck(this, StackedBlockName);
-    return _super.apply(this, arguments);
+    return _callSuper(this, StackedBlockName, arguments);
   }
-  _createClass(StackedBlockName, [{
+  _inherits(StackedBlockName, _React$PureComponent);
+  return _createClass(StackedBlockName, [{
     key: "render",
     value: function render() {
       var _this$props = this.props,
@@ -86,7 +97,6 @@ export var StackedBlockName = /*#__PURE__*/function (_React$PureComponent) {
       }, label, children);
     }
   }]);
-  return StackedBlockName;
 }(React.PureComponent);
 
 /**
@@ -94,13 +104,12 @@ export var StackedBlockName = /*#__PURE__*/function (_React$PureComponent) {
  */
 _defineProperty(StackedBlockName, "Label", StackedBlockNameLabel);
 export var StackedBlockListViewMoreButton = /*#__PURE__*/function (_React$PureComponent2) {
-  _inherits(StackedBlockListViewMoreButton, _React$PureComponent2);
-  var _super2 = _createSuper(StackedBlockListViewMoreButton);
   function StackedBlockListViewMoreButton() {
     _classCallCheck(this, StackedBlockListViewMoreButton);
-    return _super2.apply(this, arguments);
+    return _callSuper(this, StackedBlockListViewMoreButton, arguments);
   }
-  _createClass(StackedBlockListViewMoreButton, [{
+  _inherits(StackedBlockListViewMoreButton, _React$PureComponent2);
+  return _createClass(StackedBlockListViewMoreButton, [{
     key: "render",
     value: function render() {
       var _this$props2 = this.props,
@@ -135,7 +144,6 @@ export var StackedBlockListViewMoreButton = /*#__PURE__*/function (_React$PureCo
       }, " ", showMoreExtTitle) : null);
     }
   }]);
-  return StackedBlockListViewMoreButton;
 }(React.PureComponent);
 
 /**
@@ -151,24 +159,23 @@ _defineProperty(StackedBlockListViewMoreButton, "propTypes", {
 });
 
 export var StackedBlockList = /*#__PURE__*/function (_React$PureComponent3) {
-  _inherits(StackedBlockList, _React$PureComponent3);
-  var _super3 = _createSuper(StackedBlockList);
   function StackedBlockList(props) {
-    var _this;
+    var _this2;
     _classCallCheck(this, StackedBlockList);
-    _this = _super3.call(this, props);
-    _this.adjustedChildren = _this.adjustedChildren.bind(_assertThisInitialized(_this));
-    _this.handleCollapseToggle = _this.handleCollapseToggle.bind(_assertThisInitialized(_this));
-    _this.state = {
+    _this2 = _callSuper(this, StackedBlockList, [props]);
+    _this2.adjustedChildren = _this2.adjustedChildren.bind(_this2);
+    _this2.handleCollapseToggle = _this2.handleCollapseToggle.bind(_this2);
+    _this2.state = {
       'collapsed': props.defaultCollapsed,
       'incrementalExpandVisibleCount': props.collapseShow
     };
-    return _this;
+    return _this2;
   }
-  _createClass(StackedBlockList, [{
+  _inherits(StackedBlockList, _React$PureComponent3);
+  return _createClass(StackedBlockList, [{
     key: "adjustedChildren",
     value: function adjustedChildren() {
-      var _this2 = this;
+      var _this3 = this;
       var _this$props3 = this.props,
         children = _this$props3.children,
         stackDepth = _this$props3.stackDepth,
@@ -187,12 +194,12 @@ export var StackedBlockList = /*#__PURE__*/function (_React$PureComponent3) {
 
         _.forEach(['collapseLongLists', 'collapseLimit', 'collapseShow', 'defaultCollapsed', 'incrementalExpandLimit'], function (prop) {
           if (typeof c.props[prop] === 'undefined') {
-            childProps[prop] = _this2.props[prop] || null;
+            childProps[prop] = _this3.props[prop] || null;
           }
         });
-        _.forEach(_.keys(_this2.props), function (prop) {
+        _.forEach(_.keys(_this3.props), function (prop) {
           if (typeof c.props[prop] === 'undefined' && typeof childProps[prop] === 'undefined' && !StackedBlock.excludedPassedProps.has(prop)) {
-            childProps[prop] = _this2.props[prop];
+            childProps[prop] = _this3.props[prop];
           }
         });
         return /*#__PURE__*/React.cloneElement(c, childProps, c.props.children);
@@ -302,7 +309,6 @@ export var StackedBlockList = /*#__PURE__*/function (_React$PureComponent3) {
       }, children.slice(0, collapseShow), collapsibleChildrenElemsList, viewMoreButton);
     }
   }]);
-  return StackedBlockList;
 }(React.PureComponent);
 _defineProperty(StackedBlockList, "ViewMoreButton", StackedBlockListViewMoreButton);
 _defineProperty(StackedBlockList, "propTypes", {
@@ -318,19 +324,18 @@ _defineProperty(StackedBlockList, "propTypes", {
   'incrementalExpandStep': PropTypes.number
 });
 export var StackedBlock = /*#__PURE__*/function (_React$PureComponent4) {
-  _inherits(StackedBlock, _React$PureComponent4);
-  var _super4 = _createSuper(StackedBlock);
   function StackedBlock(props) {
-    var _this3;
+    var _this4;
     _classCallCheck(this, StackedBlock);
-    _this3 = _super4.call(this, props);
-    _this3.adjustedChildren = _this3.adjustedChildren.bind(_assertThisInitialized(_this3));
-    return _this3;
+    _this4 = _callSuper(this, StackedBlock, [props]);
+    _this4.adjustedChildren = _this4.adjustedChildren.bind(_this4);
+    return _this4;
   }
-  _createClass(StackedBlock, [{
+  _inherits(StackedBlock, _React$PureComponent4);
+  return _createClass(StackedBlock, [{
     key: "adjustedChildren",
     value: function adjustedChildren() {
-      var _this4 = this;
+      var _this5 = this;
       var _this$props5 = this.props,
         children = _this$props5.children,
         columnClass = _this$props5.columnClass,
@@ -356,12 +361,12 @@ export var StackedBlock = /*#__PURE__*/function (_React$PureComponent4) {
 
         _.forEach(['collapseLongLists', 'collapseLimit', 'collapseShow', 'defaultCollapsed', 'preventExpand', 'incrementalExpandLimit'], function (prop) {
           if (typeof c.props[prop] === 'undefined') {
-            childProps[prop] = _this4.props[prop];
+            childProps[prop] = _this5.props[prop];
           }
         });
-        _.forEach(_.keys(_this4.props), function (prop) {
+        _.forEach(_.keys(_this5.props), function (prop) {
           if (typeof c.props[prop] === 'undefined' && typeof childProps[prop] === 'undefined' && !StackedBlock.excludedPassedProps.has(prop)) {
-            childProps[prop] = _this4.props[prop];
+            childProps[prop] = _this5.props[prop];
           }
         });
         if (_.keys(childProps).length > 0) {
@@ -385,7 +390,6 @@ export var StackedBlock = /*#__PURE__*/function (_React$PureComponent4) {
       }, this.adjustedChildren());
     }
   }]);
-  return StackedBlock;
 }(React.PureComponent);
 
 /**
@@ -403,24 +407,23 @@ _defineProperty(StackedBlock, "List", StackedBlockList);
 /** TODO MAYBE USE HERE & ON LIST */
 _defineProperty(StackedBlock, "excludedPassedProps", new Set(['stripe', 'hideNameOnHover', 'keepLabelOnHover', 'className', 'children', 'showMoreExtTitle']));
 export var StackedBlockTable = /*#__PURE__*/function (_React$PureComponent5) {
-  _inherits(StackedBlockTable, _React$PureComponent5);
-  var _super5 = _createSuper(StackedBlockTable);
   function StackedBlockTable(props) {
-    var _this5;
+    var _this6;
     _classCallCheck(this, StackedBlockTable);
-    _this5 = _super5.call(this, props);
-    _this5.adjustedChildren = _this5.adjustedChildren.bind(_assertThisInitialized(_this5));
-    _this5.setCollapsingState = _.throttle(_this5.setCollapsingState.bind(_assertThisInitialized(_this5)));
-    _this5.memoized = {
+    _this6 = _callSuper(this, StackedBlockTable, [props]);
+    _this6.adjustedChildren = _this6.adjustedChildren.bind(_this6);
+    _this6.setCollapsingState = _.throttle(_this6.setCollapsingState.bind(_this6));
+    _this6.memoized = {
       totalColumnsMinWidth: memoize(StackedBlockTable.totalColumnsMinWidth),
       colWidthStyles: memoize(StackedBlockTable.colWidthStyles)
     };
-    _this5.state = {
+    _this6.state = {
       'mounted': false
     };
-    return _this5;
+    return _this6;
   }
-  _createClass(StackedBlockTable, [{
+  _inherits(StackedBlockTable, _React$PureComponent5);
+  return _createClass(StackedBlockTable, [{
     key: "componentDidMount",
     value: function componentDidMount() {
       this.setState({
@@ -437,7 +440,7 @@ export var StackedBlockTable = /*#__PURE__*/function (_React$PureComponent5) {
   }, {
     key: "adjustedChildren",
     value: function adjustedChildren() {
-      var _this6 = this;
+      var _this7 = this;
       var _this$props7 = this.props,
         children = _this$props7.children,
         columnHeaders = _this$props7.columnHeaders,
@@ -445,7 +448,7 @@ export var StackedBlockTable = /*#__PURE__*/function (_React$PureComponent5) {
       var colWidthStyles = this.memoized.colWidthStyles(columnHeaders, defaultInitialColumnWidth);
       return React.Children.map(children, function (c) {
         // Includes handleFileCheckboxChange, selectedFiles, etc. if present
-        var addedProps = _.omit(_this6.props, 'columnHeaders', 'stackDepth', 'colWidthStyles', 'width');
+        var addedProps = _.omit(_this7.props, 'columnHeaders', 'stackDepth', 'colWidthStyles', 'width');
 
         // REQUIRED & PASSED DOWN TO STACKEDBLOCKLIST
         addedProps.colWidthStyles = colWidthStyles;
@@ -537,7 +540,6 @@ export var StackedBlockTable = /*#__PURE__*/function (_React$PureComponent5) {
       return retObj;
     }
   }]);
-  return StackedBlockTable;
 }(React.PureComponent);
 _defineProperty(StackedBlockTable, "StackedBlock", StackedBlock);
 _defineProperty(StackedBlockTable, "propTypes", {

--- a/es/components/util/object.js
+++ b/es/components/util/object.js
@@ -1,15 +1,25 @@
 import _toConsumableArray from "@babel/runtime/helpers/toConsumableArray";
 import _classCallCheck from "@babel/runtime/helpers/classCallCheck";
 import _createClass from "@babel/runtime/helpers/createClass";
-import _assertThisInitialized from "@babel/runtime/helpers/assertThisInitialized";
-import _inherits from "@babel/runtime/helpers/inherits";
 import _possibleConstructorReturn from "@babel/runtime/helpers/possibleConstructorReturn";
 import _getPrototypeOf from "@babel/runtime/helpers/getPrototypeOf";
+import _inherits from "@babel/runtime/helpers/inherits";
 import _slicedToArray from "@babel/runtime/helpers/slicedToArray";
 import _extends from "@babel/runtime/helpers/extends";
 import _typeof from "@babel/runtime/helpers/typeof";
-function _createSuper(Derived) { var hasNativeReflectConstruct = _isNativeReflectConstruct(); return function () { var Super = _getPrototypeOf(Derived), result; if (hasNativeReflectConstruct) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
+function _callSuper(_this, derived, args) {
+  derived = _getPrototypeOf(derived);
+  return _possibleConstructorReturn(_this, function () {
+    if (typeof Reflect === "undefined" || !Reflect.construct) return false;
+    if (Reflect.construct.sham) return false;
+    if (typeof Proxy === "function") return true;
+    try {
+      return !Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {}));
+    } catch (e) {
+      return false;
+    }
+  }() ? Reflect.construct(derived, args || [], _getPrototypeOf(_this).constructor) : derived.apply(_this, args));
+}
 function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it["return"] != null) it["return"](); } finally { if (didErr) throw err; } } }; }
 function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
 function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
@@ -544,22 +554,21 @@ TooltipInfoIconContainerAuto.propTypes = {
  * @prop {string|React.Component} [wrapperElement='div'] - Element type to wrap props.children in, if any.
  */
 export var CopyWrapper = /*#__PURE__*/function (_React$PureComponent) {
-  _inherits(CopyWrapper, _React$PureComponent);
-  var _super = _createSuper(CopyWrapper);
   function CopyWrapper(props) {
-    var _this;
+    var _this2;
     _classCallCheck(this, CopyWrapper);
-    _this = _super.call(this, props);
-    _this.flashEffect = _this.flashEffect.bind(_assertThisInitialized(_this));
+    _this2 = _callSuper(this, CopyWrapper, [props]);
+    _this2.flashEffect = _this2.flashEffect.bind(_this2);
     if (typeof props.mounted !== 'boolean') {
-      _this.state = {
+      _this2.state = {
         'mounted': false
       };
     }
-    _this.wrapperRef = /*#__PURE__*/React.createRef();
-    return _this;
+    _this2.wrapperRef = /*#__PURE__*/React.createRef();
+    return _this2;
   }
-  _createClass(CopyWrapper, [{
+  _inherits(CopyWrapper, _React$PureComponent);
+  return _createClass(CopyWrapper, [{
     key: "componentDidMount",
     value: function componentDidMount() {
       var mounted = this.props.mounted;
@@ -606,7 +615,7 @@ export var CopyWrapper = /*#__PURE__*/function (_React$PureComponent) {
   }, {
     key: "render",
     value: function render() {
-      var _this2 = this;
+      var _this3 = this;
       var _this$props2 = this.props,
         value = _this$props2.value,
         children = _this$props2.children,
@@ -616,7 +625,10 @@ export var CopyWrapper = /*#__PURE__*/function (_React$PureComponent) {
         includeIcon = _this$props2.includeIcon,
         className = _this$props2.className,
         stopPropagation = _this$props2.stopPropagation,
-        whitespace = _this$props2.whitespace;
+        whitespace = _this$props2.whitespace,
+        analyticsOnCopy = _this$props2.analyticsOnCopy,
+        _this$props2$maskAnal = _this$props2.maskAnalyticsValue,
+        maskAnalyticsValue = _this$props2$maskAnal === void 0 ? true : _this$props2$maskAnal;
       if (!value) return null;
 
       // eslint-disable-next-line react/destructuring-assignment
@@ -641,13 +653,13 @@ export var CopyWrapper = /*#__PURE__*/function (_React$PureComponent) {
             e.stopPropagation();
           }
           CopyWrapper.copyToClipboard(value, function (v) {
-            _this2.onCopy();
-            analytics.event('copy_wrapper', 'CopyWrapper', 'Copy', null, {
-              'value': v
+            _this3.onCopy();
+            analyticsOnCopy && analytics.event('copy_wrapper', 'CopyWrapper', 'Copy', null, {
+              'value': maskAnalyticsValue ? '[value_is_masked]' : v
             });
           }, function (v) {
-            analytics.event('copy_wrapper', 'CopyWrapper', 'ERROR', null, {
-              'value': v
+            analyticsOnCopy && analytics.event('copy_wrapper', 'CopyWrapper', 'ERROR', null, {
+              'value': maskAnalyticsValue ? '[value_is_masked]' : v
             });
           });
         }
@@ -696,7 +708,6 @@ export var CopyWrapper = /*#__PURE__*/function (_React$PureComponent) {
       }
     }
   }]);
-  return CopyWrapper;
 }(React.PureComponent);
 CopyWrapper.defaultProps = {
   'wrapperElement': 'div',
@@ -706,7 +717,10 @@ CopyWrapper.defaultProps = {
   'includeIcon': true,
   'whitespace': true,
   'flashActiveTransform': 'scale3d(1.2, 1.2, 1.2) translate3d(0, 0, 0)',
-  'flashInactiveTransform': 'translate3d(0, 0, 0)'
+  'flashInactiveTransform': 'translate3d(0, 0, 0)',
+  'analyticsOnCopy': false,
+  // false: never trigger analytics event (default)
+  'maskAnalyticsValue': true // true: never send the actual value, send a placeholder instead (default)
 };
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@hms-dbmi-bgm/shared-portal-components",
-    "version": "0.1.83",
+    "version": "0.1.84",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@hms-dbmi-bgm/shared-portal-components",
-            "version": "0.1.83",
+            "version": "0.1.84",
             "license": "MIT",
             "dependencies": {
                 "@4dn-dcic/react-infinite": "github:4dn-dcic/react-infinite#1.1.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hms-dbmi-bgm/shared-portal-components",
-    "version": "0.1.83",
+    "version": "0.1.84",
     "description": "Shared components used for DBMI/BGM portal(s).",
     "repository": {
         "type": "git",

--- a/src/components/browse/components/StackedBlockTable.js
+++ b/src/components/browse/components/StackedBlockTable.js
@@ -35,7 +35,9 @@ export function StackedBlockNameLabel(props){
             { subtitle || accession ?
                 <div className={"ext" + (accession ? ' is-accession' : '')}>
                     { accession ?
-                        <object.CopyWrapper value={accession} key="copy-accession">{ accession || subtitle }</object.CopyWrapper>
+                        <object.CopyWrapper value={accession} key="copy-accession" analyticsOnCopy maskAnalyticsValue={false}>
+                            {accession || subtitle}
+                        </object.CopyWrapper>
                         : subtitle }
                 </div>
                 : null }

--- a/src/components/util/object.js
+++ b/src/components/util/object.js
@@ -639,7 +639,7 @@ export class CopyWrapper extends React.PureComponent {
     }
 
     render(){
-        const { value, children, mounted, wrapperElement, iconProps, includeIcon, className, stopPropagation, whitespace } = this.props;
+        const { value, children, mounted, wrapperElement, iconProps, includeIcon, className, stopPropagation, whitespace, analyticsOnCopy, maskAnalyticsValue=true } = this.props;
         if (!value) return null;
 
         // eslint-disable-next-line react/destructuring-assignment
@@ -652,9 +652,9 @@ export class CopyWrapper extends React.PureComponent {
 
             CopyWrapper.copyToClipboard(value, (v)=>{
                 this.onCopy();
-                analytics.event('copy_wrapper', 'CopyWrapper', 'Copy', null, { 'value' : v });
+                analyticsOnCopy && analytics.event('copy_wrapper', 'CopyWrapper', 'Copy', null, { 'value' : maskAnalyticsValue ? '[value_is_masked]' : v });
             }, (v)=>{
-                analytics.event('copy_wrapper', 'CopyWrapper', 'ERROR', null, { 'value' : v });
+                analyticsOnCopy && analytics.event('copy_wrapper', 'CopyWrapper', 'ERROR', null, { 'value' : maskAnalyticsValue ? '[value_is_masked]' : v });
             });
         };
 
@@ -684,7 +684,9 @@ CopyWrapper.defaultProps = {
     'includeIcon' : true,
     'whitespace': true,
     'flashActiveTransform' : 'scale3d(1.2, 1.2, 1.2) translate3d(0, 0, 0)',
-    'flashInactiveTransform' : 'translate3d(0, 0, 0)'
+    'flashInactiveTransform' : 'translate3d(0, 0, 0)',
+    'analyticsOnCopy': false, // false: never trigger analytics event (default)
+    'maskAnalyticsValue': true // true: never send the actual value, send a placeholder instead (default)
 };
 
 


### PR DESCRIPTION
Trello: https://trello.com/c/lRpSoh4o

`object.CopyWrapper` is currently sending analytics data into GA4 property. It includes copied value and it makes a security breach if sensitive data is wrapped. Two new props are added to improve security:

- `analyticsOnCopy: bool` // trigger analytics event (default is false)
- `maskAnalyticsValue: bool` // send the actual value (false) or send a placeholder instead (true - default)