### PR TITLE
Add sorting functionality to Grouping Term and its children in FacetList

### DIFF
--- a/es/components/browse/components/FacetList/FacetTermsList.js
+++ b/es/components/browse/components/FacetList/FacetTermsList.js
@@ -1,26 +1,27 @@
-import _slicedToArray from "@babel/runtime/helpers/slicedToArray";
-import _objectWithoutProperties from "@babel/runtime/helpers/objectWithoutProperties";
-import _extends from "@babel/runtime/helpers/extends";
-import _classCallCheck from "@babel/runtime/helpers/classCallCheck";
-import _createClass from "@babel/runtime/helpers/createClass";
-import _possibleConstructorReturn from "@babel/runtime/helpers/possibleConstructorReturn";
-import _getPrototypeOf from "@babel/runtime/helpers/getPrototypeOf";
-import _inherits from "@babel/runtime/helpers/inherits";
-import _defineProperty from "@babel/runtime/helpers/defineProperty";
 var _excluded = ["count", "countActive", "height", "width", "ltr", "className"];
-function _callSuper(_this, derived, args) {
-  derived = _getPrototypeOf(derived);
-  return _possibleConstructorReturn(_this, function () {
-    if (typeof Reflect === "undefined" || !Reflect.construct) return false;
-    if (Reflect.construct.sham) return false;
-    if (typeof Proxy === "function") return true;
-    try {
-      return !Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {}));
-    } catch (e) {
-      return false;
-    }
-  }() ? Reflect.construct(derived, args || [], _getPrototypeOf(_this).constructor) : derived.apply(_this, args));
-}
+function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (obj) { return typeof obj; } : function (obj) { return obj && "function" == typeof Symbol && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }, _typeof(obj); }
+function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr, i) || _nonIterableRest(); }
+function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
+function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _iterableToArrayLimit(arr, i) { var _i = null == arr ? null : "undefined" != typeof Symbol && arr[Symbol.iterator] || arr["@@iterator"]; if (null != _i) { var _s, _e, _x, _r, _arr = [], _n = !0, _d = !1; try { if (_x = (_i = _i.call(arr)).next, 0 === i) { if (Object(_i) !== _i) return; _n = !1; } else for (; !(_n = (_s = _x.call(_i)).done) && (_arr.push(_s.value), _arr.length !== i); _n = !0); } catch (err) { _d = !0, _e = err; } finally { try { if (!_n && null != _i["return"] && (_r = _i["return"](), Object(_r) !== _r)) return; } finally { if (_d) throw _e; } } return _arr; } }
+function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
+function _objectWithoutProperties(source, excluded) { if (source == null) return {}; var target = _objectWithoutPropertiesLoose(source, excluded); var key, i; if (Object.getOwnPropertySymbols) { var sourceSymbolKeys = Object.getOwnPropertySymbols(source); for (i = 0; i < sourceSymbolKeys.length; i++) { key = sourceSymbolKeys[i]; if (excluded.indexOf(key) >= 0) continue; if (!Object.prototype.propertyIsEnumerable.call(source, key)) continue; target[key] = source[key]; } } return target; }
+function _objectWithoutPropertiesLoose(source, excluded) { if (source == null) return {}; var target = {}; var sourceKeys = Object.keys(source); var key, i; for (i = 0; i < sourceKeys.length; i++) { key = sourceKeys[i]; if (excluded.indexOf(key) >= 0) continue; target[key] = source[key]; } return target; }
+function _extends() { _extends = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, _toPropertyKey(descriptor.key), descriptor); } }
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); Object.defineProperty(Constructor, "prototype", { writable: false }); return Constructor; }
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); Object.defineProperty(subClass, "prototype", { writable: false }); if (superClass) _setPrototypeOf(subClass, superClass); }
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf ? Object.setPrototypeOf.bind() : function (o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+function _createSuper(Derived) { var hasNativeReflectConstruct = _isNativeReflectConstruct(); return function () { var Super = _getPrototypeOf(Derived), result; if (hasNativeReflectConstruct) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } else if (call !== void 0) { throw new TypeError("Derived constructors may only return object or undefined"); } return _assertThisInitialized(self); }
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf.bind() : function (o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+function _defineProperty(obj, key, value) { key = _toPropertyKey(key); if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+function _toPropertyKey(arg) { var key = _toPrimitive(arg, "string"); return _typeof(key) === "symbol" ? key : String(key); }
+function _toPrimitive(input, hint) { if (_typeof(input) !== "object" || input === null) return input; var prim = input[Symbol.toPrimitive]; if (prim !== undefined) { var res = prim.call(input, hint || "default"); if (_typeof(res) !== "object") return res; throw new TypeError("@@toPrimitive must return a primitive value."); } return (hint === "string" ? String : Number)(input); }
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import _ from 'underscore';
@@ -131,15 +132,16 @@ export function segmentComponentsByStatus(termComponents) {
  * Used to render individual terms in FacetList.
  */
 export var Term = /*#__PURE__*/function (_React$PureComponent) {
-  function Term(props) {
-    var _this2;
-    _classCallCheck(this, Term);
-    _this2 = _callSuper(this, Term, [props]);
-    _this2.handleClick = _this2.handleClick.bind(_this2);
-    return _this2;
-  }
   _inherits(Term, _React$PureComponent);
-  return _createClass(Term, [{
+  var _super = _createSuper(Term);
+  function Term(props) {
+    var _this;
+    _classCallCheck(this, Term);
+    _this = _super.call(this, props);
+    _this.handleClick = _this.handleClick.bind(_assertThisInitialized(_this));
+    return _this;
+  }
+  _createClass(Term, [{
     key: "handleClick",
     value: function handleClick(e) {
       var _this$props = this.props,
@@ -291,6 +293,7 @@ export var Term = /*#__PURE__*/function (_React$PureComponent) {
       }, count))), subTermComponents);
     }
   }]);
+  return Term;
 }(React.PureComponent);
 
 /**
@@ -373,20 +376,21 @@ export function getFilteredTerms(facetTerms, searchText, includeSubTerms) {
   };
 }
 export var FacetTermsList = /*#__PURE__*/function (_React$PureComponent2) {
+  _inherits(FacetTermsList, _React$PureComponent2);
+  var _super2 = _createSuper(FacetTermsList);
   function FacetTermsList(props) {
-    var _this3;
+    var _this2;
     _classCallCheck(this, FacetTermsList);
-    _this3 = _callSuper(this, FacetTermsList, [props]);
-    _this3.handleOpenToggleClick = _this3.handleOpenToggleClick.bind(_this3);
-    _this3.handleExpandListToggleClick = _this3.handleExpandListToggleClick.bind(_this3);
-    _this3.handleSaytTermSearch = _this3.handleSaytTermSearch.bind(_this3);
-    _this3.state = {
+    _this2 = _super2.call(this, props);
+    _this2.handleOpenToggleClick = _this2.handleOpenToggleClick.bind(_assertThisInitialized(_this2));
+    _this2.handleExpandListToggleClick = _this2.handleExpandListToggleClick.bind(_assertThisInitialized(_this2));
+    _this2.handleSaytTermSearch = _this2.handleSaytTermSearch.bind(_assertThisInitialized(_this2));
+    _this2.state = {
       'expanded': false
     };
-    return _this3;
+    return _this2;
   }
-  _inherits(FacetTermsList, _React$PureComponent2);
-  return _createClass(FacetTermsList, [{
+  _createClass(FacetTermsList, [{
     key: "handleOpenToggleClick",
     value: function handleOpenToggleClick(e) {
       e.preventDefault();
@@ -539,6 +543,7 @@ export var FacetTermsList = /*#__PURE__*/function (_React$PureComponent2) {
       }));
     }
   }]);
+  return FacetTermsList;
 }(React.PureComponent);
 FacetTermsList.defaultProps = {
   'persistentCount': 10,
@@ -631,6 +636,7 @@ var ListOfTerms = /*#__PURE__*/React.memo(function (props) {
             facetSearchActive: facetSearchActive,
             tooltip: tooltip,
             status: status,
+            sortFxn: sortFxn,
             onClick: onTermClick,
             key: term.key
           });
@@ -642,7 +648,8 @@ var ListOfTerms = /*#__PURE__*/React.memo(function (props) {
             isFiltering: isFiltering,
             useRadioIcon: useRadioIcon,
             getTermStatus: getTermStatus,
-            onClick: onTermClick
+            onClick: onTermClick,
+            sortFxn: sortFxn
           };
           //duplicate terms to show parent-children tree in active and unselected sections
           return [/*#__PURE__*/React.createElement(Term, _extends({}, _commonProps, {

--- a/es/components/browse/components/FacetList/FacetTermsList.js
+++ b/es/components/browse/components/FacetList/FacetTermsList.js
@@ -167,7 +167,9 @@ export var Term = /*#__PURE__*/function (_React$PureComponent) {
         _this$props2$hideActi = _this$props2.hideActiveSubTerms,
         hideActiveSubTerms = _this$props2$hideActi === void 0 ? false : _this$props2$hideActi,
         _this$props2$hideUnse = _this$props2.hideUnselectedSubTerms,
-        hideUnselectedSubTerms = _this$props2$hideUnse === void 0 ? false : _this$props2$hideUnse;
+        hideUnselectedSubTerms = _this$props2$hideUnse === void 0 ? false : _this$props2$hideUnse,
+        _this$props2$sortFxn = _this$props2.sortFxn,
+        sortFxn = _this$props2$sortFxn === void 0 ? null : _this$props2$sortFxn;
       var _this$props3 = this.props,
         _this$props3$facetSea = _this$props3.facetSearchActive,
         facetSearchActive = _this$props3$facetSea === void 0 ? false : _this$props3$facetSea,
@@ -216,13 +218,29 @@ export var Term = /*#__PURE__*/function (_React$PureComponent) {
           onClick: onClick,
           useRadioIcon: useRadioIcon,
           groupingTermKey: term.key,
-          facetSearchActive: facetSearchActive
+          facetSearchActive: facetSearchActive,
+          sortFxn: sortFxn
         };
         var filteredTerms = term.terms;
         //filter out the terms not matching
         if (textFilteredSubTerms) {
           filteredTerms = _.filter(filteredTerms, function (t) {
             return textFilteredSubTerms[t.key];
+          });
+        }
+        if (sortFxn && typeof sortFxn === 'function') {
+          filteredTerms = filteredTerms.slice().sort(function (termA, termB) {
+            return sortFxn({
+              key: termA.key,
+              props: {
+                term: termA
+              }
+            }, {
+              key: termB.key,
+              props: {
+                term: termB
+              }
+            });
           });
         }
         subTermComponents = filteredTerms.map(function (t) {
@@ -309,7 +327,8 @@ _defineProperty(Term, "propTypes", {
   'textFilteredSubTerms': PropTypes.object,
   'tooltip': PropTypes.string,
   'hideActiveSubTerms': PropTypes.bool,
-  'hideUnselectedSubTerms': PropTypes.bool
+  'hideUnselectedSubTerms': PropTypes.bool,
+  'sortFxn': PropTypes.func
 });
 _defineProperty(Term, "defaultProps", {
   'useRadioIcon': false

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@hms-dbmi-bgm/shared-portal-components",
-    "version": "0.1.97",
+    "version": "0.1.98",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@hms-dbmi-bgm/shared-portal-components",
-            "version": "0.1.97",
+            "version": "0.1.98",
             "license": "MIT",
             "dependencies": {
                 "@4dn-dcic/react-infinite": "github:4dn-dcic/react-infinite#1.1.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hms-dbmi-bgm/shared-portal-components",
-    "version": "0.1.97",
+    "version": "0.1.98",
     "description": "Shared components used for DBMI/BGM portal(s).",
     "repository": {
         "type": "git",

--- a/src/components/browse/components/FacetList/FacetTermsList.js
+++ b/src/components/browse/components/FacetList/FacetTermsList.js
@@ -455,9 +455,9 @@ const ListOfTerms = React.memo(function ListOfTerms(props){
                 }
             }
             if (status !== 'partial') {
-                return <Term {...{ facet, term, termTransformFxn, isFiltering, useRadioIcon, getTermStatus, textFilteredTerms, textFilteredSubTerms, facetSearchActive, tooltip, status }} onClick={onTermClick} key={term.key} />;
+                return <Term {...{ facet, term, termTransformFxn, isFiltering, useRadioIcon, getTermStatus, textFilteredTerms, textFilteredSubTerms, facetSearchActive, tooltip, status, sortFxn }} onClick={onTermClick} key={term.key} />;
             } else {
-                const commonProps = { facet, term, termTransformFxn, isFiltering, useRadioIcon, getTermStatus, onClick: onTermClick };
+                const commonProps = { facet, term, termTransformFxn, isFiltering, useRadioIcon, getTermStatus, onClick: onTermClick, sortFxn };
                 //duplicate terms to show parent-children tree in active and unselected sections
                 return [
                     <Term {...commonProps} {...{ textFilteredTerms: {}, status }} key={term.key} hideUnselectedSubTerms />,

--- a/src/components/browse/components/FacetList/FacetTermsList.js
+++ b/src/components/browse/components/FacetList/FacetTermsList.js
@@ -132,6 +132,7 @@ export class Term extends React.PureComponent {
         'tooltip'           : PropTypes.string,
         'hideActiveSubTerms': PropTypes.bool,
         'hideUnselectedSubTerms': PropTypes.bool,
+        'sortFxn'           : PropTypes.func,
     };
 
     static defaultProps = {
@@ -152,7 +153,8 @@ export class Term extends React.PureComponent {
     render() {
         const {
             term, facet, status, getTermStatus, termTransformFxn, isFiltering, onClick, useRadioIcon = false,
-            groupingTermKey, tooltip, hideActiveSubTerms = false, hideUnselectedSubTerms = false
+            groupingTermKey, tooltip, hideActiveSubTerms = false, hideUnselectedSubTerms = false,
+            sortFxn = null
         } = this.props;
         let { facetSearchActive = false, textFilteredTerms, textFilteredSubTerms } = this.props;
 
@@ -187,11 +189,19 @@ export class Term extends React.PureComponent {
         // if the term is a grouping term, then create sub term components
         let subTermComponents = null;
         if (isGroupingTerm && term.terms.length > 0){
-            const childProps = { facet, getTermStatus, termTransformFxn, isFiltering, onClick, useRadioIcon, groupingTermKey: term.key, facetSearchActive };
+            const childProps = { facet, getTermStatus, termTransformFxn, isFiltering, onClick, useRadioIcon, groupingTermKey: term.key, facetSearchActive, sortFxn };
             let filteredTerms = term.terms;
             //filter out the terms not matching
             if (textFilteredSubTerms) {
                 filteredTerms = _.filter(filteredTerms, function (t) { return textFilteredSubTerms[t.key]; });
+            }
+            if (sortFxn && typeof sortFxn === 'function') {
+                filteredTerms = filteredTerms.slice().sort(function(termA, termB) {
+                    return sortFxn(
+                        { key: termA.key, props: { term: termA } },
+                        { key: termB.key, props: { term: termB } }
+                    );
+                });
             }
             subTermComponents = filteredTerms.map(function (t) { return (<Term key={t.key} term={t} {...childProps} status={status === 'selected' ? 'selected' : getTermStatus(t, facet)} />); });
             //filter out selected/omitted sub term components


### PR DESCRIPTION
This pull request adds support for custom sorting of sub-terms in the `FacetTermsList` and `Term` components by introducing a new `sortFxn` prop. The `sortFxn` function, if provided, will be used to sort sub-terms before rendering. The changes ensure that this sorting function is passed down and applied consistently in both the main and sub-term rendering logic.

**Custom Sorting Enhancements:**

* Added a new optional `sortFxn` prop to the `Term` component's `propTypes` and ensured it defaults to `null` if not provided. This allows consumers to specify a custom sorting function for sub-terms. [[1]](diffhunk://#diff-275c3af872d6508e8b0d979edf6384da15ddf677830d529cb7989576d4d865b9R135) [[2]](diffhunk://#diff-275c3af872d6508e8b0d979edf6384da15ddf677830d529cb7989576d4d865b9L155-R157)
* Updated the logic in the `Term` component so that, when rendering sub-terms, the `sortFxn` is applied (if provided and is a function) to sort the sub-terms before mapping them to components.
* Passed the `sortFxn` prop down to sub-terms and from the `ListOfTerms` component to ensure sorting is consistently applied throughout the term hierarchy.

**Refactoring and Consistency:**

* Refactored the ES build output in `es/components/browse/components/FacetList/FacetTermsList.js` to match the new logic, including helper function rewrites and class inheritance patterns for consistency with the updated source. [[1]](diffhunk://#diff-17fc0bbd4e63b2e38eb9f40cf7109bd398e662e13beb0d88898fbd8f529e2f60L1-R24) [[2]](diffhunk://#diff-17fc0bbd4e63b2e38eb9f40cf7109bd398e662e13beb0d88898fbd8f529e2f60R135-R144) [[3]](diffhunk://#diff-17fc0bbd4e63b2e38eb9f40cf7109bd398e662e13beb0d88898fbd8f529e2f60L170-R174) [[4]](diffhunk://#diff-17fc0bbd4e63b2e38eb9f40cf7109bd398e662e13beb0d88898fbd8f529e2f60L219-R224) [[5]](diffhunk://#diff-17fc0bbd4e63b2e38eb9f40cf7109bd398e662e13beb0d88898fbd8f529e2f60R233-R247) [[6]](diffhunk://#diff-17fc0bbd4e63b2e38eb9f40cf7109bd398e662e13beb0d88898fbd8f529e2f60R296) [[7]](diffhunk://#diff-17fc0bbd4e63b2e38eb9f40cf7109bd398e662e13beb0d88898fbd8f529e2f60L312-R334) [[8]](diffhunk://#diff-17fc0bbd4e63b2e38eb9f40cf7109bd398e662e13beb0d88898fbd8f529e2f60R379-R393) [[9]](diffhunk://#diff-17fc0bbd4e63b2e38eb9f40cf7109bd398e662e13beb0d88898fbd8f529e2f60R546) [[10]](diffhunk://#diff-17fc0bbd4e63b2e38eb9f40cf7109bd398e662e13beb0d88898fbd8f529e2f60R639) [[11]](diffhunk://#diff-17fc0bbd4e63b2e38eb9f40cf7109bd398e662e13beb0d88898fbd8f529e2f60L626-R652)

**Versioning:**

* Incremented the package version in `package.json` from `0.1.97` to `0.1.98` to reflect the new feature addition.