### PR TITLE
Add normalizeQueryValuesForStringify function and update version

### DIFF
--- a/es/components/browse/components/SearchResultTable.js
+++ b/es/components/browse/components/SearchResultTable.js
@@ -6,6 +6,7 @@ import _getPrototypeOf from "@babel/runtime/helpers/getPrototypeOf";
 import _inherits from "@babel/runtime/helpers/inherits";
 import _defineProperty from "@babel/runtime/helpers/defineProperty";
 import _extends from "@babel/runtime/helpers/extends";
+import _typeof from "@babel/runtime/helpers/typeof";
 var _excluded = ["columnDefinitions", "mounted", "columnWidths", "windowWidth", "defaultColAlignment"];
 function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); enumerableOnly && (symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; })), keys.push.apply(keys, symbols); } return keys; }
 function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = null != arguments[i] ? arguments[i] : {}; i % 2 ? ownKeys(Object(source), !0).forEach(function (key) { _defineProperty(target, key, source[key]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)) : ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } return target; }
@@ -46,6 +47,15 @@ import { ResultRowColumnBlockValue } from './table-commons/ResultRowColumnBlockV
 import { columnsToColumnDefinitions, getColumnWidthFromDefinition } from './table-commons/ColumnCombiner';
 import { HeadersRow } from './table-commons/HeadersRow';
 import { basicColumnExtensionMap } from './table-commons/basicColumnExtensionMap';
+function normalizeQueryValuesForStringify() {
+  var query = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+  return _.mapObject(query, function (value) {
+    if (value && _typeof(value) === 'object' && !Array.isArray(value) && !(value instanceof Date)) {
+      return _.values(value);
+    }
+    return value;
+  });
+}
 var ResultRowColumnBlock = /*#__PURE__*/React.memo(function (props) {
   var columnDefinition = props.columnDefinition,
     columnNumber = props.columnNumber,
@@ -565,7 +575,7 @@ var LoadMoreAsYouScroll = /*#__PURE__*/function (_React$Component) {
       if (!origCompoundFilterSet) {
         // Assumed href/string request
         var parts = url.parse(origHref, true); // memoizedUrlParse not used in case is EmbeddedSearchView.
-        var query = parts.query;
+        var query = normalizeQueryValuesForStringify(parts.query);
         query.from = nextFromValue;
         parts.search = '?' + queryString.stringify(query);
         nextHref = url.format(parts);

--- a/es/components/util/search-filters.js
+++ b/es/components/util/search-filters.js
@@ -1,6 +1,6 @@
-import _typeof from "@babel/runtime/helpers/typeof";
 import _toConsumableArray from "@babel/runtime/helpers/toConsumableArray";
 import _slicedToArray from "@babel/runtime/helpers/slicedToArray";
+import _typeof from "@babel/runtime/helpers/typeof";
 function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it["return"] != null) it["return"](); } finally { if (didErr) throw err; } } }; }
 function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
 function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
@@ -11,6 +11,18 @@ import url from 'url';
 import queryString from 'query-string';
 import { navigate } from './navigate';
 import { isServerSide } from './misc';
+function normalizeQueryValueToArray(value) {
+  if (Array.isArray(value)) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    return [value];
+  }
+  if (value && _typeof(value) === 'object') {
+    return _.values(value);
+  }
+  return [];
+}
 
 /**
  * @deprecated
@@ -253,8 +265,8 @@ export function buildSearchHref(field, term, searchBase) {
   if (term.terms && Array.isArray(term.terms)) {
     if (!(field in query)) {
       query[field] = [];
-    } else if (typeof query[field] === 'string') {
-      query[field] = [query[field]];
+    } else {
+      query[field] = normalizeQueryValueToArray(query[field]);
     }
     var fieldClear = null;
     if (field.endsWith('!')) {
@@ -271,8 +283,8 @@ export function buildSearchHref(field, term, searchBase) {
       }
     }
     //convert query param to array
-    if (fieldClear && typeof query[fieldClear] === 'string') {
-      query[fieldClear] = [query[fieldClear]];
+    if (fieldClear) {
+      query[fieldClear] = normalizeQueryValueToArray(query[fieldClear]);
     }
     term.terms.forEach(function (t) {
       //add all sub terms into query
@@ -290,11 +302,7 @@ export function buildSearchHref(field, term, searchBase) {
   } else {
     //term is a regular term, has no sub terms
     if (field in query) {
-      if (Array.isArray(query[field])) {
-        query[field] = query[field].concat(term.key);
-      } else {
-        query[field] = [query[field]].concat(term.key);
-      }
+      query[field] = normalizeQueryValueToArray(query[field]).concat(term.key);
     } else {
       query[field] = term.key;
     }

--- a/es/components/util/search-filters.js
+++ b/es/components/util/search-filters.js
@@ -11,6 +11,10 @@ import url from 'url';
 import queryString from 'query-string';
 import { navigate } from './navigate';
 import { isServerSide } from './misc';
+
+// Browserified `url.parse(..., true)` can return object-shaped values for repeated
+// query params once `qs` array limits are exceeded. Normalize them before any
+// facet mutation logic that expects arrays of selected terms.
 function normalizeQueryValueToArray(value) {
   if (Array.isArray(value)) {
     return value;
@@ -22,6 +26,18 @@ function normalizeQueryValueToArray(value) {
     return _.values(value);
   }
   return [];
+}
+
+// `query-string.stringify` will serialize object values as `[object Object]`.
+// Convert any object-shaped repeated params back into arrays before stringifying.
+function normalizeQueryValuesForStringify() {
+  var query = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+  return _.mapObject(query, function (value) {
+    if (value && _typeof(value) === 'object' && !Array.isArray(value)) {
+      return _.values(value);
+    }
+    return value;
+  });
 }
 
 /**
@@ -107,7 +123,7 @@ export function getUnselectHrefIfSelectedFromResponseFilters(term, facet, filter
           }
         }
       });
-      retHref = '?' + queryString.stringify(commonQs);
+      retHref = '?' + queryString.stringify(normalizeQueryValuesForStringify(commonQs));
       if (includePathName) {
         retHref += partsFrom.pathname;
       }
@@ -234,7 +250,7 @@ export function getStatusAndUnselectHrefIfSelectedOrOmittedFromResponseFilters(t
           return t.key === v;
         });
       });
-      retHref += '?' + queryString.stringify(cloned);
+      retHref += '?' + queryString.stringify(normalizeQueryValuesForStringify(cloned));
     } else {
       retHref += parts.search;
     }
@@ -302,12 +318,17 @@ export function buildSearchHref(field, term, searchBase) {
   } else {
     //term is a regular term, has no sub terms
     if (field in query) {
+      // Preserve repeated params as arrays even if the parser materialized
+      // them as an object due to the `qs` array limit behavior.
       query[field] = normalizeQueryValueToArray(query[field]).concat(term.key);
     } else {
       query[field] = term.key;
     }
   }
-  var queryStr = queryString.stringify(query);
+
+  // Normalize untouched repeated params from other fields as well before
+  // serializing, otherwise they can become `[object Object]` in the URL.
+  var queryStr = queryString.stringify(normalizeQueryValuesForStringify(query));
   parts.search = queryStr && queryStr.length > 0 ? '?' + queryStr : '';
   return url.format(parts);
 }
@@ -712,7 +733,7 @@ function getBaseHref() {
       hrefQuery.type = 'Item';
     }
   }
-  return baseHref + (_.keys(hrefQuery).length > 0 ? '?' + queryString.stringify(hrefQuery) : '');
+  return baseHref + (_.keys(hrefQuery).length > 0 ? '?' + queryString.stringify(normalizeQueryValuesForStringify(hrefQuery)) : '');
 }
 export function searchQueryStringFromHref(href) {
   if (!href) return null;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@hms-dbmi-bgm/shared-portal-components",
-    "version": "0.1.96",
+    "version": "0.1.97",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@hms-dbmi-bgm/shared-portal-components",
-            "version": "0.1.96",
+            "version": "0.1.97",
             "license": "MIT",
             "dependencies": {
                 "@4dn-dcic/react-infinite": "github:4dn-dcic/react-infinite#1.1.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hms-dbmi-bgm/shared-portal-components",
-    "version": "0.1.96",
+    "version": "0.1.97",
     "description": "Shared components used for DBMI/BGM portal(s).",
     "repository": {
         "type": "git",

--- a/src/components/browse/components/SearchResultTable.js
+++ b/src/components/browse/components/SearchResultTable.js
@@ -26,6 +26,21 @@ import { HeadersRow } from './table-commons/HeadersRow';
 import { basicColumnExtensionMap } from './table-commons/basicColumnExtensionMap';
 
 
+function normalizeQueryValuesForStringify(query = {}){
+    return _.mapObject(query, function(value){
+        if (
+            value &&
+            typeof value === 'object' &&
+            !Array.isArray(value) &&
+            !(value instanceof Date)
+        ) {
+            return _.values(value);
+        }
+        return value;
+    });
+}
+
+
 const ResultRowColumnBlock = React.memo(function ResultRowColumnBlock(props){
     const { columnDefinition, columnNumber, width, defaultColAlignment } = props;
     const { field } = columnDefinition;
@@ -542,7 +557,7 @@ class LoadMoreAsYouScroll extends React.Component {
         let nextCompoundFilterSetRequest = null;
         if (!origCompoundFilterSet) { // Assumed href/string request
             const parts = url.parse(origHref, true); // memoizedUrlParse not used in case is EmbeddedSearchView.
-            const { query } = parts;
+            const query = normalizeQueryValuesForStringify(parts.query);
             query.from = nextFromValue;
             parts.search = '?' + queryString.stringify(query);
             nextHref = url.format(parts);

--- a/src/components/util/search-filters.js
+++ b/src/components/util/search-filters.js
@@ -8,6 +8,9 @@ import { navigate } from './navigate';
 import { isServerSide } from './misc';
 
 
+// Browserified `url.parse(..., true)` can return object-shaped values for repeated
+// query params once `qs` array limits are exceeded. Normalize them before any
+// facet mutation logic that expects arrays of selected terms.
 function normalizeQueryValueToArray(value){
     if (Array.isArray(value)) {
         return value;
@@ -19,6 +22,17 @@ function normalizeQueryValueToArray(value){
         return _.values(value);
     }
     return [];
+}
+
+// `query-string.stringify` will serialize object values as `[object Object]`.
+// Convert any object-shaped repeated params back into arrays before stringifying.
+function normalizeQueryValuesForStringify(query = {}){
+    return _.mapObject(query, function(value){
+        if (value && typeof value === 'object' && !Array.isArray(value)) {
+            return _.values(value);
+        }
+        return value;
+    });
 }
 
 
@@ -99,7 +113,7 @@ export function getUnselectHrefIfSelectedFromResponseFilters(term, facet, filter
                 }
             });
 
-            retHref = '?' + queryString.stringify(commonQs);
+            retHref = '?' + queryString.stringify(normalizeQueryValuesForStringify(commonQs));
             if (includePathName) {
                 retHref += partsFrom.pathname;
             }
@@ -200,7 +214,7 @@ export function getStatusAndUnselectHrefIfSelectedOrOmittedFromResponseFilters(t
             const tmp = Array.isArray(parts.query[facetField]) ? parts.query[facetField] : [parts.query[facetField]];
             const cloned = _.clone(parts.query);
             cloned[facetField] = _.filter(tmp, function (v) { return !_.any(term.terms, function (t) { return t.key === v; });});
-            retHref += '?' + queryString.stringify(cloned);
+            retHref += '?' + queryString.stringify(normalizeQueryValuesForStringify(cloned));
         } else {
             retHref += parts.search;
         }
@@ -265,13 +279,17 @@ export function buildSearchHref(field, term, searchBase){
     } else {
         //term is a regular term, has no sub terms
         if (field in query) {
+            // Preserve repeated params as arrays even if the parser materialized
+            // them as an object due to the `qs` array limit behavior.
             query[field] = normalizeQueryValueToArray(query[field]).concat(term.key);
         } else {
             query[field] = term.key;
         }
     }
 
-    const queryStr = queryString.stringify(query);
+    // Normalize untouched repeated params from other fields as well before
+    // serializing, otherwise they can become `[object Object]` in the URL.
+    const queryStr = queryString.stringify(normalizeQueryValuesForStringify(query));
     parts.search = queryStr && queryStr.length > 0 ? ('?' + queryStr) : '';
 
     return url.format(parts);
@@ -698,7 +716,7 @@ function getBaseHref(currentHref = '/browse/', hrefPath = null, requiredQs = {})
         }
     }
 
-    return baseHref + (_.keys(hrefQuery).length > 0 ? '?' + queryString.stringify(hrefQuery) : '');
+    return baseHref + (_.keys(hrefQuery).length > 0 ? '?' + queryString.stringify(normalizeQueryValuesForStringify(hrefQuery)) : '');
 }
 
 export function searchQueryStringFromHref(href){

--- a/src/components/util/search-filters.js
+++ b/src/components/util/search-filters.js
@@ -8,6 +8,20 @@ import { navigate } from './navigate';
 import { isServerSide } from './misc';
 
 
+function normalizeQueryValueToArray(value){
+    if (Array.isArray(value)) {
+        return value;
+    }
+    if (typeof value === 'string') {
+        return [value];
+    }
+    if (value && typeof value === 'object') {
+        return _.values(value);
+    }
+    return [];
+}
+
+
 /**
  * @deprecated
  * If the given term is selected, return the href for the term from context.filters.
@@ -212,8 +226,8 @@ export function buildSearchHref(field, term, searchBase){
     if (term.terms && Array.isArray(term.terms)) {
         if (!(field in query)) {
             query[field] = [];
-        } else if (typeof query[field] === 'string') {
-            query[field] = [query[field]];
+        } else {
+            query[field] = normalizeQueryValueToArray(query[field]);
         }
 
         let fieldClear = null;
@@ -231,8 +245,8 @@ export function buildSearchHref(field, term, searchBase){
             }
         }
         //convert query param to array
-        if (fieldClear && typeof query[fieldClear] === 'string') {
-            query[fieldClear] = [query[fieldClear]];
+        if (fieldClear) {
+            query[fieldClear] = normalizeQueryValueToArray(query[fieldClear]);
         }
 
         term.terms.forEach((t) => {
@@ -251,11 +265,7 @@ export function buildSearchHref(field, term, searchBase){
     } else {
         //term is a regular term, has no sub terms
         if (field in query) {
-            if (Array.isArray(query[field])) {
-                query[field] = query[field].concat(term.key);
-            } else {
-                query[field] = [query[field]].concat(term.key);
-            }
+            query[field] = normalizeQueryValueToArray(query[field]).concat(term.key);
         } else {
             query[field] = term.key;
         }
@@ -730,4 +740,3 @@ export function getSearchItemType(context){
     }
     return null;
 }
-


### PR DESCRIPTION
This pull request introduces a utility function to normalize query parameter values when generating URLs for paginated search results. This normalization ensures that object-type query values are converted to arrays, which helps prevent issues with URL stringification and navigation. The change is implemented in both the ES module and source files. The package version is also incremented.

Key changes:

**Query Parameter Normalization:**
* Added a `normalizeQueryValuesForStringify` function in both `es/components/browse/components/SearchResultTable.js` and `src/components/browse/components/SearchResultTable.js` to convert object-type query parameter values (excluding arrays and dates) into arrays for consistent URL stringification. [[1]](diffhunk://#diff-1c58ca0dfd8eb42953b998411003ea82fda546a24a0eb02397af742807e8ef5eR50-R58) [[2]](diffhunk://#diff-3f6a6c9c074a854cae1381cad63b04d566dd8f7bc9d5a5fbe0698ae0e13711f7R29-R43)
* Updated the logic in the `LoadMoreAsYouScroll` component to use `normalizeQueryValuesForStringify` when preparing the next page's URL, ensuring proper handling of query parameters during pagination. [[1]](diffhunk://#diff-1c58ca0dfd8eb42953b998411003ea82fda546a24a0eb02397af742807e8ef5eL568-R578) [[2]](diffhunk://#diff-3f6a6c9c074a854cae1381cad63b04d566dd8f7bc9d5a5fbe0698ae0e13711f7L545-R560)

**Dependency and Build Updates:**
* Bumped the package version from `0.1.96` to `0.1.97` in `package.json`.

**Build Artifacts:**
* Imported `_typeof` helper from Babel in the ES build to support the new normalization logic.