### PR TITLE
LocalizedTime UTC Updates

### DIFF
--- a/es/components/ui/LocalizedTime.js
+++ b/es/components/ui/LocalizedTime.js
@@ -29,11 +29,16 @@ export var LocalizedTime = /*#__PURE__*/function (_React$Component) {
     _classCallCheck(this, LocalizedTime);
     _this2 = _callSuper(this, LocalizedTime, [props]);
     _this2.memoized = {
-      getDateFns: memoize(function (dateFnsDate, timestamp) {
-        var parsedTime = zonedTimeToUtc(timestamp);
-        // console.log("parsedTime", parsedTime);
+      getDateFns: memoize(function (dateFnsDate, timestamp, localize) {
         if (dateFnsDate) return dateFnsDate;
-        if (timestamp) return parsedTime;
+        if (timestamp) {
+          var d = zonedTimeToUtc(timestamp);
+          // shift the date to the local timezone if it is not zoned
+          if (!LocalizedTime.isZoned(timestamp) && !localize) {
+            d = new Date(d.getTime() + d.getTimezoneOffset() * 60000);
+          }
+          return d;
+        }
         return new Date();
       })
     };
@@ -62,7 +67,7 @@ export var LocalizedTime = /*#__PURE__*/function (_React$Component) {
         dateFnsDate = _this$props.dateFnsDate,
         timestamp = _this$props.timestamp;
       var mounted = this.state.mounted;
-      var selfDateFns = this.memoized.getDateFns(dateFnsDate, timestamp);
+      var selfDateFns = this.memoized.getDateFns(dateFnsDate, timestamp, localize);
       if (!mounted || isServerSide()) {
         return /*#__PURE__*/React.createElement("span", {
           className: className + ' utc',
@@ -74,6 +79,14 @@ export var LocalizedTime = /*#__PURE__*/function (_React$Component) {
           suppressHydrationWarning: true
         }, display(selfDateFns, formatType, dateTimeSeparator, localize, customOutputFormat));
       }
+    }
+  }], [{
+    key: "isZoned",
+    value:
+    // Function to check if the date string contains timezone information
+    function isZoned(dateString) {
+      // Checks if the string ends with "Z" or an offset (+HH:mm or -HH:mm)
+      return /Z$|[+-]\d{2}:\d{2}$/.test(dateString);
     }
   }]);
 }(React.Component);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@hms-dbmi-bgm/shared-portal-components",
-    "version": "0.1.94",
+    "version": "0.1.95",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@hms-dbmi-bgm/shared-portal-components",
-            "version": "0.1.94",
+            "version": "0.1.95",
             "license": "MIT",
             "dependencies": {
                 "@4dn-dcic/react-infinite": "github:4dn-dcic/react-infinite#1.1.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hms-dbmi-bgm/shared-portal-components",
-    "version": "0.1.94",
+    "version": "0.1.95",
     "description": "Shared components used for DBMI/BGM portal(s).",
     "repository": {
         "type": "git",


### PR DESCRIPTION
Neutralize `date-fns'`s UTC adjustments for date time input lacks timezone.

For instance, if we have string literal `2025-01-01` as input and need to display it as `2025-01-01` using `LocalizedTime`, it is displayed as `2024-12-31` in GMT- time zones, whereas in GMT+ time zones it remains `2025-01-01`. Even though the represented datetime object is correct, the displayed date misleads users, particularly in facet date range components.