### PR TITLE
Bug Fix - Table of Content props.children handling

### DIFF
--- a/es/components/static-pages/TableOfContents.js
+++ b/es/components/static-pages/TableOfContents.js
@@ -233,7 +233,7 @@ var TableEntry = /*#__PURE__*/function (_React$Component) {
 }(React.Component);
 _defineProperty(TableEntry, "getChildHeaders", memoize(function (content, maxHeaderDepth, currentDepth) {
   if (!TableOfContents.isContentJSX(content) || !content.props || !content.props.children) return [];
-  return content.props.children.filter(function (child) {
+  return React.Children.toArray(content.props.children).filter(function (child) {
     return TableOfContents.isHeaderComponent(child, maxHeaderDepth || 6) && child.props.type === 'h' + (currentDepth + 1);
   });
 }));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@hms-dbmi-bgm/shared-portal-components",
-    "version": "0.1.89",
+    "version": "0.1.90",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@hms-dbmi-bgm/shared-portal-components",
-            "version": "0.1.89",
+            "version": "0.1.90",
             "license": "MIT",
             "dependencies": {
                 "@4dn-dcic/react-infinite": "github:4dn-dcic/react-infinite#1.1.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hms-dbmi-bgm/shared-portal-components",
-    "version": "0.1.89",
+    "version": "0.1.90",
     "description": "Shared components used for DBMI/BGM portal(s).",
     "repository": {
         "type": "git",

--- a/src/components/static-pages/TableOfContents.js
+++ b/src/components/static-pages/TableOfContents.js
@@ -13,7 +13,7 @@ class TableEntry extends React.Component {
 
     static getChildHeaders = memoize(function(content, maxHeaderDepth, currentDepth){
         if (!TableOfContents.isContentJSX(content) || !content.props || !content.props.children) return [];
-        return content.props.children.filter(function(child,i,a){
+        return React.Children.toArray(content.props.children).filter(function(child,i,a){
             return TableOfContents.isHeaderComponent(child, maxHeaderDepth || 6) && (child.props.type === 'h' + (currentDepth + 1));
         });
     });


### PR DESCRIPTION
This fixes the "`props.children` used to be an array" assumption and converts non-array children to arrays before iterating through them.