### PR TITLE
URL truncation issue while sorting in browse/search view

### DIFF
--- a/es/components/browse/components/FacetList/FacetTermsList.js
+++ b/es/components/browse/components/FacetList/FacetTermsList.js
@@ -1,27 +1,26 @@
+import _slicedToArray from "@babel/runtime/helpers/slicedToArray";
+import _objectWithoutProperties from "@babel/runtime/helpers/objectWithoutProperties";
+import _extends from "@babel/runtime/helpers/extends";
+import _classCallCheck from "@babel/runtime/helpers/classCallCheck";
+import _createClass from "@babel/runtime/helpers/createClass";
+import _possibleConstructorReturn from "@babel/runtime/helpers/possibleConstructorReturn";
+import _getPrototypeOf from "@babel/runtime/helpers/getPrototypeOf";
+import _inherits from "@babel/runtime/helpers/inherits";
+import _defineProperty from "@babel/runtime/helpers/defineProperty";
 var _excluded = ["count", "countActive", "height", "width", "ltr", "className"];
-function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (obj) { return typeof obj; } : function (obj) { return obj && "function" == typeof Symbol && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }, _typeof(obj); }
-function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr, i) || _nonIterableRest(); }
-function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
-function _iterableToArrayLimit(arr, i) { var _i = null == arr ? null : "undefined" != typeof Symbol && arr[Symbol.iterator] || arr["@@iterator"]; if (null != _i) { var _s, _e, _x, _r, _arr = [], _n = !0, _d = !1; try { if (_x = (_i = _i.call(arr)).next, 0 === i) { if (Object(_i) !== _i) return; _n = !1; } else for (; !(_n = (_s = _x.call(_i)).done) && (_arr.push(_s.value), _arr.length !== i); _n = !0); } catch (err) { _d = !0, _e = err; } finally { try { if (!_n && null != _i["return"] && (_r = _i["return"](), Object(_r) !== _r)) return; } finally { if (_d) throw _e; } } return _arr; } }
-function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
-function _objectWithoutProperties(source, excluded) { if (source == null) return {}; var target = _objectWithoutPropertiesLoose(source, excluded); var key, i; if (Object.getOwnPropertySymbols) { var sourceSymbolKeys = Object.getOwnPropertySymbols(source); for (i = 0; i < sourceSymbolKeys.length; i++) { key = sourceSymbolKeys[i]; if (excluded.indexOf(key) >= 0) continue; if (!Object.prototype.propertyIsEnumerable.call(source, key)) continue; target[key] = source[key]; } } return target; }
-function _objectWithoutPropertiesLoose(source, excluded) { if (source == null) return {}; var target = {}; var sourceKeys = Object.keys(source); var key, i; for (i = 0; i < sourceKeys.length; i++) { key = sourceKeys[i]; if (excluded.indexOf(key) >= 0) continue; target[key] = source[key]; } return target; }
-function _extends() { _extends = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, _toPropertyKey(descriptor.key), descriptor); } }
-function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); Object.defineProperty(Constructor, "prototype", { writable: false }); return Constructor; }
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); Object.defineProperty(subClass, "prototype", { writable: false }); if (superClass) _setPrototypeOf(subClass, superClass); }
-function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf ? Object.setPrototypeOf.bind() : function (o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
-function _createSuper(Derived) { var hasNativeReflectConstruct = _isNativeReflectConstruct(); return function () { var Super = _getPrototypeOf(Derived), result; if (hasNativeReflectConstruct) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
-function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } else if (call !== void 0) { throw new TypeError("Derived constructors may only return object or undefined"); } return _assertThisInitialized(self); }
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
-function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf.bind() : function (o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
-function _defineProperty(obj, key, value) { key = _toPropertyKey(key); if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-function _toPropertyKey(arg) { var key = _toPrimitive(arg, "string"); return _typeof(key) === "symbol" ? key : String(key); }
-function _toPrimitive(input, hint) { if (_typeof(input) !== "object" || input === null) return input; var prim = input[Symbol.toPrimitive]; if (prim !== undefined) { var res = prim.call(input, hint || "default"); if (_typeof(res) !== "object") return res; throw new TypeError("@@toPrimitive must return a primitive value."); } return (hint === "string" ? String : Number)(input); }
+function _callSuper(_this, derived, args) {
+  derived = _getPrototypeOf(derived);
+  return _possibleConstructorReturn(_this, function () {
+    if (typeof Reflect === "undefined" || !Reflect.construct) return false;
+    if (Reflect.construct.sham) return false;
+    if (typeof Proxy === "function") return true;
+    try {
+      return !Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {}));
+    } catch (e) {
+      return false;
+    }
+  }() ? Reflect.construct(derived, args || [], _getPrototypeOf(_this).constructor) : derived.apply(_this, args));
+}
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import _ from 'underscore';
@@ -132,16 +131,15 @@ export function segmentComponentsByStatus(termComponents) {
  * Used to render individual terms in FacetList.
  */
 export var Term = /*#__PURE__*/function (_React$PureComponent) {
-  _inherits(Term, _React$PureComponent);
-  var _super = _createSuper(Term);
   function Term(props) {
-    var _this;
+    var _this2;
     _classCallCheck(this, Term);
-    _this = _super.call(this, props);
-    _this.handleClick = _this.handleClick.bind(_assertThisInitialized(_this));
-    return _this;
+    _this2 = _callSuper(this, Term, [props]);
+    _this2.handleClick = _this2.handleClick.bind(_this2);
+    return _this2;
   }
-  _createClass(Term, [{
+  _inherits(Term, _React$PureComponent);
+  return _createClass(Term, [{
     key: "handleClick",
     value: function handleClick(e) {
       var _this$props = this.props,
@@ -293,7 +291,6 @@ export var Term = /*#__PURE__*/function (_React$PureComponent) {
       }, count))), subTermComponents);
     }
   }]);
-  return Term;
 }(React.PureComponent);
 
 /**
@@ -376,21 +373,20 @@ export function getFilteredTerms(facetTerms, searchText, includeSubTerms) {
   };
 }
 export var FacetTermsList = /*#__PURE__*/function (_React$PureComponent2) {
-  _inherits(FacetTermsList, _React$PureComponent2);
-  var _super2 = _createSuper(FacetTermsList);
   function FacetTermsList(props) {
-    var _this2;
+    var _this3;
     _classCallCheck(this, FacetTermsList);
-    _this2 = _super2.call(this, props);
-    _this2.handleOpenToggleClick = _this2.handleOpenToggleClick.bind(_assertThisInitialized(_this2));
-    _this2.handleExpandListToggleClick = _this2.handleExpandListToggleClick.bind(_assertThisInitialized(_this2));
-    _this2.handleSaytTermSearch = _this2.handleSaytTermSearch.bind(_assertThisInitialized(_this2));
-    _this2.state = {
+    _this3 = _callSuper(this, FacetTermsList, [props]);
+    _this3.handleOpenToggleClick = _this3.handleOpenToggleClick.bind(_this3);
+    _this3.handleExpandListToggleClick = _this3.handleExpandListToggleClick.bind(_this3);
+    _this3.handleSaytTermSearch = _this3.handleSaytTermSearch.bind(_this3);
+    _this3.state = {
       'expanded': false
     };
-    return _this2;
+    return _this3;
   }
-  _createClass(FacetTermsList, [{
+  _inherits(FacetTermsList, _React$PureComponent2);
+  return _createClass(FacetTermsList, [{
     key: "handleOpenToggleClick",
     value: function handleOpenToggleClick(e) {
       e.preventDefault();
@@ -543,7 +539,6 @@ export var FacetTermsList = /*#__PURE__*/function (_React$PureComponent2) {
       }));
     }
   }]);
-  return FacetTermsList;
 }(React.PureComponent);
 FacetTermsList.defaultProps = {
   'persistentCount': 10,

--- a/es/components/browse/components/SearchResultTable.js
+++ b/es/components/browse/components/SearchResultTable.js
@@ -6,7 +6,6 @@ import _getPrototypeOf from "@babel/runtime/helpers/getPrototypeOf";
 import _inherits from "@babel/runtime/helpers/inherits";
 import _defineProperty from "@babel/runtime/helpers/defineProperty";
 import _extends from "@babel/runtime/helpers/extends";
-import _typeof from "@babel/runtime/helpers/typeof";
 var _excluded = ["columnDefinitions", "mounted", "columnWidths", "windowWidth", "defaultColAlignment"];
 function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); enumerableOnly && (symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; })), keys.push.apply(keys, symbols); } return keys; }
 function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = null != arguments[i] ? arguments[i] : {}; i % 2 ? ownKeys(Object(source), !0).forEach(function (key) { _defineProperty(target, key, source[key]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)) : ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } return target; }
@@ -41,21 +40,13 @@ import { itemUtil } from './../../util/object';
 import { load } from './../../util/ajax';
 import { getPageVerticalScrollPosition, getElementOffset, responsiveGridState } from './../../util/layout';
 import { getItemTypeTitle } from './../../util/schema-transforms';
+import { normalizeQueryValuesForStringify } from './../../util/search-filters';
 import { requestAnimationFrame as raf, cancelAnimationFrame as caf, style as vizStyle } from './../../viz/utilities';
 import { Alerts } from './../../ui/Alerts';
 import { ResultRowColumnBlockValue } from './table-commons/ResultRowColumnBlockValue';
 import { columnsToColumnDefinitions, getColumnWidthFromDefinition } from './table-commons/ColumnCombiner';
 import { HeadersRow } from './table-commons/HeadersRow';
 import { basicColumnExtensionMap } from './table-commons/basicColumnExtensionMap';
-function normalizeQueryValuesForStringify() {
-  var query = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
-  return _.mapObject(query, function (value) {
-    if (value && _typeof(value) === 'object' && !Array.isArray(value) && !(value instanceof Date)) {
-      return _.values(value);
-    }
-    return value;
-  });
-}
 var ResultRowColumnBlock = /*#__PURE__*/React.memo(function (props) {
   var columnDefinition = props.columnDefinition,
     columnNumber = props.columnNumber,

--- a/es/components/browse/components/SortController.js
+++ b/es/components/browse/components/SortController.js
@@ -34,6 +34,7 @@ import queryString from 'querystring';
 import memoize from 'memoize-one';
 import _ from 'underscore';
 import { navigate as _navigate } from './../../util/navigate';
+import { normalizeQueryValuesForStringify } from './../../util/search-filters';
 import { flattenColumnsDefinitionsSortFields, HeadersRow } from './table-commons';
 export var SortController = /*#__PURE__*/function (_React$PureComponent) {
   function SortController(props) {
@@ -94,7 +95,7 @@ export var SortController = /*#__PURE__*/function (_React$PureComponent) {
             direction = _ref.direction;
           return (direction === 'desc' ? '-' : '') + column;
         });
-        var stringifiedNextQuery = queryString.stringify(query);
+        var stringifiedNextQuery = queryString.stringify(normalizeQueryValuesForStringify(query));
         var navTarget = null;
         if (currSearchHref) {
           // Using search href

--- a/es/components/util/search-filters.js
+++ b/es/components/util/search-filters.js
@@ -30,10 +30,10 @@ function normalizeQueryValueToArray(value) {
 
 // `query-string.stringify` will serialize object values as `[object Object]`.
 // Convert any object-shaped repeated params back into arrays before stringifying.
-function normalizeQueryValuesForStringify() {
+export function normalizeQueryValuesForStringify() {
   var query = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
   return _.mapObject(query, function (value) {
-    if (value && _typeof(value) === 'object' && !Array.isArray(value)) {
+    if (value && _typeof(value) === 'object' && !Array.isArray(value) && !(value instanceof Date)) {
       return _.values(value);
     }
     return value;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@hms-dbmi-bgm/shared-portal-components",
-    "version": "0.1.98",
+    "version": "0.1.99",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@hms-dbmi-bgm/shared-portal-components",
-            "version": "0.1.98",
+            "version": "0.1.99",
             "license": "MIT",
             "dependencies": {
                 "@4dn-dcic/react-infinite": "github:4dn-dcic/react-infinite#1.1.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hms-dbmi-bgm/shared-portal-components",
-    "version": "0.1.98",
+    "version": "0.1.99",
     "description": "Shared components used for DBMI/BGM portal(s).",
     "repository": {
         "type": "git",

--- a/src/components/browse/components/SearchResultTable.js
+++ b/src/components/browse/components/SearchResultTable.js
@@ -17,6 +17,7 @@ import { itemUtil } from './../../util/object';
 import { load } from './../../util/ajax';
 import { getPageVerticalScrollPosition, getElementOffset, responsiveGridState } from './../../util/layout';
 import { getItemTypeTitle } from './../../util/schema-transforms';
+import { normalizeQueryValuesForStringify } from './../../util/search-filters';
 import { requestAnimationFrame as raf, cancelAnimationFrame as caf, style as vizStyle } from './../../viz/utilities';
 import { Alerts } from './../../ui/Alerts';
 
@@ -24,21 +25,6 @@ import { ResultRowColumnBlockValue } from './table-commons/ResultRowColumnBlockV
 import { columnsToColumnDefinitions, getColumnWidthFromDefinition } from './table-commons/ColumnCombiner';
 import { HeadersRow } from './table-commons/HeadersRow';
 import { basicColumnExtensionMap } from './table-commons/basicColumnExtensionMap';
-
-
-function normalizeQueryValuesForStringify(query = {}){
-    return _.mapObject(query, function(value){
-        if (
-            value &&
-            typeof value === 'object' &&
-            !Array.isArray(value) &&
-            !(value instanceof Date)
-        ) {
-            return _.values(value);
-        }
-        return value;
-    });
-}
 
 
 const ResultRowColumnBlock = React.memo(function ResultRowColumnBlock(props){

--- a/src/components/browse/components/SortController.js
+++ b/src/components/browse/components/SortController.js
@@ -7,6 +7,7 @@ import queryString from 'querystring';
 import memoize from 'memoize-one';
 import _ from 'underscore';
 import { navigate } from './../../util/navigate';
+import { normalizeQueryValuesForStringify } from './../../util/search-filters';
 import { flattenColumnsDefinitionsSortFields, HeadersRow } from './table-commons';
 
 
@@ -76,7 +77,7 @@ export class SortController extends React.PureComponent {
                 return (direction === 'desc' ? '-' : '') + column;
             });
 
-            const stringifiedNextQuery = queryString.stringify(query);
+            const stringifiedNextQuery = queryString.stringify(normalizeQueryValuesForStringify(query));
             let navTarget = null;
             if (currSearchHref) {
                 // Using search href

--- a/src/components/util/search-filters.js
+++ b/src/components/util/search-filters.js
@@ -26,9 +26,9 @@ function normalizeQueryValueToArray(value){
 
 // `query-string.stringify` will serialize object values as `[object Object]`.
 // Convert any object-shaped repeated params back into arrays before stringifying.
-function normalizeQueryValuesForStringify(query = {}){
+export function normalizeQueryValuesForStringify(query = {}){
     return _.mapObject(query, function(value){
-        if (value && typeof value === 'object' && !Array.isArray(value)) {
+        if (value && typeof value === 'object' && !Array.isArray(value) && !(value instanceof Date)) {
             return _.values(value);
         }
         return value;


### PR DESCRIPTION
related PR: https://github.com/smaht-dac/smaht-portal/pull/658

- Export `normalizeQueryValuesForStringify` from util/search-filters to fix missing export warnings in `SortController`.
- Remove duplicate helper in `SearchResultTable` and import the shared utility instead.
- Keep behavior unchanged, including Date handling.

release (beta): https://github.com/4dn-dcic/shared-portal-components/releases/tag/0.1.99b1